### PR TITLE
Improve prior integration

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -106,33 +106,40 @@ def compute_history_frequency(
     return freq
 
 
+@lru_cache(maxsize=8)
 def compute_position_probabilities(
     samples_dir: str, rows: int, cols: int
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
     """Return per-cell number probabilities from all samples."""
-    counts: Dict[Tuple[int, int], Dict[int, int]] = {
-        (r, c): defaultdict(int) for r in range(rows) for c in range(cols)
-    }
+    counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
     total = 0
     for sample in iter_sample_jsons(samples_dir):
         if sample["rows"] != rows or sample["cols"] != cols:
             continue
         total += 1
-        grid = sample["grid"]
-        for r in range(rows):
-            for c in range(cols):
-                val = int(grid[r][c])
-                counts[(r, c)][val] += 1
+        grid = np.asarray(sample["grid"], dtype=int)
+        mask = (grid >= 1) & (grid <= rows * cols)
+        rr, cc = np.indices(grid.shape)
+        np.add.at(counts, (rr[mask], cc[mask], grid[mask]), 1)
 
-    probs: Dict[Tuple[int, int], Dict[int, float]] = {}
-    for key, d in counts.items():
-        s = sum(d.values()) or 1
-        probs[key] = {int(k): v / s for k, v in d.items()}
+    prob_map: Dict[Tuple[int, int], Dict[int, float]] = {}
+    for r in range(rows):
+        for c in range(cols):
+            dist = counts[r, c]
+            total_cell = dist.sum()
+            if total_cell:
+                prob_map[(r, c)] = {
+                    n: dist[n] / float(total_cell)
+                    for n in range(1, rows * cols + 1)
+                    if dist[n] > 0
+                }
+            else:
+                prob_map[(r, c)] = {}
 
     logger.info(
         "Position frequencies for %d×%d processed %d samples", rows, cols, total
     )
-    return probs
+    return prob_map
 
 
 # Count-Min Sketch (optimized for low memory)
@@ -768,6 +775,12 @@ def predict_scratch_card(
                     dist[num] /= tot
         except Exception as exc:  # pragma: no cover - history load failures
             logger.error("position frequency blend failed: %s", exc)
+
+    # 后置正規化避免混權後機率失真
+    for dist in prob_map.values():
+        total = sum(dist.values()) or 1e-12
+        for k in dist:
+            dist[k] /= total
 
     module_scores = {
         mod: get_module_score(mod, grid_np, priors=priors, target=target_num)

--- a/app.py
+++ b/app.py
@@ -232,6 +232,7 @@ async def predict(req: GridRequest):
         payload = {
             "predictions": result.get("predictions", []),
             "full_probabilities": clean_probs,
+            "sample_gamma_used": req.sample_gamma or 0.0,
         }
         safe_payload = sanitize_floats(payload)
         logger.info("✅ Response ready")

--- a/tests/test_prior_normalization.py
+++ b/tests/test_prior_normalization.py
@@ -1,0 +1,31 @@
+import json
+import logging
+import os
+import zipfile
+
+import analyzer
+
+
+def test_prior_mix_is_normalized(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    zpath = samples / "s.zip"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        zf.writestr("a.json", json.dumps(data))
+
+    logging.disable(logging.CRITICAL)
+    os.environ["FAST_TEST"] = "1"
+    res = analyzer.predict_scratch_card(
+        grid=[[-1, -1], [-1, -1]],
+        iterations=1,
+        global_iter=1,
+        focus_iter=0,
+        top_n=1,
+        epsilon=0.0,
+        unique=False,
+        sample_gamma=1.0,
+        history_dir=str(samples),
+    )
+    for dist in res["full_probabilities"].values():
+        assert abs(sum(dist.values()) - 1.0) < 1e-9


### PR DESCRIPTION
## Summary
- vectorize and cache compute_position_probabilities
- normalize blended probabilities
- expose used sample_gamma in API
- test normalization of blended priors

## Testing
- `black --check analyzer.py app.py tests/test_prior_normalization.py`
- `isort --check analyzer.py app.py tests/test_prior_normalization.py`
- `flake8 analyzer.py app.py tests/test_prior_normalization.py`
- `python -m py_compile $(git ls-files '*.py')`
- `FAST_TEST=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa28f758083248205e3e72ca00960