### PR TITLE
Implement heatmap probability estimator

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -4,7 +4,7 @@ import math
 import os
 from collections import defaultdict
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import xxhash
@@ -702,3 +702,101 @@ def process_grid(grid):
             }
         )
     return preds
+
+
+def monte_carlo_prob_map(
+    grid: Union[List[List[int]], np.ndarray],
+    k: Optional[int],
+    n_iter: int = 1000,
+    *,
+    seed: int = 0,
+) -> Union[np.ndarray, Dict[int, np.ndarray]]:
+    """Estimate number distribution via Monte-Carlo sampling.
+
+    Parameters
+    ----------
+    grid : List[List[int]] or np.ndarray
+        Board matrix where ``-1`` denotes an unknown cell.
+    k : int or None
+        Target number to estimate. ``None`` computes probability for all
+        remaining numbers.
+    n_iter : int
+        Simulation iterations.
+    seed : int
+        RNG seed for reproducibility.
+
+    Returns
+    -------
+    np.ndarray or Dict[int, np.ndarray]
+        If ``k`` is provided, a 2-D probability matrix of the same shape as the
+        grid is returned. Otherwise a mapping from number to probability matrix
+        is produced.
+    """
+
+    g = np.asarray(grid, dtype=int)
+    rng = np.random.default_rng(seed)
+
+    rows, cols = g.shape
+    blanks = np.argwhere(g == -1)
+    blank_idx = (blanks[:, 0], blanks[:, 1])
+    known_vals = g[g != -1]
+    all_vals = np.arange(1, rows * cols + 1)
+    remain = np.setdiff1d(all_vals, known_vals, assume_unique=True)
+
+    if k is not None and k not in all_vals:
+        raise ValueError("k out of range")
+
+    if k is not None:
+        counts = np.zeros((rows, cols), dtype=int)
+    else:
+        counts = {int(val): np.zeros((rows, cols), dtype=int) for val in remain}
+
+    for _ in range(max(1, n_iter)):
+        sample = rng.permutation(remain)
+        board = g.copy()
+        board[blank_idx] = sample[: blanks.shape[0]]
+
+        if k is not None:
+            hits = board == k
+            counts += hits.astype(int)
+        else:
+            for val in remain:
+                counts[int(val)] += (board == val).astype(int)
+
+    if k is not None:
+        prob = counts.astype(float) / float(n_iter)
+        prob[g != -1] = 0.0
+        return prob
+
+    prob_all: Dict[int, np.ndarray] = {}
+    for val, mat in counts.items():
+        arr = mat.astype(float) / float(n_iter)
+        arr[g != -1] = 0.0
+        prob_all[int(val)] = arr
+    return prob_all
+
+
+def prob_map_to_png(prob_map: np.ndarray) -> bytes:
+    """Render probability matrix to a grayscale PNG."""
+    import struct
+    import zlib
+
+    h, w = prob_map.shape
+    img = np.clip(prob_map, 0.0, 1.0)
+    img8 = (img * 255).astype(np.uint8)
+
+    raw = b"".join(b"\x00" + img8[i].tobytes() for i in range(h))
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 0, 0, 0, 0))
+    png += chunk(b"IDAT", zlib.compress(raw))
+    png += chunk(b"IEND", b"")
+    return png

--- a/app.py
+++ b/app.py
@@ -1,10 +1,11 @@
+import base64
 import json
 import logging
 import os
 import sys
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, status
@@ -12,7 +13,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel
 
-from analyzer import predict_scratch_card
+# fmt: off
+# isort: off
+from analyzer import (
+    monte_carlo_prob_map,
+    predict_scratch_card,
+    prob_map_to_png,
+)
+# isort: on
+# fmt: on
 
 log_handlers = [
     logging.StreamHandler(sys.stdout),
@@ -68,6 +77,18 @@ class Prediction(BaseModel):
 class PredictResponse(BaseModel):
     predictions: List[Prediction]
     full_probabilities: Dict[str, Dict[str, float]]
+
+
+class HeatmapRequest(BaseModel):
+    grid: List[List[int]]
+    k: Optional[int] = None
+    iterations: int = 1000
+    seed: int = 0
+
+
+class HeatmapResponse(BaseModel):
+    prob_map: Union[List[List[float]], Dict[str, List[List[float]]]]
+    heatmap: Optional[str] = None
 
 
 # ==== Routes ====
@@ -176,6 +197,27 @@ async def predict(req: GridRequest):
         raise HTTPException(
             status_code=500, detail="❌ 回傳 JSON 格式異常：" + str(exc)
         ) from exc
+
+
+@app.post(
+    "/heatmap",
+    response_model=HeatmapResponse,
+    response_class=JSONResponse,
+    status_code=200,
+)
+async def heatmap(req: HeatmapRequest):
+    try:
+        prob = monte_carlo_prob_map(req.grid, req.k, req.iterations, seed=req.seed)
+        if isinstance(prob, dict):
+            prob_map = {str(int(k)): v.tolist() for k, v in prob.items()}
+            return {"prob_map": prob_map, "heatmap": None}
+
+        png_bytes = prob_map_to_png(prob)
+        b64 = base64.b64encode(png_bytes).decode("ascii")
+        return {"prob_map": prob.tolist(), "heatmap": b64}
+    except Exception as exc:
+        logger.error("Heatmap generation failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @app.on_event("startup")

--- a/main.py
+++ b/main.py
@@ -7,7 +7,15 @@ from typing import List
 import numpy as np
 import ray
 
-from analyzer import predict_scratch_card
+# fmt: off
+# isort: off
+from analyzer import (
+    monte_carlo_prob_map,
+    predict_scratch_card,
+    prob_map_to_png,
+)
+# isort: on
+# fmt: on
 
 # Logging configuration
 logging.basicConfig(
@@ -50,6 +58,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--epsilon", type=float, default=0.05, help="Exploration rate")
     parser.add_argument(
         "--target", type=int, default=None, help="Target number to predict"
+    )
+    parser.add_argument(
+        "--heatmap-k",
+        type=int,
+        default=None,
+        help="Generate probability heatmap for this number (None to skip)",
+    )
+    parser.add_argument(
+        "--heatmap-iter",
+        type=int,
+        default=1000,
+        help="Iterations for heatmap simulation",
     )
     return parser.parse_args()
 
@@ -100,6 +120,20 @@ def main():
             epsilon=args.epsilon,
         )
         ray.shutdown()
+
+        if args.heatmap_k is not None:
+            prob = monte_carlo_prob_map(
+                grid_np,
+                args.heatmap_k if args.heatmap_k != -1 else None,
+                args.heatmap_iter,
+            )
+            if not isinstance(prob, dict):
+                png_bytes = prob_map_to_png(prob)
+                with open("heatmap.png", "wb") as f:
+                    f.write(png_bytes)
+                logging.info("Heatmap saved to heatmap.png")
+            else:
+                logging.info("Full probability maps computed (no image)")
         logging.info("Prediction results:")
         for pred in result["predictions"]:
             logging.info(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,3 +30,12 @@ def test_predict_too_small(client):
     resp = client.post("/predict", json={"grid": [[-1]]})
     assert resp.status_code == 500
     assert "at least 2x2" in resp.json()["detail"].lower()
+
+
+def test_heatmap_endpoint(client):
+    grid = [[1, -1], [2, -1]]
+    resp = client.post("/heatmap", json={"grid": grid, "k": 3, "iterations": 8})
+    body = resp.json()
+    assert resp.status_code == 200
+    assert "heatmap" in body
+    assert body["heatmap"].startswith("iVBOR")

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -1,0 +1,20 @@
+import base64
+
+import numpy as np
+
+from analyzer import monte_carlo_prob_map, prob_map_to_png
+
+
+def test_monte_carlo_prob_map_basic():
+    grid = np.array([[1, -1], [2, -1]])
+    prob = monte_carlo_prob_map(grid, 3, n_iter=32, seed=42)
+    assert prob.shape == grid.shape
+    assert 0.0 <= prob[0, 1] <= 1.0
+
+
+def test_prob_map_to_png_roundtrip():
+    mat = np.array([[0.0, 1.0], [0.5, 0.2]])
+    data = prob_map_to_png(mat)
+    assert data.startswith(b"\x89PNG")
+    b64 = base64.b64encode(data).decode("ascii")
+    assert isinstance(b64, str)


### PR DESCRIPTION
## Summary
- add Monte-Carlo probability map generation and PNG renderer
- expose `/heatmap` FastAPI endpoint
- CLI option for heatmap export
- basic tests for new functions and endpoint

## Testing
- `isort . --check-only`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2d2897908324b6b8aab998e86691