### PR TITLE
Fix seeding for board generation

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -121,10 +121,10 @@ def generate_full_boards(rows: int, cols: int, batch: int, rng: np.random.Genera
     kv_bytes = known_vals.tobytes()
     idx_bytes = known_mask.nonzero()[0].astype(np.int32).tobytes()
     mask = xxhash.xxh64(kv_bytes + idx_bytes).hexdigest()
-    seed = rng.integers(0, 0xFFFF)
-    for i in range(batch):
+    seeds = rng.integers(0, 0xFFFF, size=batch)
+    for i, s in enumerate(seeds):
         board1d = _cached_board(
-            mask, seed & 0xFFFF,
+            mask, int(s) & 0xFFFF,
             rows, cols,
             kv_bytes, idx_bytes
         ).reshape(rows, cols)


### PR DESCRIPTION
## Summary
- ensure each board uses its own random seed when generating full boards

## Testing
- `python -m py_compile main.py app.py analyzer.py brain.py modules.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685855c4f80483248034c7f154c2059a