### PR TITLE
Enhance heuristics with vectorized sampling

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -80,7 +80,7 @@ def select_modules(grid: np.ndarray) -> List[str]:
     if os.getenv("FORCE_FULL_SCAN", "0") == "1":
         return list(REGISTERED_MODULES_BRAIN)   # 直接使用所有模組
     # 原始邏輯：動態選擇模組
-    base_modules = ["EXT_Q1_ProximityEntropy_Vec", "EXT_Q2_PotentialPath_Vec", "EXT_Q5_GlobalEntropy_Vec", "EXT_Q6_LineBridge_Vec", "EXT_Q7_VariancePrior_Vec"]
+    base_modules = ["EXT_Q1_ProximityEntropy_Vec", "EXT_Q2_PotentialPath_Vec", "EXT_Q5_GlobalEntropy_Vec", "EXT_Q6_LineBridge_Vec", "EXT_Q7_VariancePrior_Vec", "EXT_E1_TailCluster_Vec"]
     scores = {mod: np.mean(get_module_score(mod, grid)) for mod in REGISTERED_MODULES_BRAIN}
     top_modules = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)[:2]
     return base_modules + [m for m in top_modules if m not in base_modules]
@@ -234,12 +234,12 @@ def simulate_full_board(grid: np.ndarray, target_num: Optional[int], n_iter: int
     importance_weights = importance_weights / (np.sum(importance_weights) + 1e-10)
 
     # Dynamic formula weights based on grid pattern
-    history = {"random_entropy": 0.4, "shuffle": 0.3, "tail_cluster": 0.3}
+    history = {"random_entropy": 0.35, "shuffle": 0.25, "tail_cluster": 0.25, "spatial_entropy": 0.15}
     if np.mean(module_scores) > 0.6:
         history["tail_cluster"] += 0.1
         history["random_entropy"] -= 0.05
 
-    formulas = ("random_entropy", "shuffle", "tail_cluster")
+    formulas = ("random_entropy", "shuffle", "tail_cluster", "spatial_entropy")
     weights = adjust_weights_based_on_history(history, formulas)
     remain = n_iter
     counts = defaultdict(lambda: defaultdict(int))

--- a/brain.py
+++ b/brain.py
@@ -354,6 +354,18 @@ def EXT_M1_Tail_Pattern_Vec(grid: np.ndarray, request_id: Optional[str] = "N/A")
             scores[r, c] = max_score
     return scores
 
+def EXT_E1_TailCluster_Vec(grid: np.ndarray, request_id: Optional[str] = "N/A") -> np.ndarray:
+    """Score cells by clustering of tail digits within a 3x3 neighborhood."""
+    valid = grid == -1
+    tails = np.mod(np.where(valid, 0, grid), 10)
+    one_hot = np.eye(10, dtype=float)[tails]
+    kernel = np.ones((3, 3, 1), dtype=float)
+    conv = ndi.convolve(one_hot, kernel, mode="constant", cval=0.0)
+    conv -= one_hot
+    score = conv.max(axis=-1) / 8.0
+    score[~valid] = 0.0
+    return score
+
 @njit(parallel=True, fastmath=True)
 def _m3_local_focus_kernel(grid, legal_vals, row_flags, col_flags, radius):
     rows, cols = grid.shape
@@ -571,7 +583,8 @@ def EXT_Q1_ProximityEntropy_Vec(grid: np.ndarray, request_id: Optional[str] = "N
     """Composite scoring for proximity and entropy."""
     a2 = get_module_score("EXT_M3_Local_Focus_Vec", grid, request_id=request_id)
     m1 = get_module_score("EXT_M1_Tail_Pattern_Vec", grid, request_id=request_id)
-    return 0.65 * a2 + 0.35 * m1
+    e1 = get_module_score("EXT_E1_TailCluster_Vec", grid, request_id=request_id)
+    return 0.5 * a2 + 0.3 * m1 + 0.2 * e1
 
 def EXT_Q2_PotentialPath_Vec(grid: np.ndarray, request_id: Optional[str] = "N/A") -> np.ndarray:
     """Composite scoring for potential paths and sequences."""
@@ -604,6 +617,7 @@ mods = {
     "EXT_Q9_MultiScaleEntropy_Vec": EXT_Q9_MultiScaleEntropy_Vec,
     "EXT_Q10_DistPotential_Vec": EXT_Q10_DistPotential_Vec,
     "EXT_M1_Tail_Pattern_Vec": EXT_M1_Tail_Pattern_Vec,
+    "EXT_E1_TailCluster_Vec": EXT_E1_TailCluster_Vec,
     "EXT_M3_Local_Focus_Vec": EXT_M3_Local_Focus_Vec,
     "EXT_M10_Sequence_Block_Vec": EXT_M10_Sequence_Block_Vec,
     "EXT_R3_Error_Correction_Vec": EXT_R3_Error_Correction_Vec,
@@ -625,6 +639,7 @@ FAST_PHASE = [
     "EXT_Q2_PotentialPath_Vec",
     "EXT_Q5_GlobalEntropy_Vec",
     "EXT_Q8_SpatialKL_Vec",
+    "EXT_E1_TailCluster_Vec",
 ]
 
 RERANK_PHASE = [

--- a/modules.py
+++ b/modules.py
@@ -31,20 +31,29 @@ def gen_shuffle(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:
     """Generate grid by shuffling numbers within each row."""
     nums = np.arange(1, rows * cols + 1)
     board = nums.reshape(rows, cols)
-    for r in range(rows):
-        rng.shuffle(board[r])
+    shuffle_idx = rng.random((rows, cols)).argsort(axis=1)
+    board = np.take_along_axis(board, shuffle_idx, axis=1)
     return board
 
 @register_formula("random_entropy")
 def gen_random_entropy(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:
     """Generate grid with entropy-based random dispersion."""
-    grid = np.zeros((rows, cols), dtype=np.int64)
-    legal = list(range(1, rows * cols + 1))
-    rng.shuffle(legal)
-    for i in range(rows * cols):
-        r, c = divmod(i, cols)
-        grid[r, c] = legal[i]
-    return grid
+    nums = rng.permutation(rows * cols) + 1
+    return nums.reshape(rows, cols)
+
+@register_formula("spatial_entropy")
+def gen_spatial_entropy(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:
+    """Generate grid placing larger numbers near the center based on a spatial entropy map."""
+    n = rows * cols
+    nums = rng.permutation(n) + 1
+    base_grid = nums.reshape(rows, cols)
+    r_idx = np.linspace(-1.0, 1.0, rows)[:, None]
+    c_idx = np.linspace(-1.0, 1.0, cols)
+    dist = np.sqrt(r_idx ** 2 + c_idx ** 2)
+    order = np.argsort(dist.ravel())
+    flat = base_grid.ravel()
+    flat = flat[order]
+    return flat.reshape(rows, cols)
 
 @register_formula("tail_cluster")
 def gen_tail_cluster(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:


### PR DESCRIPTION
## Summary
- optimize shuffle and random_entropy grid generators
- add spatial_entropy generator
- introduce tail-cluster scoring module
- update composite scoring to incorporate the new module
- include new module in module selection and sampling weights

## Testing
- `python -m py_compile brain.py analyzer.py modules.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685958afbfa08324b21a9eef2b50e773