### PR TITLE
Add configurable prediction top-k

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -518,6 +518,7 @@ def predict_scratch_card(
     focus_iter: Optional[int] = None,
     top_n: int = 10,
     epsilon: float = 0.05,
+    result_top_k: Optional[int] = None,
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
     rows, cols = grid_np.shape
@@ -540,6 +541,17 @@ def predict_scratch_card(
 
     phase1 = global_iter if global_iter is not None else iterations or 5000
     phase2 = focus_iter if focus_iter is not None else 1000
+    top_k = (
+        result_top_k
+        if result_top_k is not None
+        else int(os.getenv("RESULT_TOP_K", "3"))
+    )
+
+    def _trim(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if top_k <= 0 or top_k >= len(items):
+            return items
+        return items[:top_k]
+
     logger.info(
         "Two-phase simulation | phase1=%d, phase2=%d, top_n=%d, epsilon=%.2f",
         phase1,
@@ -584,7 +596,7 @@ def predict_scratch_card(
         rank.sort(key=lambda x: x["probability"], reverse=True)
 
         module_scores = {mod: get_module_score(mod, grid_np) for mod, _ in modules}
-        for pred in rank[:3]:
+        for pred in _trim(rank):
             reasons = []
             scores = [
                 (mod, module_scores[mod][pred["row"], pred["col"]], desc)
@@ -605,7 +617,7 @@ def predict_scratch_card(
         return {
             "mode": "target",
             "target": target_num,
-            "predictions": rank[:3],
+            "predictions": _trim(rank),
             "full_probabilities": prob_map,
         }
 
@@ -653,7 +665,7 @@ def predict_scratch_card(
             mode = "mcts_unique"
 
         module_scores = {mod: get_module_score(mod, grid_np) for mod, _ in modules}
-        for pred in preds[:3]:
+        for pred in _trim(preds):
             reasons = []
             scores = [
                 (mod, module_scores[mod][pred["row"], pred["col"]], desc)
@@ -672,7 +684,11 @@ def predict_scratch_card(
             }
 
         preds.sort(key=lambda x: x["probability"], reverse=True)
-        return {"mode": mode, "predictions": preds[:3], "full_probabilities": prob_map}
+        return {
+            "mode": mode,
+            "predictions": _trim(preds),
+            "full_probabilities": prob_map,
+        }
 
     preds = []
     for (r, c), dist in prob_map.items():
@@ -688,7 +704,7 @@ def predict_scratch_card(
         )
 
     module_scores = {mod: get_module_score(mod, grid_np) for mod, _ in modules}
-    for pred in preds[:3]:
+    for pred in _trim(preds):
         reasons = []
         scores = [
             (mod, module_scores[mod][pred["row"], pred["col"]], desc)
@@ -705,9 +721,14 @@ def predict_scratch_card(
         }
 
     preds.sort(
-        key=lambda x: x["probability"][0] if x["probability"] else 0, reverse=True
+        key=lambda x: x["probability"][0] if x["probability"] else 0,
+        reverse=True,
     )
-    return {"mode": "top3", "predictions": preds[:3], "full_probabilities": prob_map}
+    return {
+        "mode": "top3",
+        "predictions": _trim(preds),
+        "full_probabilities": prob_map,
+    }
 
 
 def process_grid(grid):

--- a/app.py
+++ b/app.py
@@ -62,6 +62,7 @@ class GridRequest(BaseModel):
     focus_iter: Optional[int] = None
     top_n: Optional[int] = None
     epsilon: Optional[float] = None
+    result_top_k: Optional[int] = None
 
 
 class Prediction(BaseModel):
@@ -100,13 +101,15 @@ os.environ.setdefault("PHASE1_ITERATIONS", "5000")
 os.environ.setdefault("PHASE2_ITERATIONS", "1000")
 os.environ.setdefault("PHASE2_TOP_N", "10")
 os.environ.setdefault("PHASE2_EPSILON", "0.05")
+os.environ.setdefault("RESULT_TOP_K", "3")
 os.environ.setdefault("LOG_LEVEL", "INFO")
 
 # 解析 ENV 到 Python 常量
-PHASE1_ITER  = int(os.getenv("PHASE1_ITERATIONS"))
-PHASE2_ITER  = int(os.getenv("PHASE2_ITERATIONS"))
+PHASE1_ITER = int(os.getenv("PHASE1_ITERATIONS"))
+PHASE2_ITER = int(os.getenv("PHASE2_ITERATIONS"))
 PHASE2_TOP_N = int(os.getenv("PHASE2_TOP_N"))
-PHASE2_EPS   = float(os.getenv("PHASE2_EPSILON"))
+PHASE2_EPS = float(os.getenv("PHASE2_EPSILON"))
+RESULT_TOP_K = int(os.getenv("RESULT_TOP_K"))
 
 
 # ==== Routes ==============================================================
@@ -151,8 +154,9 @@ async def predict(req: GridRequest):
         # — 日志记录实际使用的两阶段参数 —
         phase1 = req.iterations or PHASE1_ITER
         phase2 = req.focus_iter or PHASE2_ITER
-        top_n  = req.top_n      or PHASE2_TOP_N
-        eps    = req.epsilon    or PHASE2_EPS
+        top_n = req.top_n or PHASE2_TOP_N
+        eps = req.epsilon or PHASE2_EPS
+        ret_k = req.result_top_k or RESULT_TOP_K
 
         logger.info(
             "Predict API called | size=%dx%d | target=%s | phase1=%d | phase2=%d | top_n=%d | eps=%.3f",
@@ -174,6 +178,7 @@ async def predict(req: GridRequest):
             focus_iter=phase2,
             top_n=top_n,
             epsilon=eps,
+            result_top_k=ret_k,
         )
 
         # — 整理 full_probabilities 为 JSON-safe 格式 —
@@ -188,7 +193,11 @@ async def predict(req: GridRequest):
                 key_str = str(loc_key)
             inner: Dict[str, float] = {}
             for num, prob in prob_map.items():
-                num_key = str(int(float(num))) if isinstance(num, (int, float, str)) else str(num)
+                num_key = (
+                    str(int(float(num)))
+                    if isinstance(num, (int, float, str))
+                    else str(num)
+                )
                 inner[num_key] = float(prob) * 100
             clean_probs[key_str] = inner
 
@@ -196,7 +205,9 @@ async def predict(req: GridRequest):
             "predictions": predictions,
             "full_probabilities": clean_probs,
         }
-        clean_json = json.loads(json.dumps(response_payload, default=lambda x: float(x)))
+        clean_json = json.loads(
+            json.dumps(response_payload, default=lambda x: float(x))
+        )
         logger.info("✅ Final response payload: %s", clean_json)
         return JSONResponse(content=clean_json, status_code=200)
 

--- a/main.py
+++ b/main.py
@@ -78,6 +78,12 @@ def parse_args() -> argparse.Namespace:
         default="png_bytes",
         help="Format for heatmap output",
     )
+    parser.add_argument(
+        "--result-top-k",
+        type=int,
+        default=None,
+        help="Number of predictions to display (env RESULT_TOP_K if omitted)",
+    )
     return parser.parse_args()
 
 
@@ -125,6 +131,7 @@ def main():
             focus_iter=args.focus_iter,
             top_n=args.top_n,
             epsilon=args.epsilon,
+            result_top_k=args.result_top_k,
         )
         ray.shutdown()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,3 +51,14 @@ def test_heatmap_endpoint_raw(client):
     assert resp.status_code == 200
     assert body["heatmap"] is None
     assert isinstance(body["prob_map"], list)
+
+
+def test_result_top_k(client):
+    grid = [[-1, -1], [-1, -1]]
+    resp = client.post(
+        "/predict",
+        json={"grid": grid, "result_top_k": 2},
+    )
+    body = resp.json()
+    assert resp.status_code == 200
+    assert len(body["predictions"]) == 2


### PR DESCRIPTION
## Summary
- allow setting `RESULT_TOP_K` env or `result_top_k` request field
- slice predictions using helper `_trim`
- expose parameter in CLI
- test API result_top_k behavior

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685d1aae42748324b1c8130140f4f426