### PR TITLE
Implement weighted score normalization

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -11,9 +11,9 @@ import xxhash
 from joblib import Parallel, delayed
 
 # fmt: off
-from brain import (REGISTERED_MODULES_BRAIN, BoardAnalyzerUtils,
+from brain import (AGG_WEIGHTS, REGISTERED_MODULES_BRAIN, BoardAnalyzerUtils,
                    EXT_GM20_Skip_Pattern_Confidence_Vec, MathUtils,
-                   bytes_to_grid, get_module_score)
+                   aggregate_scores, bytes_to_grid, get_module_score)
 # fmt: on
 from modules import FORMULA_REGISTRY
 
@@ -229,13 +229,22 @@ def simulate_full_board(
 
         if len(boards) > 0:
             for board in boards:
-                fast = (
-                    0.5 * get_module_score("EXT_Q1_ProximityEntropy_Vec", board)
-                    + 0.5 * get_module_score("EXT_Q2_PotentialPath_Vec", board)
-                    + 0.2 * get_module_score("EXT_Q5_GlobalEntropy_Vec", board)
-                    + 0.2 * get_module_score("EXT_Q6_LineBridge_Vec", board)
-                    + 0.1 * get_module_score("EXT_Q7_VariancePrior_Vec", board)
+                mods_fast = [
+                    "EXT_Q1_ProximityEntropy_Vec",
+                    "EXT_Q2_PotentialPath_Vec",
+                    "EXT_Q5_GlobalEntropy_Vec",
+                    "EXT_Q6_LineBridge_Vec",
+                    "EXT_Q7_VariancePrior_Vec",
+                ]
+                stack_fast = np.stack(
+                    [get_module_score(m, board) for m in mods_fast], axis=0
                 )
+                w_fast = np.array([AGG_WEIGHTS[m] for m in mods_fast])
+                fast = aggregate_scores(stack_fast, w_fast, mods_fast)
+                tau_local = float(os.getenv("TAU_SOFTMAX", "1.0"))
+                soft_fast = np.exp(fast / tau_local)
+                soft_fast /= soft_fast.sum() + 1e-10
+                fast = soft_fast
                 cells_iter = blanks if focus_set is None else focus_set
                 if focus_set is not None and other_cells and rng.random() < epsilon:
                     cells_iter = list(focus_set) + [
@@ -258,7 +267,22 @@ def simulate_full_board(
 
     # Two-phase scoring: Re-rank top K candidates with Borda or Soft-Max
     tau = float(os.getenv("TAU_SOFTMAX", "0.3"))
-    w = np.array([0.28, 0.28, 0.12, 0.12, 0.08, 0.07, 0.05])  # Q1~Q7
+    mods_rerank = [
+        "EXT_Q1_ProximityEntropy_Vec",
+        "EXT_Q2_PotentialPath_Vec",
+        "EXT_Q3_DiscontinuitySym_Vec",
+        "EXT_Q4_ControlComposite_Vec",
+        "EXT_Q5_GlobalEntropy_Vec",
+        "EXT_Q6_LineBridge_Vec",
+        "EXT_Q7_VariancePrior_Vec",
+    ]
+    w = np.array([AGG_WEIGHTS[m] for m in mods_rerank])
+    stack_rerank = np.stack(
+        [get_module_score(m, g, target=target_num) for m in mods_rerank], axis=0
+    )
+    final_heat = aggregate_scores(stack_rerank, w, mods_rerank)
+    soft_heat = np.exp(final_heat / tau)
+    soft_heat /= soft_heat.sum() + 1e-10
     topk = int(os.getenv("TOPK_RERANK", "100"))
     if topk < 0:  # -1 表示 rows × cols
         topk = rows * cols
@@ -271,19 +295,7 @@ def simulate_full_board(
     top_k = heapq.nlargest(topk, candidates, key=lambda x: x[2])
     final_prob_map = {}
     for r, c, fast_score, num in top_k:
-        scores = [
-            get_module_score("EXT_Q1_ProximityEntropy_Vec", g)[r, c],
-            get_module_score("EXT_Q2_PotentialPath_Vec", g)[r, c],
-            get_module_score("EXT_Q3_DiscontinuitySym_Vec", g)[r, c],
-            # pass target forward so composite & children receive it
-            get_module_score("EXT_Q4_ControlComposite_Vec", g, target=target_num)[r, c],
-            get_module_score("EXT_Q5_GlobalEntropy_Vec", g)[r, c],
-            get_module_score("EXT_Q6_LineBridge_Vec", g)[r, c],
-            get_module_score("EXT_Q7_VariancePrior_Vec", g)[r, c],
-        ]
-        soft = np.exp(np.array(scores) / tau)
-        soft /= soft.sum() + 1e-10
-        final_score = (w * soft).sum()
+        final_score = float(soft_heat[r, c])
         if (r, c) not in final_prob_map:
             final_prob_map[(r, c)] = {}
         final_prob_map[(r, c)][num] = final_score

--- a/brain.py
+++ b/brain.py
@@ -951,6 +951,45 @@ RERANK_PHASE = [
     "EXT_Q10_DistPotential_Vec",
 ]
 
+# Static weights for module aggregation
+AGG_WEIGHTS = {
+    "EXT_Q1_ProximityEntropy_Vec": 0.20,
+    "EXT_Q2_PotentialPath_Vec": 0.15,
+    "EXT_Q3_DiscontinuitySym_Vec": 0.10,
+    "EXT_Q4_ControlComposite_Vec": 0.10,
+    "EXT_Q5_GlobalEntropy_Vec": 0.08,
+    "EXT_Q6_LineBridge_Vec": 0.08,
+    "EXT_Q7_VariancePrior_Vec": 0.08,
+    "EXT_Q8_SpatialKL_Vec": 0.05,
+    "EXT_Q9_MultiScaleEntropy_Vec": 0.05,
+    "EXT_Q10_DistPotential_Vec": 0.04,
+    "EXT_Q11_GlobalDigitAffinity_Vec": 0.03,
+    "EXT_Q12_ArithmeticProgression_Vec": 0.04,
+    "EXT_Q13_GlobalConsistencySpectrum_Vec": 0.04,
+}
+
+
+def _load_weights() -> Dict[str, float]:
+    """Return normalized weights with ENV overrides."""
+    w = AGG_WEIGHTS.copy()
+    for name in w:
+        env_key = f"WEIGHT_{name.split('_')[1]}"
+        env_val = os.getenv(env_key)
+        if env_val is not None:
+            try:
+                w[name] = float(env_val)
+            except ValueError:
+                logger.warning("Invalid weight for %s: %s", env_key, env_val)
+    total = sum(w.values())
+    if not math.isclose(total, 1.0, rel_tol=1e-3):
+        logger.info("Normalizing module weights (sum %.3f)", total)
+        for k in w:
+            w[k] /= total or 1e-10
+    return w
+
+
+AGG_WEIGHTS = _load_weights()
+
 
 # ----------------------------------------------------------------------
 # Module execution
@@ -968,7 +1007,6 @@ def get_module_score(
         rows, cols = grid.shape
         return np.zeros((rows, cols), dtype=float)
     module_func = REGISTERED_MODULES_BRAIN[module_name]
-    # Always forward the target keyword so lambdas requiring it won't fail
     kwargs["target"] = target
     score_grid = safe_call(module_func, grid, **kwargs)
     if module_name not in _seen_modules_once:
@@ -998,3 +1036,19 @@ def get_module_score(
         )
         rows, cols = grid.shape
         return np.zeros((rows, cols), dtype=float)
+
+
+def aggregate_scores(
+    stack: np.ndarray, weights: np.ndarray, names: Optional[list[str]] | None = None
+) -> np.ndarray:
+    """Normalize score maps then combine via weighted sum."""
+    mu = stack.mean(axis=(1, 2), keepdims=True)
+    sigma = stack.std(axis=(1, 2), keepdims=True) + 1e-6
+    stack_z = (stack - mu) / sigma
+    weights_normalized = weights / (weights.sum() + 1e-10)
+    final = np.tensordot(weights_normalized, stack_z, axes=(0, 0))
+    if names:
+        contrib = (weights_normalized[:, None, None] * stack_z).mean(axis=(1, 2))
+        for n, w, c in zip(names, weights_normalized, contrib):
+            logger.info("aggregate | %s | w=%.3f | contrib=%.3f", n, w, float(c))
+    return final

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -16,3 +16,16 @@ def test_module_shapes(make_grid):
         out = fn(grid, target=42) if "target" in fn.__code__.co_varnames else fn(grid)
         assert out.shape == grid.shape
         assert np.isfinite(out).all(), f"{fn.__name__} 出現 NaN/Inf"
+
+
+def test_aggregate_scores_basic():
+    stack = np.array(
+        [
+            np.ones((2, 2)),
+            np.full((2, 2), 2.0),
+        ]
+    )
+    weights = np.array([0.7, 0.3])
+    out = brain.aggregate_scores(stack, weights, ["A", "B"])
+    assert out.shape == (2, 2)
+    assert np.all(np.isfinite(out))


### PR DESCRIPTION
## Summary
- add AGG_WEIGHTS table with ENV overrides and auto-normalization
- implement `aggregate_scores` to z-score each module and log contributions
- use new aggregator in simulation and final rerank
- test aggregator basics

## Testing
- `black --check analyzer.py brain.py tests/test_brain.py`
- `isort analyzer.py brain.py tests/test_brain.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c11e35414832494d3390767445b12