### PR TITLE
Remove redundant compute_global_features

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -18,8 +18,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-from modules import FORMULA_REGISTRY, compute_global_features
+from modules import FORMULA_REGISTRY
 from brain import (
+    compute_global_features,
     EXT_GM20_Skip_Pattern_Confidence_Vec,
     MathUtils,
     BoardAnalyzerUtils,

--- a/modules.py
+++ b/modules.py
@@ -74,12 +74,3 @@ class AdaptiveWeights:
                 json.dump(self.history, f, ensure_ascii=False)
         except OSError as e:
             logging.error(f"Failed to save weights history: {e}")
-
-def compute_global_features(grid: np.ndarray) -> Tuple[float, float]:
-    """Compute global statistical features of the grid."""
-    known_vals = grid[grid != -1].astype(np.float32)
-    if known_vals.size == 0:
-        return 0.0, 1.0
-    mean_val = np.mean(known_vals)
-    std_val = np.std(known_vals) if np.std(known_vals) > 0 else 1.0
-    return mean_val, std_val


### PR DESCRIPTION
## Summary
- keep the authoritative `compute_global_features` in **brain.py**
- drop the duplicate version from `modules.py`
- update `analyzer.py` to import the function from `brain`

## Testing
- `python -m py_compile main.py app.py analyzer.py brain.py modules.py`

------
https://chatgpt.com/codex/tasks/task_e_68582864c7548324bbd1e3ee27a0a0bc