### PR TITLE
Extract brain self-test

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -10,12 +10,16 @@ from numpy.fft import rfftn, irfftn
 import random
 
 # Logging configuration
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler()]
-)
 logger = logging.getLogger(__name__)
+
+def configure_logging() -> None:
+    """Configure default logging if no handlers are present."""
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(message)s",
+            handlers=[logging.StreamHandler()]
+        )
 
 # 來自 log_once_patch.txt 和 final_numpy_coord_fix_summary.txt
 _seen_modules_once = set()
@@ -630,35 +634,3 @@ def get_module_score(module_name: str, grid: np.ndarray, **kwargs) -> np.ndarray
         logger.error(f"Error executing module {module_name}: {e}", extra={"request_id": effective_request_id})
         rows, cols = grid.shape
         return np.zeros((rows, cols), dtype=float)
-
-# Verification
-if __name__ == "__main__":
-    print("Verifying brain.py structure...")
-    dummy_grid = np.array([[1, 2, -1], [-1, 1, 5], [3, -1, 4]])
-    print(f"Created dummy grid:\n{dummy_grid}")
-    for module_to_test in [
-        "EXT_Q1_ProximityEntropy_Vec",
-        "EXT_Q2_PotentialPath_Vec",
-        "EXT_Q3_DiscontinuitySym_Vec",
-        "EXT_Q4_ControlComposite_Vec",
-        "EXT_Q5_GlobalEntropy_Vec",
-        "EXT_Q6_LineBridge_Vec",
-        "EXT_Q7_VariancePrior_Vec",
-        "EXT_Q8_SpatialKL_Vec",
-        "EXT_Q9_MultiScaleEntropy_Vec",
-        "EXT_Q10_DistPotential_Vec"
-    ]:
-        print(f"Testing get_module_score with '{module_to_test}'...")
-        try:
-            scores = get_module_score(module_to_test, dummy_grid)
-            print(f"Successfully called {module_to_test}. Output:\n{scores}")
-            assert isinstance(scores, np.ndarray), "Return type is not np.ndarray"
-            assert scores.shape == dummy_grid.shape, "Return shape does not match grid shape"
-            assert scores.dtype == float, "Return dtype is not float"
-        except ValueError as e:
-            print(f"Error: {e}")
-    print("Listing all registered modules:")
-    for i, name in enumerate(REGISTERED_MODULES_BRAIN.keys()):
-        print(f" {i+1}. {name}")
-    print(f"Total modules registered: {len(REGISTERED_MODULES_BRAIN)}")
-    print("brain.py verification complete.")

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import numpy as np
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import brain
+
+brain.configure_logging()
+
+def test_registered_modules():
+    dummy_grid = np.array([[1, 2, -1], [-1, 1, 5], [3, -1, 4]])
+    modules = [
+        "EXT_Q1_ProximityEntropy_Vec",
+        "EXT_Q2_PotentialPath_Vec",
+        "EXT_Q3_DiscontinuitySym_Vec",
+        "EXT_Q4_ControlComposite_Vec",
+        "EXT_Q5_GlobalEntropy_Vec",
+        "EXT_Q6_LineBridge_Vec",
+        "EXT_Q7_VariancePrior_Vec",
+        "EXT_Q8_SpatialKL_Vec",
+        "EXT_Q9_MultiScaleEntropy_Vec",
+        "EXT_Q10_DistPotential_Vec",
+    ]
+    for mod in modules:
+        try:
+            scores = brain.get_module_score(mod, dummy_grid)
+            assert isinstance(scores, np.ndarray)
+            assert scores.shape == dummy_grid.shape
+            assert scores.dtype == float
+        except ValueError:
+            # Some modules may legitimately raise ValueError on small grids
+            continue
+    assert len(brain.REGISTERED_MODULES_BRAIN) >= len(modules)


### PR DESCRIPTION
## Summary
- remove runtime verification block from `brain.py`
- ensure logging can be configured lazily
- add `tests/test_brain.py` replicating verification logic

## Testing
- `python -m py_compile main.py app.py analyzer.py brain.py modules.py tests/test_brain.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582866457c8324b75aa6ec4d34d204