### PR TITLE
Add Q11 and Q12 scoring modules

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -10,9 +10,11 @@ import numpy as np
 import xxhash
 from joblib import Parallel, delayed
 
+# fmt: off
 from brain import (REGISTERED_MODULES_BRAIN, BoardAnalyzerUtils,
                    EXT_GM20_Skip_Pattern_Confidence_Vec, MathUtils,
                    bytes_to_grid, get_module_score)
+# fmt: on
 from modules import FORMULA_REGISTRY
 
 # Logger configuration
@@ -76,23 +78,28 @@ def adjust_weights_based_on_history(
 
 def select_modules(grid: np.ndarray, target: Optional[int] = None) -> List[str]:
     """Dynamically select modules based on grid characteristics."""
-    # 根據 FORCE_FULL_SCAN 環境變數決定是否使用所有模組
     if os.getenv("FORCE_FULL_SCAN", "0") == "1":
-        return list(REGISTERED_MODULES_BRAIN)  # 直接使用所有模組
-    # 原始邏輯：動態選擇模組
-    base_modules = [
-        "EXT_Q1_ProximityEntropy_Vec",
-        "EXT_Q2_PotentialPath_Vec",
-        "EXT_Q5_GlobalEntropy_Vec",
-        "EXT_Q6_LineBridge_Vec",
-        "EXT_Q7_VariancePrior_Vec",
-    ]
-    scores = {
-        mod: np.mean(get_module_score(mod, grid, target=target))
-        for mod in REGISTERED_MODULES_BRAIN
-    }
-    top_modules = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)[:2]
-    return base_modules + [m for m in top_modules if m not in base_modules]
+        mods = list(REGISTERED_MODULES_BRAIN)
+    else:
+        base_modules = [
+            "EXT_Q1_ProximityEntropy_Vec",
+            "EXT_Q2_PotentialPath_Vec",
+            "EXT_Q5_GlobalEntropy_Vec",
+            "EXT_Q6_LineBridge_Vec",
+            "EXT_Q7_VariancePrior_Vec",
+        ]
+        scores = {
+            mod: np.mean(get_module_score(mod, grid, target=target))
+            for mod in REGISTERED_MODULES_BRAIN
+        }
+        top_modules = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)[:2]
+        mods = base_modules + [m for m in top_modules if m not in base_modules]
+
+    if "EXT_Q12_ArithmeticProgression_Vec" not in mods:
+        mods.append("EXT_Q12_ArithmeticProgression_Vec")
+    if target is not None and "EXT_Q11_GlobalDigitAffinity_Vec" not in mods:
+        mods.append("EXT_Q11_GlobalDigitAffinity_Vec")
+    return mods
 
 
 @lru_cache(maxsize=500000)

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 from datetime import datetime
-# Logging
 from logging.handlers import RotatingFileHandler
 from typing import Any, Dict, List, Optional
 

--- a/brain.py
+++ b/brain.py
@@ -433,6 +433,96 @@ def EXT_Q10_DistPotential_Vec(
     return 1 - dist_norm
 
 
+@batchable
+def EXT_Q11_GlobalDigitAffinity_Vec(
+    grid: np.ndarray, target: Optional[int] = None, request_id: Optional[str] = "N/A"
+) -> np.ndarray:
+    if target is None:
+        return np.zeros_like(grid, dtype=float)
+
+    rows, cols = grid.shape
+    max_val = rows * cols
+    vals = np.arange(1, max_val + 1)
+
+    sim = np.zeros_like(vals, dtype=float)
+    np.maximum(sim, (vals % 10 == target % 10).astype(float) * 1.0, out=sim)
+    np.maximum(
+        sim, np.isin(np.abs(vals - target), [10, 20]).astype(float) * 0.7, out=sim
+    )
+    np.maximum(sim, (vals % 10 == target // 10).astype(float) * 0.4, out=sim)
+
+    rr = np.arange(rows)[:, None]
+    cc = np.arange(cols)[None, :]
+    center = ((rows - 1) / 2.0, (cols - 1) / 2.0)
+    dist = np.sqrt((rr - center[0]) ** 2 + (cc - center[1]) ** 2)
+    kernel = 1.0 / (1.0 + 0.5 * dist)
+
+    masks = (grid[..., None] == vals).astype(float)
+    k_fft = rfftn(kernel, s=grid.shape)
+    masks_fft = rfftn(masks, s=grid.shape, axes=(0, 1))
+    conv = irfftn(masks_fft * k_fft[..., None], s=grid.shape, axes=(0, 1))
+    score = np.tensordot(conv, sim, axes=([2], [0]))
+
+    score = np.where(grid == -1, score, 0.0)
+    mn, mx = score.min(), score.max()
+    if mx > mn:
+        score = (score - mn) / (mx - mn)
+    else:
+        score.fill(0.0)
+    return score.astype(np.float32)
+
+
+def _shift(arr: np.ndarray, dr: int, dc: int) -> np.ndarray:
+    out = np.zeros_like(arr)
+    r_start = max(0, dr)
+    r_end = arr.shape[0] + min(0, dr)
+    c_start = max(0, dc)
+    c_end = arr.shape[1] + min(0, dc)
+    out[r_start:r_end, c_start:c_end] = arr[
+        r_start - dr : r_end - dr, c_start - dc : c_end - dc
+    ]
+    return out
+
+
+@batchable
+def EXT_Q12_ArithmeticProgression_Vec(
+    grid: np.ndarray, request_id: Optional[str] = "N/A"
+) -> np.ndarray:
+    rows, cols = grid.shape
+    val = np.where(grid == -1, 0, grid)
+    mask = (grid != -1).astype(int)
+    score = np.zeros_like(val, dtype=float)
+
+    directions = [
+        (0, 1),
+        (1, 0),
+        (1, 1),
+        (1, -1),
+        (2, 1),
+        (2, -1),
+        (1, 2),
+        (-1, 2),
+    ]
+
+    for dr, dc in directions:
+        prev = _shift(val, -dr, -dc)
+        next_ = _shift(val, dr, dc)
+        conv1 = prev - 2 * val + next_
+        cnt = _shift(mask, -dr, -dc) + mask + _shift(mask, dr, dc)
+        valid = (conv1 == 0) & (cnt == 3)
+        w_gap = 1.0 / (1.0 + max(abs(dr), abs(dc)))
+        v = valid.astype(float)
+        score += w_gap * (v + _shift(v, dr, dc) + _shift(v, -dr, -dc))
+
+    score = np.where(grid == -1, score, 0.0)
+    mn, mx = score.min(), score.max()
+    if mx > mn:
+        score = (score - mn) / (mx - mn)
+    else:
+        score.fill(0.0)
+    return score.astype(np.float32)
+
+
 # --- Scoring Module Implementations ---
 
 
@@ -763,6 +853,8 @@ mods = {
     "EXT_Q8_SpatialKL_Vec": EXT_Q8_SpatialKL_Vec,
     "EXT_Q9_MultiScaleEntropy_Vec": EXT_Q9_MultiScaleEntropy_Vec,
     "EXT_Q10_DistPotential_Vec": EXT_Q10_DistPotential_Vec,
+    "EXT_Q11_GlobalDigitAffinity_Vec": EXT_Q11_GlobalDigitAffinity_Vec,
+    "EXT_Q12_ArithmeticProgression_Vec": EXT_Q12_ArithmeticProgression_Vec,
     "EXT_M1_Tail_Pattern_Vec": EXT_M1_Tail_Pattern_Vec,
     "EXT_M3_Local_Focus_Vec": EXT_M3_Local_Focus_Vec,
     "EXT_M10_Sequence_Block_Vec": EXT_M10_Sequence_Block_Vec,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,18 @@
 # tests/conftest.py
+import importlib.util
+import pathlib
+import sys
+
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
-from app import app
 
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))  # noqa: E402
+spec = importlib.util.spec_from_file_location("app", ROOT_DIR / "app.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+app = module.app
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_q11_q12.py
+++ b/tests/test_q11_q12.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+import analyzer
+import brain
+
+
+def random_board(rng, r, c):
+    board = np.arange(1, r * c + 1, dtype=int).reshape(r, c)
+    blanks = rng.choice(r * c, max(1, (r * c) // 5), replace=False)
+    board.ravel()[blanks] = -1
+    return board
+
+
+def test_q11_q12_basic():
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        r = int(rng.integers(4, 8))
+        c = int(rng.integers(4, 8))
+        grid = random_board(rng, r, c)
+        target = int(rng.integers(1, r * c + 1))
+        s11 = brain.EXT_Q11_GlobalDigitAffinity_Vec(grid, target=target)
+        s12 = brain.EXT_Q12_ArithmeticProgression_Vec(grid)
+        assert s11.shape == grid.shape and s12.shape == grid.shape
+        assert np.all(s11[grid != -1] == 0)
+        assert np.all(s12[grid != -1] == 0)
+        assert np.any(s11[grid == -1] >= 0)
+        assert 0.0 <= float(s11.max()) <= 1.0
+        assert 0.0 <= float(s12.max()) <= 1.0
+
+
+def test_select_modules_includes_new():
+    grid = np.array([[1, -1], [2, 3]])
+    mods = analyzer.select_modules(grid, target=5)
+    assert "EXT_Q11_GlobalDigitAffinity_Vec" in mods
+    assert "EXT_Q12_ArithmeticProgression_Vec" in mods
+    mods2 = analyzer.select_modules(grid, target=None)
+    assert "EXT_Q12_ArithmeticProgression_Vec" in mods2


### PR DESCRIPTION
## Summary
- implement EXT_Q11_GlobalDigitAffinity_Vec and EXT_Q12_ArithmeticProgression_Vec
- register new modules and update analyzer module selection
- provide tests covering new heuristics and module selection logic
- adjust test setup to load app module reliably

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bda484a648324bac8a0bc1b8d44cd