### PR TITLE
Add Q16 module and integrate modules

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -99,6 +99,8 @@ def select_modules(grid: np.ndarray, target: Optional[int] = None) -> List[str]:
         mods.append("EXT_M12_RestoreOriginalValue_Vec")
     if "EXT_Q15_GlobalSpread_Vec" not in mods:
         mods.append("EXT_Q15_GlobalSpread_Vec")
+    if "EXT_Q16_NumericalRelationalPattern_Vec" not in mods:
+        mods.append("EXT_Q16_NumericalRelationalPattern_Vec")
     if (
         os.getenv("ENABLE_SPECTRUM", "0") == "1"
         and "EXT_Q13_GlobalConsistencySpectrum_Vec" not in mods
@@ -573,13 +575,20 @@ def predict_scratch_card(
 
     modules = [
         ("EXT_Q1_ProximityEntropy_Vec", "Proximity and entropy scoring"),
-        ("EXT_Q2_PotentialPath_Vec", "Sequence and path scoring"),
         ("EXT_Q3_DiscontinuitySym_Vec", "Discontinuity and symmetry scoring"),
-        ("EXT_Q4_ControlComposite_Vec", "Control and error correction"),
         ("EXT_Q5_GlobalEntropy_Vec", "Global entropy and clustering"),
-        ("EXT_Q6_LineBridge_Vec", "Linearity and bridge connectivity"),
-        ("EXT_Q7_VariancePrior_Vec", "Variance smoothing and prior"),
+        ("EXT_Q14_TargetAffinity_Vec", "Target number affinity"),
+        ("EXT_Q15_GlobalSpread_Vec", "Global spread preference"),
+        ("EXT_Q16_NumericalRelationalPattern_Vec", "Numerical relational patterns"),
     ]
+
+    mod_names = [m for m, _ in modules]
+    weights = np.array([0.2, 0.15, 0.25, 0.2, 0.1, 0.2], dtype=float)
+    score_stack = np.stack(
+        [get_module_score(m, grid_np, target=target_num) for m in mod_names],
+        axis=0,
+    )
+    final_score_map = (weights[:, None, None] * score_stack).sum(axis=0)
 
     phase1 = global_iter if global_iter is not None else iterations or 5000
     phase2 = focus_iter if focus_iter is not None else 1000
@@ -606,9 +615,9 @@ def predict_scratch_card(
         rng=np.random.default_rng(),
     )
 
-    # select top-n cells for refinement
+    # select top-n cells for refinement using weighted module scores
     ranked = sorted(
-        ((r, c, max(d.values())) for (r, c), d in prob_map.items()),
+        [(r, c, final_score_map[r, c]) for r, c in blanks],
         key=lambda x: x[2],
         reverse=True,
     )

--- a/brain.py
+++ b/brain.py
@@ -1083,6 +1083,83 @@ def EXT_Q15_GlobalSpread_Vec(
     return score.astype(np.float32)
 
 
+@batchable
+def EXT_Q16_NumericalRelationalPattern_Vec(
+    grid: np.ndarray, request_id: Optional[str] = "N/A"
+) -> np.ndarray:
+    """Score cells via combined numerical relational patterns."""
+    rows, cols = grid.shape
+    blanks = np.argwhere(grid == -1)
+    if blanks.size == 0:
+        return np.zeros((rows, cols), dtype=float)
+
+    score = np.zeros((rows, cols), dtype=float)
+    for r, c in blanks:
+        mirror = 0.0
+        checks = 0
+        if 0 <= rows - 1 - r < rows:
+            if grid[rows - 1 - r, c] != -1:
+                mirror += 1.0
+            checks += 1
+        if 0 <= cols - 1 - c < cols:
+            if grid[r, cols - 1 - c] != -1:
+                mirror += 1.0
+            checks += 1
+        if 0 <= rows - 1 - r < rows and 0 <= cols - 1 - c < cols:
+            if grid[rows - 1 - r, cols - 1 - c] != -1:
+                mirror += 1.0
+            checks += 1
+        if rows == cols and 0 <= c < rows and 0 <= r < cols:
+            if grid[c, r] != -1:
+                mirror += 1.0
+            checks += 1
+        mirror_score = mirror / float(checks or 1)
+
+        seq_score = 0.0
+        seq_checks = 0
+        for dr, dc in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            nr, nc = r + dr, c + dc
+            nnr, nnc = nr + dr, nc + dc
+            if 0 <= nr < rows and 0 <= nc < cols and grid[nr, nc] != -1:
+                seq_checks += 1
+                if 0 <= nnr < rows and 0 <= nnc < cols and grid[nnr, nnc] != -1:
+                    if abs(int(grid[nnr, nnc]) - int(grid[nr, nc])) == 1:
+                        seq_score += 1.0
+        seq_score /= float(seq_checks or 1)
+
+        jump_score = 0.0
+        jump_checks = 0
+        for dr, dc in [(2, 0), (-2, 0), (0, 2), (0, -2)]:
+            nr, nc = r + dr, c + dc
+            if 0 <= nr < rows and 0 <= nc < cols and grid[nr, nc] != -1:
+                jump_score += 1.0
+            jump_checks += 1
+        jump_score /= float(jump_checks or 1)
+
+        neighbors = [
+            int(grid[nr, nc])
+            for dr in range(-1, 2)
+            for dc in range(-1, 2)
+            if not (dr == 0 and dc == 0)
+            for nr, nc in [(r + dr, c + dc)]
+            if 0 <= nr < rows and 0 <= nc < cols and grid[nr, nc] != -1
+        ]
+        tail_score = 0.0
+        unique_score = 0.0
+        if neighbors:
+            tails = [v % 10 for v in neighbors]
+            tail_score = len(set(tails)) / float(len(tails))
+            unique_score = len(set(neighbors)) / float(len(neighbors))
+
+        features = [mirror_score, seq_score, jump_score, tail_score, unique_score]
+        score[r, c] = sum(features) / len(features)
+
+    mx = score.max(initial=0.0)
+    if mx > 0:
+        score /= mx
+    return score.astype(np.float32)
+
+
 # ----------------------------------------------------------------------
 # Registration
 # ----------------------------------------------------------------------
@@ -1099,6 +1176,7 @@ mods = {
     "EXT_M12_RestoreOriginalValue_Vec": EXT_M12_RestoreOriginalValue_Vec,
     "EXT_Q14_TargetAffinity_Vec": EXT_Q14_TargetAffinity_Vec,
     "EXT_Q15_GlobalSpread_Vec": EXT_Q15_GlobalSpread_Vec,
+    "EXT_Q16_NumericalRelationalPattern_Vec": EXT_Q16_NumericalRelationalPattern_Vec,
     "EXT_M1_Tail_Pattern_Vec": EXT_M1_Tail_Pattern_Vec,
     "EXT_M3_Local_Focus_Vec": EXT_M3_Local_Focus_Vec,
     "EXT_M10_Sequence_Block_Vec": EXT_M10_Sequence_Block_Vec,
@@ -1160,6 +1238,7 @@ AGG_WEIGHTS = {
     "EXT_M12_RestoreOriginalValue_Vec": 0.05,
     "EXT_Q14_TargetAffinity_Vec": 0.05,
     "EXT_Q15_GlobalSpread_Vec": 0.04,
+    "EXT_Q16_NumericalRelationalPattern_Vec": 0.05,
     "EXT_M11_Mirror_Sequence_Vec": -0.03,
 }
 

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -9,6 +9,7 @@ def test_new_modules_registered():
         "EXT_M12_RestoreOriginalValue_Vec",
         "EXT_Q14_TargetAffinity_Vec",
         "EXT_Q15_GlobalSpread_Vec",
+        "EXT_Q16_NumericalRelationalPattern_Vec",
     ]:
         assert name in brain.REGISTERED_MODULES_BRAIN
         assert name in brain.AGG_WEIGHTS
@@ -21,7 +22,8 @@ def test_new_module_shapes(make_grid):
     s1 = brain.EXT_M12_RestoreOriginalValue_Vec(grid, original_grid=original)
     s2 = brain.EXT_Q14_TargetAffinity_Vec(grid, target=3)
     s3 = brain.EXT_Q15_GlobalSpread_Vec(grid)
-    for s in (s1, s2, s3):
+    s4 = brain.EXT_Q16_NumericalRelationalPattern_Vec(grid)
+    for s in (s1, s2, s3, s4):
         assert s.shape == grid.shape
         assert np.isfinite(s).all()
 
@@ -33,5 +35,6 @@ def test_select_modules_include_new(make_grid):
         "EXT_M12_RestoreOriginalValue_Vec",
         "EXT_Q14_TargetAffinity_Vec",
         "EXT_Q15_GlobalSpread_Vec",
+        "EXT_Q16_NumericalRelationalPattern_Vec",
     ]:
         assert name in mods


### PR DESCRIPTION
## Summary
- implement `EXT_Q16_NumericalRelationalPattern_Vec`
- register new module and weight
- integrate updated module set in `predict_scratch_card`
- ensure `select_modules` includes Q16
- extend tests for the new module

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eed0124f48324bda6ffefcf7176d7