### PR TITLE
Add flexible heatmap API utilities

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1,3 +1,4 @@
+import base64
 import heapq
 import logging
 import math
@@ -800,3 +801,59 @@ def prob_map_to_png(prob_map: np.ndarray) -> bytes:
     png += chunk(b"IDAT", zlib.compress(raw))
     png += chunk(b"IEND", b"")
     return png
+
+
+def heatmap_to_base64(prob_map: np.ndarray) -> str:
+    """Convert probability map to a base64-encoded PNG."""
+    png_bytes = prob_map_to_png(prob_map)
+    return base64.b64encode(png_bytes).decode("ascii")
+
+
+def render_heatmap(prob_map: np.ndarray, output_format: str = "base64") -> Any:
+    """Return heatmap in the desired format.
+
+    Parameters
+    ----------
+    prob_map : np.ndarray
+        Probability matrix to render.
+    output_format : str
+        One of ``"raw"``, ``"base64"``, or ``"png_bytes"``.
+    """
+
+    fmt = output_format.lower()
+    if fmt == "raw":
+        return prob_map
+    if fmt == "base64":
+        return heatmap_to_base64(prob_map)
+    if fmt == "png_bytes":
+        return prob_map_to_png(prob_map)
+    raise ValueError(f"Unsupported output_format: {output_format}")
+
+
+def probability_heatmap(
+    grid: Union[List[List[int]], np.ndarray],
+    k: Optional[int],
+    n_iter: int = 6000,
+    *,
+    seed: int = 0,
+) -> Union[np.ndarray, Dict[int, np.ndarray]]:
+    """Heatmap simulation using :func:`simulate_full_board`."""
+
+    rng = np.random.default_rng(seed)
+    grid_np = np.asarray(grid, dtype=int)
+    prob_map_dict = simulate_full_board(grid_np, k, n_iter=n_iter, rng=rng)
+
+    if k is not None:
+        out = np.zeros_like(grid_np, dtype=float)
+        for (r, c), cell in prob_map_dict.items():
+            out[r, c] = cell.get(k, 0.0)
+        return out
+
+    numbers = {n for cell in prob_map_dict.values() for n in cell}
+    result: Dict[int, np.ndarray] = {
+        int(n): np.zeros_like(grid_np, dtype=float) for n in numbers
+    }
+    for (r, c), cell in prob_map_dict.items():
+        for n, p in cell.items():
+            result[int(n)][r, c] = p
+    return result

--- a/app.py
+++ b/app.py
@@ -16,9 +16,9 @@ from pydantic import BaseModel
 # fmt: off
 # isort: off
 from analyzer import (
-    monte_carlo_prob_map,
+    probability_heatmap,
     predict_scratch_card,
-    prob_map_to_png,
+    render_heatmap,
 )
 # isort: on
 # fmt: on
@@ -84,6 +84,7 @@ class HeatmapRequest(BaseModel):
     k: Optional[int] = None
     iterations: int = 1000
     seed: int = 0
+    output_format: str = "base64"
 
 
 class HeatmapResponse(BaseModel):
@@ -207,13 +208,19 @@ async def predict(req: GridRequest):
 )
 async def heatmap(req: HeatmapRequest):
     try:
-        prob = monte_carlo_prob_map(req.grid, req.k, req.iterations, seed=req.seed)
+        prob = probability_heatmap(req.grid, req.k, req.iterations, seed=req.seed)
         if isinstance(prob, dict):
             prob_map = {str(int(k)): v.tolist() for k, v in prob.items()}
             return {"prob_map": prob_map, "heatmap": None}
 
-        png_bytes = prob_map_to_png(prob)
-        b64 = base64.b64encode(png_bytes).decode("ascii")
+        if req.output_format.lower() == "raw":
+            return {"prob_map": prob.tolist(), "heatmap": None}
+
+        rendered = render_heatmap(prob, req.output_format)
+        if isinstance(rendered, bytes):
+            b64 = base64.b64encode(rendered).decode("ascii")
+        else:
+            b64 = rendered
         return {"prob_map": prob.tolist(), "heatmap": b64}
     except Exception as exc:
         logger.error("Heatmap generation failed: %s", exc, exc_info=True)

--- a/main.py
+++ b/main.py
@@ -10,9 +10,9 @@ import ray
 # fmt: off
 # isort: off
 from analyzer import (
-    monte_carlo_prob_map,
+    probability_heatmap,
     predict_scratch_card,
-    prob_map_to_png,
+    render_heatmap,
 )
 # isort: on
 # fmt: on
@@ -71,6 +71,13 @@ def parse_args() -> argparse.Namespace:
         default=1000,
         help="Iterations for heatmap simulation",
     )
+    parser.add_argument(
+        "--heatmap-format",
+        type=str,
+        choices=["raw", "base64", "png_bytes"],
+        default="png_bytes",
+        help="Format for heatmap output",
+    )
     return parser.parse_args()
 
 
@@ -122,18 +129,23 @@ def main():
         ray.shutdown()
 
         if args.heatmap_k is not None:
-            prob = monte_carlo_prob_map(
+            prob = probability_heatmap(
                 grid_np,
                 args.heatmap_k if args.heatmap_k != -1 else None,
                 args.heatmap_iter,
             )
-            if not isinstance(prob, dict):
-                png_bytes = prob_map_to_png(prob)
-                with open("heatmap.png", "wb") as f:
-                    f.write(png_bytes)
-                logging.info("Heatmap saved to heatmap.png")
-            else:
+            if isinstance(prob, dict):
                 logging.info("Full probability maps computed (no image)")
+            else:
+                rendered = render_heatmap(prob, args.heatmap_format)
+                if isinstance(rendered, bytes):
+                    with open("heatmap.png", "wb") as f:
+                        f.write(rendered)
+                    logging.info("Heatmap saved to heatmap.png")
+                elif isinstance(rendered, str):
+                    with open("heatmap.txt", "w") as f:
+                        f.write(rendered)
+                    logging.info("Heatmap base64 saved to heatmap.txt")
         logging.info("Prediction results:")
         for pred in result["predictions"]:
             logging.info(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,3 +39,15 @@ def test_heatmap_endpoint(client):
     assert resp.status_code == 200
     assert "heatmap" in body
     assert body["heatmap"].startswith("iVBOR")
+
+
+def test_heatmap_endpoint_raw(client):
+    grid = [[1, -1], [2, -1]]
+    resp = client.post(
+        "/heatmap",
+        json={"grid": grid, "k": 3, "iterations": 8, "output_format": "raw"},
+    )
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["heatmap"] is None
+    assert isinstance(body["prob_map"], list)

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -2,7 +2,13 @@ import base64
 
 import numpy as np
 
-from analyzer import monte_carlo_prob_map, prob_map_to_png
+from analyzer import (
+    heatmap_to_base64,
+    monte_carlo_prob_map,
+    prob_map_to_png,
+    probability_heatmap,
+    render_heatmap,
+)
 
 
 def test_monte_carlo_prob_map_basic():
@@ -18,3 +24,27 @@ def test_prob_map_to_png_roundtrip():
     assert data.startswith(b"\x89PNG")
     b64 = base64.b64encode(data).decode("ascii")
     assert isinstance(b64, str)
+
+
+def test_heatmap_to_base64():
+    mat = np.array([[0.1, 0.2], [0.3, 0.4]])
+    b64 = heatmap_to_base64(mat)
+    assert isinstance(b64, str)
+    assert b64.startswith("iVBOR")
+
+
+def test_probability_heatmap_base64():
+    grid = np.array([[1, -1], [2, -1]])
+    prob = probability_heatmap(grid, 3, n_iter=16, seed=1)
+    assert prob.shape == grid.shape
+    img = render_heatmap(prob, "base64")
+    assert isinstance(img, str)
+    assert img.startswith("iVBOR")
+
+
+def test_probability_heatmap_raw():
+    grid = np.array([[1, -1], [2, -1]])
+    prob = probability_heatmap(grid, 3, n_iter=16, seed=1)
+    arr = render_heatmap(prob, "raw")
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == grid.shape


### PR DESCRIPTION
## Summary
- add `heatmap_to_base64`, `render_heatmap`, and `probability_heatmap`
- expose output format in `/heatmap` endpoint
- support heatmap format selection in CLI
- test new heatmap utilities and API options

## Testing
- `isort --check analyzer.py app.py main.py tests/test_heatmap.py tests/test_api.py`
- `black --check analyzer.py app.py main.py tests/test_heatmap.py tests/test_api.py`
- `flake8 analyzer.py app.py main.py tests/test_heatmap.py tests/test_api.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c86a6ae0c83248cbe2ebd61a49400