### PR TITLE
Implement sample-based prior module

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -15,19 +15,10 @@ import xxhash
 from joblib import Parallel, delayed
 
 import brain
-
 # fmt: off
-from brain import (
-    AGG_WEIGHTS,
-    REGISTERED_MODULES_BRAIN,
-    BoardAnalyzerUtils,
-    EXT_GM20_Skip_Pattern_Confidence_Vec,
-    MathUtils,
-    aggregate_scores,
-    bytes_to_grid,
-    get_module_score,
-)
-
+from brain import (AGG_WEIGHTS, REGISTERED_MODULES_BRAIN, BoardAnalyzerUtils,
+                   EXT_GM20_Skip_Pattern_Confidence_Vec, MathUtils,
+                   aggregate_scores, bytes_to_grid, get_module_score)
 # fmt: on
 from modules import FORMULA_REGISTRY
 
@@ -113,6 +104,35 @@ def compute_history_frequency(
         total,
     )
     return freq
+
+
+def compute_position_probabilities(
+    samples_dir: str, rows: int, cols: int
+) -> Dict[Tuple[int, int], Dict[int, float]]:
+    """Return per-cell number probabilities from all samples."""
+    counts: Dict[Tuple[int, int], Dict[int, int]] = {
+        (r, c): defaultdict(int) for r in range(rows) for c in range(cols)
+    }
+    total = 0
+    for sample in iter_sample_jsons(samples_dir):
+        if sample["rows"] != rows or sample["cols"] != cols:
+            continue
+        total += 1
+        grid = sample["grid"]
+        for r in range(rows):
+            for c in range(cols):
+                val = int(grid[r][c])
+                counts[(r, c)][val] += 1
+
+    probs: Dict[Tuple[int, int], Dict[int, float]] = {}
+    for key, d in counts.items():
+        s = sum(d.values()) or 1
+        probs[key] = {int(k): v / s for k, v in d.items()}
+
+    logger.info(
+        "Position frequencies for %d×%d processed %d samples", rows, cols, total
+    )
+    return probs
 
 
 # Count-Min Sketch (optimized for low memory)
@@ -641,6 +661,7 @@ def predict_scratch_card(
     priors: Optional[Dict[int, float]] = None,
     history_dir: str = "samples",
     gamma_history: float = 0.0,
+    sample_gamma: float = 0.0,
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
     rows, cols = grid_np.shape
@@ -677,6 +698,19 @@ def predict_scratch_card(
                 final_score_map += gamma_history * (hist / float(hist.max()))
         except Exception as exc:  # pragma: no cover - history load failures
             logger.error("history frequency failed: %s", exc)
+
+    if sample_gamma > 0.0:
+        try:
+            pos_probs = compute_position_probabilities(history_dir, rows, cols)
+            sample_map = np.zeros((rows, cols), dtype=float)
+            for (r, c), dist in pos_probs.items():
+                if dist:
+                    sample_map[r, c] = max(dist.values())
+            if sample_map.max() > 0:
+                sample_map /= float(sample_map.max())
+                final_score_map += sample_gamma * sample_map
+        except Exception as exc:  # pragma: no cover - history load failures
+            logger.error("position frequency failed: %s", exc)
 
     phase1 = global_iter if global_iter is not None else iterations or 5000
     phase2 = focus_iter if focus_iter is not None else 1000
@@ -721,6 +755,19 @@ def predict_scratch_card(
             epsilon=epsilon,
         )
         prob_map.update(refine_map)
+
+    if sample_gamma > 0.0:
+        try:
+            pos_probs = compute_position_probabilities(history_dir, rows, cols)
+            for key, dist in prob_map.items():
+                prior = pos_probs.get(key, {})
+                for num in list(dist.keys()):
+                    dist[num] *= 1.0 + sample_gamma * prior.get(num, 0.0)
+                tot = sum(dist.values()) or 1e-10
+                for num in dist:
+                    dist[num] /= tot
+        except Exception as exc:  # pragma: no cover - history load failures
+            logger.error("position frequency blend failed: %s", exc)
 
     module_scores = {
         mod: get_module_score(mod, grid_np, priors=priors, target=target_num)

--- a/app.py
+++ b/app.py
@@ -76,6 +76,7 @@ class GridRequest(BaseModel):
     top_n: Optional[int] = None
     epsilon: Optional[float] = None
     result_top_k: Optional[int] = None
+    sample_gamma: Optional[float] = None
 
 
 class Prediction(BaseModel):
@@ -215,6 +216,7 @@ async def predict(req: GridRequest):
             epsilon=eps,
             result_top_k=top_k,
             priors=priors,
+            sample_gamma=req.sample_gamma or 0.0,
         )
 
         # 清洗 full_probabilities

--- a/main.py
+++ b/main.py
@@ -83,6 +83,12 @@ def parse_args() -> argparse.Namespace:
         default="png_bytes",
         help="Format for heatmap output",
     )
+    parser.add_argument(
+        "--sample-gamma",
+        type=float,
+        default=0.0,
+        help="Weight for sample-based frequency prior",
+    )
     return parser.parse_args()
 
 
@@ -139,6 +145,7 @@ def main():
             epsilon=args.epsilon,
             result_top_k=None,
             priors=priors,
+            sample_gamma=args.sample_gamma,
         )
         ray.shutdown()
 

--- a/tests/test_sample_prior.py
+++ b/tests/test_sample_prior.py
@@ -1,0 +1,42 @@
+import json
+import zipfile
+
+import analyzer
+
+
+def test_compute_position_probabilities(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data1 = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    data2 = {"rows": 2, "cols": 2, "grid": [[2, 1], [4, 3]]}
+    zpath = samples / "s.zip"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        zf.writestr("a.json", json.dumps(data1))
+        zf.writestr("b.json", json.dumps(data2))
+
+    probs = analyzer.compute_position_probabilities(str(samples), 2, 2)
+    assert (0, 0) in probs
+    cell = probs[(0, 0)]
+    assert abs(sum(cell.values()) - 1.0) < 1e-6
+    assert cell.get(1, 0) == cell.get(2, 0)
+
+
+def test_predict_with_sample_prior(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    zpath = samples / "s.zip"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        zf.writestr("c.json", json.dumps(data))
+
+    grid = [[-1, 2], [3, 4]]
+    res = analyzer.predict_scratch_card(
+        grid,
+        target_num=1,
+        iterations=4,
+        global_iter=2,
+        focus_iter=2,
+        history_dir=str(samples),
+        sample_gamma=1.0,
+    )
+    assert "predictions" in res


### PR DESCRIPTION
## Summary
- use JSON samples to compute per-cell probabilities
- blend sample prior into prediction flow via `sample_gamma`
- expose `sample_gamma` in API/CLI
- test sample prior logic

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f835efb0083249f051e8a2a30e64e