### PR TITLE
Expand mirror sequence penalty

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -768,42 +768,22 @@ def EXT_F7_Strong_Pattern_Vec(
 def EXT_M11_Mirror_Sequence_Vec(
     grid: np.ndarray, request_id: Optional[str] = "N/A"
 ) -> np.ndarray:
-    """Penalize sequential pairs on symmetric boards."""
+    """Penalty for sequential pairs across mirror-symmetric points."""
     rows, cols = grid.shape
-    max_val = rows * cols
-    penalty = np.zeros((rows, cols), dtype=float)
+    scores = np.zeros((rows, cols), dtype=float)
 
-    # Horizontal symmetry
     for r in range(rows):
-        row = grid[r].astype(float)
-        rev = row[::-1]
-        diff_mean = np.mean(np.abs(row - rev))
-        sym_score = 1.0 - diff_mean / (max_val + 1e-9)
-        diffs = np.abs(np.diff(row))
-        pair = np.zeros(cols)
-        mask = diffs == 1
-        pair[:-1] += mask
-        pair[1:] += mask
-        penalty[r] += sym_score * pair
+        for c in range(cols):
+            r2, c2 = rows - 1 - r, cols - 1 - c
+            if r > r2 or (r == r2 and c >= c2):
+                continue
+            if abs(int(grid[r, c]) - int(grid[r2, c2])) == 1:
+                scores[r, c] += 1.0
+                scores[r2, c2] += 1.0
 
-    # Vertical symmetry
-    for c in range(cols):
-        col = grid[:, c].astype(float)
-        rev = col[::-1]
-        diff_mean = np.mean(np.abs(col - rev))
-        sym_score = 1.0 - diff_mean / (max_val + 1e-9)
-        diffs = np.abs(np.diff(col))
-        pair = np.zeros(rows)
-        mask = diffs == 1
-        pair[:-1] += mask
-        pair[1:] += mask
-        penalty[:, c] += sym_score * pair
-
-    if penalty.max(initial=0.0) > 0:
-        penalty /= penalty.max()
-    score = 1.0 - penalty
-    score = np.where(grid == -1, score, 0.0)
-    return score.astype(np.float32)
+    if scores.max(initial=0.0) > 0:
+        scores /= scores.max()
+    return scores.astype(np.float32)
 
 
 @batchable
@@ -1010,7 +990,7 @@ AGG_WEIGHTS = {
     "EXT_Q11_GlobalDigitAffinity_Vec": 0.03,
     "EXT_Q12_ArithmeticProgression_Vec": 0.04,
     "EXT_Q13_GlobalConsistencySpectrum_Vec": 0.04,
-    "EXT_M11_Mirror_Sequence_Vec": 0.03,
+    "EXT_M11_Mirror_Sequence_Vec": -0.03,
 }
 
 

--- a/tests/test_m11_mirror.py
+++ b/tests/test_m11_mirror.py
@@ -9,10 +9,22 @@ def test_m11_module_shape_and_range():
     s = brain.EXT_M11_Mirror_Sequence_Vec(grid)
     assert s.shape == grid.shape
     assert np.all(np.isfinite(s))
-    assert np.all(s[grid != -1] == 0)
+
+
+def test_m11_detects_sequential_pairs():
+    grid = np.array([[1, 8], [7, 2]])
+    s = brain.EXT_M11_Mirror_Sequence_Vec(grid)
+    assert s[0, 0] > 0
+    assert s[1, 1] > 0
+    assert s[0, 1] > 0
+    assert s[1, 0] > 0
 
 
 def test_select_modules_includes_m11():
     grid = np.array([[1, -1], [2, 3]])
     mods = analyzer.select_modules(grid, target=None)
     assert "EXT_M11_Mirror_Sequence_Vec" in mods
+
+
+def test_m11_weight_negative():
+    assert brain.AGG_WEIGHTS["EXT_M11_Mirror_Sequence_Vec"] < 0


### PR DESCRIPTION
## Summary
- update `EXT_M11_Mirror_Sequence_Vec` to scan all mirrored pairs and normalize scores
- assign negative weight for the mirror-sequence penalty module
- extend tests for sequential mirror detection and weight sign

## Testing
- `black . --check`
- `isort . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0be22a188324aad1bf8309ff4aa0