### PR TITLE
Implement two-phase Monte Carlo

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -173,8 +173,11 @@ def simulate_full_board(
     target_num: Optional[int],
     n_iter: int = 6000,
     rng: Optional[np.random.Generator] = None,
+    *,
+    focus_cells: Optional[List[Tuple[int, int]]] = None,
+    epsilon: float = 0.0,
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
-    """Simulate full boards with enhanced importance sampling and target_num hits."""
+    """Simulate full boards with optional focus and ε-exploration."""
     if rng is None:
         rng = np.random.default_rng()
 
@@ -204,6 +207,10 @@ def simulate_full_board(
     weights = adjust_weights_based_on_history(history, formulas)
     remain = n_iter
     counts = defaultdict(lambda: defaultdict(int))
+    focus_set = {tuple(fc) for fc in focus_cells} if focus_cells else None
+    other_cells = (
+        [tuple(b) for b in blanks if tuple(b) not in focus_set] if focus_set else []
+    )
 
     while remain > 0:
         batch = min(4000, remain)
@@ -221,7 +228,7 @@ def simulate_full_board(
                 boards = boards[mask]
 
         if len(boards) > 0:
-            for i, board in enumerate(boards):
+            for board in boards:
                 fast = (
                     0.5 * get_module_score("EXT_Q1_ProximityEntropy_Vec", board)
                     + 0.5 * get_module_score("EXT_Q2_PotentialPath_Vec", board)
@@ -229,7 +236,12 @@ def simulate_full_board(
                     + 0.2 * get_module_score("EXT_Q6_LineBridge_Vec", board)
                     + 0.1 * get_module_score("EXT_Q7_VariancePrior_Vec", board)
                 )
-                for r, c in blanks:
+                cells_iter = blanks if focus_set is None else focus_set
+                if focus_set is not None and other_cells and rng.random() < epsilon:
+                    cells_iter = list(focus_set) + [
+                        other_cells[int(rng.integers(len(other_cells)))]
+                    ]
+                for r, c in cells_iter:
                     idx = r * cols + c
                     if rng.random() < importance_weights[idx]:
                         num = board[r, c]
@@ -466,6 +478,11 @@ def predict_scratch_card(
     refine_iter: Optional[int] = None,
     min_total_iter: Optional[int] = None,
     unique: bool = True,
+    *,
+    global_iter: Optional[int] = None,
+    focus_iter: Optional[int] = None,
+    top_n: int = 10,
+    epsilon: float = 0.05,
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
     rows, cols = grid_np.shape
@@ -486,18 +503,38 @@ def predict_scratch_card(
         ("EXT_Q7_VariancePrior_Vec", "Variance smoothing and prior"),
     ]
 
-    base_iter = iterations if iterations is not None else int(os.getenv("ITER", "5000"))
-    total_iter = int(base_iter * max(rows * cols / 40, 1))
-    quick_iter = quick_iter if quick_iter is not None else int(total_iter * 0.35)
-    refine_iter = refine_iter if refine_iter is not None else total_iter - quick_iter
-    min_total_iter = (
-        min_total_iter if min_total_iter is not None else max(1000, total_iter // 5)
+    phase1 = global_iter if global_iter is not None else iterations or 5000
+    phase2 = focus_iter if focus_iter is not None else 1000
+    logger.info(
+        "Two-phase simulation | phase1=%d, phase2=%d, top_n=%d, epsilon=%.2f",
+        phase1,
+        phase2,
+        top_n,
+        epsilon,
     )
 
-    logger.info(f"Simulating full board with {total_iter} iterations")
     prob_map = simulate_full_board(
-        grid_np, target_num, n_iter=total_iter, rng=np.random.default_rng()
+        grid_np, target_num, n_iter=phase1, rng=np.random.default_rng()
     )
+
+    # select top-n cells for refinement
+    ranked = sorted(
+        ((r, c, max(d.values())) for (r, c), d in prob_map.items()),
+        key=lambda x: x[2],
+        reverse=True,
+    )
+    focus_cells = [(r, c) for r, c, _ in ranked[: max(1, min(top_n, len(ranked)))]]
+
+    if phase2 > 0:
+        refine_map = simulate_full_board(
+            grid_np,
+            target_num,
+            n_iter=phase2,
+            rng=np.random.default_rng(),
+            focus_cells=focus_cells,
+            epsilon=epsilon,
+        )
+        prob_map.update(refine_map)
 
     if target_num is not None:
         rank = [

--- a/app.py
+++ b/app.py
@@ -50,6 +50,10 @@ class GridRequest(BaseModel):
     grid: List[List[int]]
     target_num: Optional[int] = None
     iterations: Optional[int] = 5000
+    global_iter: Optional[int] = None
+    focus_iter: Optional[int] = None
+    top_n: int = 10
+    epsilon: float = 0.05
 
 
 class Prediction(BaseModel):
@@ -122,7 +126,13 @@ async def predict(req: GridRequest):
 
         # 推理邏輯
         result = predict_scratch_card(
-            grid=req.grid, target_num=req.target_num, iterations=req.iterations
+            grid=req.grid,
+            target_num=req.target_num,
+            iterations=req.iterations,
+            global_iter=req.global_iter,
+            focus_iter=req.focus_iter,
+            top_n=req.top_n,
+            epsilon=req.epsilon,
         )
 
         predictions = result.get("predictions", [])

--- a/main.py
+++ b/main.py
@@ -35,6 +35,20 @@ def parse_args() -> argparse.Namespace:
         help="Number of Monte Carlo iterations",
     )
     parser.add_argument(
+        "--global-iter",
+        type=int,
+        default=None,
+        help="Phase-1 global iteration count",
+    )
+    parser.add_argument(
+        "--focus-iter",
+        type=int,
+        default=None,
+        help="Phase-2 focused iteration count",
+    )
+    parser.add_argument("--top-n", type=int, default=10, help="Top cells to refine")
+    parser.add_argument("--epsilon", type=float, default=0.05, help="Exploration rate")
+    parser.add_argument(
         "--target", type=int, default=None, help="Target number to predict"
     )
     return parser.parse_args()
@@ -77,7 +91,13 @@ def main():
         # Disable Ray dashboard to avoid excessive port scanning
         ray.init(num_cpus=4, include_dashboard=False)
         result = predict_scratch_card(
-            grid, target_num=args.target, iterations=iterations
+            grid,
+            target_num=args.target,
+            iterations=iterations,
+            global_iter=args.global_iter,
+            focus_iter=args.focus_iter,
+            top_n=args.top_n,
+            epsilon=args.epsilon,
         )
         ray.shutdown()
         logging.info("Prediction results:")

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -20,6 +20,19 @@ def test_simulate_runs_on_min_board(make_grid):
     simulate_full_board(grid, None, n_iter=8)
 
 
+def test_simulate_focus_cells(make_grid):
+    grid = np.array(make_grid(4, 4))
+    blanks = [tuple(p) for p in np.argwhere(np.array(grid) == -1)]
+    probs = simulate_full_board(
+        grid,
+        None,
+        n_iter=4,
+        focus_cells=blanks[:1],
+        epsilon=0.1,
+    )
+    assert isinstance(probs, dict)
+
+
 def test_weight_prob_by_modules_variation(monkeypatch):
     grid = np.array([[1, -1], [3, -1]])
     prob_map = {(0, 1): {2: 0.6}, (1, 1): {4: 0.4}}

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -27,7 +27,15 @@ def test_predict_valid_grid():
             val += 1
         grid.append(row)
     grid[2][3] = -1
-    payload = {"grid": grid, "target_num": 6, "iterations": 10}
+    payload = {
+        "grid": grid,
+        "target_num": 6,
+        "iterations": 10,
+        "global_iter": 5,
+        "focus_iter": 2,
+        "top_n": 5,
+        "epsilon": 0.1,
+    }
     res = client.post("/predict", json=payload)
     assert res.status_code == 200
     body = res.json()


### PR DESCRIPTION
## Summary
- add parameters to GridRequest and CLI for two-phase Monte Carlo
- implement focus-based simulation with epsilon exploration in `simulate_full_board`
- update prediction logic to run global then focused iteration
- update API and CLI to accept new parameters
- test new focus feature

## Testing
- `black --check analyzer.py app.py main.py tests/test_analyzer.py tests/test_predict.py`
- `isort --check-only analyzer.py app.py main.py tests/test_analyzer.py tests/test_predict.py`
- `flake8 analyzer.py app.py main.py tests/test_analyzer.py tests/test_predict.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c039524008324be92005066edd791