### PR TITLE
Add skip rule for target-bound modules

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -24,11 +24,15 @@ from brain import (
     BoardAnalyzerUtils,
     REGISTERED_MODULES_BRAIN,
     get_module_score,
-    bytes_to_grid
+    bytes_to_grid,
 )
 
 math_utils = MathUtils()
 analyzer_utils = BoardAnalyzerUtils()
+
+# Modules that require a target value when executed. These are skipped during
+# automatic module scoring where no target is provided.
+MODULES_REQUIRE_TARGET = {"EXT_GlobalOffsetCooccurrence_Vec"}
 
 # 來自 probmap_key_patch_v2.txt
 def _native_coord(k):
@@ -76,7 +80,11 @@ def select_modules(grid: np.ndarray) -> List[str]:
         return list(REGISTERED_MODULES_BRAIN)   # 直接使用所有模組
     # 原始邏輯：動態選擇模組
     base_modules = ["EXT_Q1_ProximityEntropy_Vec", "EXT_Q2_PotentialPath_Vec", "EXT_Q5_GlobalEntropy_Vec", "EXT_Q6_LineBridge_Vec", "EXT_Q7_VariancePrior_Vec"]
-    scores = {mod: np.mean(get_module_score(mod, grid)) for mod in REGISTERED_MODULES_BRAIN}
+    scores = {}
+    for mod in REGISTERED_MODULES_BRAIN:
+        if mod in MODULES_REQUIRE_TARGET:
+            continue
+        scores[mod] = np.mean(get_module_score(mod, grid))
     top_modules = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)[:2]
     return base_modules + [m for m in top_modules if m not in base_modules]
 

--- a/brain.py
+++ b/brain.py
@@ -8,6 +8,7 @@ from scipy.cluster.vq import kmeans2
 from scipy import ndimage as ndi
 from numpy.fft import rfftn, irfftn
 import random
+from modules import global_offset_cooccurrence
 
 # Logging configuration
 logger = logging.getLogger(__name__)
@@ -324,6 +325,20 @@ def EXT_Q10_DistPotential_Vec(grid: np.ndarray, request_id: Optional[str] = "N/A
     dist_norm = (dist - dist.min()) / (dist.max() - dist.min() + 1e-9)
     return 1 - dist_norm
 
+def EXT_GlobalOffsetCooccurrence_Vec(
+    grid: np.ndarray,
+    target: int,
+    offsets: Optional[list[int]] = None,
+    request_id: Optional[str] = "N/A",
+) -> np.ndarray:
+    """Wrapper for :func:`modules.global_offset_cooccurrence`.
+
+    Parameters are forwarded to the underlying implementation and the resulting
+    score for the single grid is returned.
+    """
+    scores = global_offset_cooccurrence(grid[np.newaxis, :, :], target, offsets)
+    return scores[0]
+
 # --- Scoring Module Implementations ---
 def EXT_M1_Tail_Pattern_Vec(grid: np.ndarray, request_id: Optional[str] = "N/A") -> np.ndarray:
     """Score based on tail number patterns in 5x5 neighborhood."""
@@ -571,6 +586,7 @@ mods = {
     "EXT_Q8_SpatialKL_Vec": EXT_Q8_SpatialKL_Vec,
     "EXT_Q9_MultiScaleEntropy_Vec": EXT_Q9_MultiScaleEntropy_Vec,
     "EXT_Q10_DistPotential_Vec": EXT_Q10_DistPotential_Vec,
+    "EXT_GlobalOffsetCooccurrence_Vec": EXT_GlobalOffsetCooccurrence_Vec,
     "EXT_M1_Tail_Pattern_Vec": EXT_M1_Tail_Pattern_Vec,
     "EXT_M3_Local_Focus_Vec": EXT_M3_Local_Focus_Vec,
     "EXT_M10_Sequence_Block_Vec": EXT_M10_Sequence_Block_Vec,
@@ -614,7 +630,10 @@ def get_module_score(module_name: str, grid: np.ndarray, **kwargs) -> np.ndarray
         rows, cols = grid.shape
         return np.zeros((rows, cols), dtype=float)
     module_func = REGISTERED_MODULES_BRAIN[module_name]
-    score_grid = module_func(grid, **kwargs)
+    if grid.ndim == 3:
+        score_grid = np.stack([module_func(g, **kwargs) for g in grid])
+    else:
+        score_grid = module_func(grid, **kwargs)
     if module_name not in _seen_modules_once:
         logger.info(f"Executing module FIRST time: {module_name}", extra={"request_id": effective_request_id})
         _seen_modules_once.add(module_name)

--- a/modules.py
+++ b/modules.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Dict, Callable
+from typing import Dict, Callable, Optional
 import logging
 import json
 
@@ -11,7 +11,7 @@ logging.basicConfig(
 )
 
 # Formula registry for Monte Carlo simulation
-FORMULA_REGISTRY: Dict[str, Callable[[int, int, np.random.Generator], np.ndarray]] = {}
+FORMULA_REGISTRY: Dict[str, Callable[..., np.ndarray]] = {}
 
 def register_formula(name: str) -> Callable:
     """Decorator to register formula functions for generating scratch card grids."""
@@ -21,34 +21,36 @@ def register_formula(name: str) -> Callable:
     return _decorator
 
 @register_formula("excel")
-def gen_excel(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:
-    """Generate grid using random permutation of numbers 1 to N."""
-    nums = rng.permutation(rows * cols) + 1
-    return nums.reshape(rows, cols)
+def gen_excel(rows: int, cols: int, rng: np.random.Generator, batch: int = 1) -> np.ndarray:
+    """Generate batch of grids using random permutation of numbers 1..N."""
+    base = np.arange(1, rows * cols + 1)
+    rand = rng.random((batch, rows * cols))
+    idx = np.argsort(rand, axis=1)
+    boards = base[idx].reshape(batch, rows, cols)
+    return boards.astype(np.int16)
 
 @register_formula("shuffle")
-def gen_shuffle(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:
-    """Generate grid by shuffling numbers within each row."""
-    nums = np.arange(1, rows * cols + 1)
-    board = nums.reshape(rows, cols)
-    for r in range(rows):
-        rng.shuffle(board[r])
-    return board
+def gen_shuffle(rows: int, cols: int, rng: np.random.Generator, batch: int = 1) -> np.ndarray:
+    """Generate batch of grids by shuffling numbers within each row."""
+    base = np.arange(1, rows * cols + 1).reshape(rows, cols)
+    base = np.broadcast_to(base, (batch, rows, cols)).copy()
+    rand = rng.random((batch, rows, cols))
+    idx = np.argsort(rand, axis=2)
+    boards = np.take_along_axis(base, idx, axis=2)
+    return boards.astype(np.int16)
 
 @register_formula("random_entropy")
-def gen_random_entropy(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:
-    """Generate grid with entropy-based random dispersion."""
-    grid = np.zeros((rows, cols), dtype=np.int64)
-    legal = list(range(1, rows * cols + 1))
-    rng.shuffle(legal)
-    for i in range(rows * cols):
-        r, c = divmod(i, cols)
-        grid[r, c] = legal[i]
-    return grid
+def gen_random_entropy(rows: int, cols: int, rng: np.random.Generator, batch: int = 1) -> np.ndarray:
+    """Generate batch of grids with entropy-based random dispersion."""
+    base = np.arange(1, rows * cols + 1)
+    rand = rng.random((batch, rows * cols))
+    idx = np.argsort(rand, axis=1)
+    boards = base[idx].reshape(batch, rows, cols)
+    return boards.astype(np.int16)
 
 @register_formula("tail_cluster")
-def gen_tail_cluster(rows: int, cols: int, rng: np.random.Generator) -> np.ndarray:
-    """Generate grid clustering larger numbers near the bottom-right corner."""
+def gen_tail_cluster(rows: int, cols: int, rng: np.random.Generator, batch: int = 1) -> np.ndarray:
+    """Generate batch of grids clustering larger numbers near the bottom-right corner."""
     n = rows * cols
     high_rows = max(1, int(rows * 0.3))
     high_cols = max(1, int(cols * 0.3))
@@ -58,17 +60,15 @@ def gen_tail_cluster(rows: int, cols: int, rng: np.random.Generator) -> np.ndarr
     low_idx = np.flatnonzero(~mask.ravel())
 
     nums = np.arange(1, n + 1)
-    rng.shuffle(nums)
-    nums.sort()
-    high_nums = nums[-len(high_idx):]
-    low_nums = nums[:-len(high_idx)]
-    rng.shuffle(high_nums)
-    rng.shuffle(low_nums)
-
-    board = np.empty(n, dtype=np.int64)
-    board[low_idx] = low_nums
-    board[high_idx] = high_nums
-    return board.reshape(rows, cols)
+    rand = rng.random((batch, n))
+    perm = nums[np.argsort(rand, axis=1)]
+    perm.sort(axis=1)
+    high_nums = perm[:, -len(high_idx):]
+    low_nums = perm[:, :-len(high_idx)]
+    boards = np.empty((batch, n), dtype=np.int16)
+    boards[:, low_idx] = low_nums
+    boards[:, high_idx] = high_nums
+    return boards.reshape(batch, rows, cols)
 
 class AdaptiveWeights:
     """Manages dynamic weight adjustments for formulas based on performance."""
@@ -95,3 +95,45 @@ class AdaptiveWeights:
                 json.dump(self.history, f, ensure_ascii=False)
         except OSError as e:
             logging.error(f"Failed to save weights history: {e}")
+
+def global_offset_cooccurrence(
+    boards: np.ndarray,
+    target: int,
+    offsets: Optional[list[int]] = None,
+) -> np.ndarray:
+    """GlobalOffsetCooccurrenceModule
+
+    Count occurrences of ``target + offset`` across each board and assign the
+    count to every hidden cell as a base score.
+
+    Parameters
+    ----------
+    boards : np.ndarray
+        Batch of boards with shape ``(batch, rows, cols)``.
+    target : int
+        Target number to offset from.
+    offsets : list[int], optional
+        Offsets to check; defaults to ``[1, -1, 10, -10, 20, -20]``.
+
+    Returns
+    -------
+    np.ndarray
+        Score array of shape ``(batch, rows, cols)``.
+    """
+    if offsets is None:
+        offsets = [1, -1, 10, -10, 20, -20]
+
+    boards = np.asarray(boards)
+    if boards.ndim != 3:
+        raise ValueError("boards must have shape (batch, rows, cols)")
+
+    batch, r, c = boards.shape
+    mask_hidden = (boards == -1).astype(float)
+    score = np.zeros((batch, r, c), dtype=float)
+
+    for o in offsets:
+        counts = np.sum(boards == (target + o), axis=(1, 2))
+        score += mask_hidden * counts[:, None, None]
+
+    return score
+

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -30,3 +30,15 @@ def test_registered_modules():
             # Some modules may legitimately raise ValueError on small grids
             continue
     assert len(brain.REGISTERED_MODULES_BRAIN) >= len(modules)
+
+def test_global_offset_cooccurrence():
+    grid = np.array([[1, 2, -1], [2, 1, -1]])
+    scores = brain.get_module_score(
+        "EXT_GlobalOffsetCooccurrence_Vec",
+        grid,
+        target=1,
+    )
+    assert scores.shape == grid.shape
+    assert scores[0, 2] == 2
+    assert scores[1, 2] == 2
+


### PR DESCRIPTION
## Summary
- avoid running `EXT_GlobalOffsetCooccurrence_Vec` when module selection has no target parameter

## Testing
- `python -m py_compile main.py app.py analyzer.py brain.py modules.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a4c7691948324a80ff012bfb138f6