### PR TITLE
Implement prior numpy cache

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -144,7 +144,7 @@ def compute_position_probabilities(
 
     counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
     board_cnt = ok_zip = err_zip = 0
-    for ok, sample in iter_sample_jsons(samples_dir):
+    for ok, sample, *rest in iter_sample_jsons(samples_dir):
         if not ok:
             err_zip += 1
             continue

--- a/analyzer.py
+++ b/analyzer.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import sys
 import zipfile
 from collections import defaultdict
 from functools import lru_cache
@@ -45,6 +46,7 @@ def _native_dict(d):
 
 def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
     """Yield JSON objects from a zip file with basic validation."""
+    count = 0
     with zipfile.ZipFile(zip_path) as zf:
         for name in zf.namelist():
             if not name.endswith(".json"):
@@ -53,7 +55,9 @@ def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
                 with zf.open(name) as f:
                     data = json.load(f)
             except Exception as exc:  # pragma: no cover - corrupted JSON
-                logger.error("Failed to read %s:%s: %s", zip_path.name, name, exc)
+                logger.error(
+                    "Failed to read %s:%s: %s", zip_path.name, name, exc
+                )
                 continue
             grid = data.get("grid")
             if not isinstance(grid, list) or not all(
@@ -64,9 +68,13 @@ def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
             rows = data.get("rows", len(grid))
             cols = data.get("cols", len(grid[0]) if grid else 0)
             if rows != len(grid) or any(len(r) != cols for r in grid):
-                logger.warning("Row/col mismatch in %s:%s", zip_path.name, name)
+                logger.warning(
+                    "Row/col mismatch in %s:%s", zip_path.name, name
+                )
                 continue
+            count += 1
             yield {"rows": rows, "cols": cols, "grid": grid}
+    logger.info("Loaded %s (%d JSON)", zip_path.name, count)
 
 
 def iter_sample_jsons(samples_dir: str) -> Iterator[Dict[str, Any]]:
@@ -76,7 +84,6 @@ def iter_sample_jsons(samples_dir: str) -> Iterator[Dict[str, Any]]:
         try:
             for item in _iter_json_from_zip(zp):
                 yield item
-            logger.info("Loaded %s", zp.name)
         except Exception as exc:  # pragma: no cover - broken zip
             logger.error("Failed to load %s: %s", zp.name, exc)
 
@@ -111,6 +118,26 @@ def compute_position_probabilities(
     samples_dir: str, rows: int, cols: int
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
     """Return per-cell number probabilities from all samples."""
+    cached = Path(samples_dir) / "prior.npy"
+    if cached.exists():
+        cube = np.load(cached, mmap_mode="r")
+        if cube.shape[:2] != (rows, cols):
+            logger.warning("Cached prior shape mismatch: %s", cube.shape)
+        else:
+            logger.info("Loaded prior from %s", cached)
+            prob_map: Dict[Tuple[int, int], Dict[int, float]] = {}
+            for r in range(rows):
+                for c in range(cols):
+                    dist = cube[r, c].astype(float)
+                    total = dist.sum() or 1.0
+                    probs = {
+                        i: dist[i] / total
+                        for i in range(1, dist.size)
+                        if dist[i] > 0
+                    }
+                    prob_map[(r, c)] = probs
+            return prob_map
+
     counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
     total = 0
     for sample in iter_sample_jsons(samples_dir):
@@ -137,7 +164,10 @@ def compute_position_probabilities(
                 prob_map[(r, c)] = {}
 
     logger.info(
-        "Position frequencies for %d×%d processed %d samples", rows, cols, total
+        "Position frequencies for %d×%d processed %d samples",
+        rows,
+        cols,
+        total,
     )
     return prob_map
 
@@ -145,7 +175,9 @@ def compute_position_probabilities(
 # Count-Min Sketch (optimized for low memory)
 class CountMinSketch:
     def __init__(self, width: int = 1024, depth: int = 1):
-        self.w = max(1024, min(2048, int(8e9 / (depth * 4))))  # 8 GB RAM 動態調整
+        self.w = max(
+            1024, min(2048, int(8e9 / (depth * 4)))
+        )  # 8 GB RAM 動態調整
         self.d = depth
         self.table = np.zeros((depth, self.w), dtype=np.uint32)
         self.seeds = [i * 0x9E3779B1 for i in range(depth)]
@@ -158,7 +190,9 @@ class CountMinSketch:
             self.table[i, self._idx(key, s)] += value
 
     def query(self, key: bytes) -> int:
-        return min(self.table[i, self._idx(key, s)] for i, s in enumerate(self.seeds))
+        return min(
+            self.table[i, self._idx(key, s)] for i, s in enumerate(self.seeds)
+        )
 
 
 def pack_key(cell_idx: int, num: int) -> bytes:
@@ -167,7 +201,9 @@ def pack_key(cell_idx: int, num: int) -> bytes:
 
 # Precompute skip scores with LRU cache
 @lru_cache(maxsize=1024)
-def precompute_skip_scores(grid_bytes: bytes, rows: int, cols: int) -> np.ndarray:
+def precompute_skip_scores(
+    grid_bytes: bytes, rows: int, cols: int
+) -> np.ndarray:
     grid = bytes_to_grid(grid_bytes, (rows, cols))
     return EXT_GM20_Skip_Pattern_Confidence_Vec(grid)
 
@@ -180,14 +216,45 @@ def adjust_weights_based_on_history(
     return np.array([history.get(f, 0.0) / total for f in formulas])
 
 
-def select_modules(grid: np.ndarray, target: Optional[int] = None) -> List[str]:
+def dump_prior(samples_dir: str, outfile: str) -> None:
+    """Aggregate all samples into a prior cube and save as ``outfile``."""
+    cube = None
+    rows = cols = 0
+    for sample in iter_sample_jsons(samples_dir):
+        r, c = sample["rows"], sample["cols"]
+        if cube is None:
+            rows, cols = r, c
+            cube = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
+        if r != rows or c != cols:
+            logger.warning("Skip mismatched sample %s×%s", r, c)
+            continue
+        grid = np.asarray(sample["grid"], dtype=int)
+        mask = (grid >= 1) & (grid <= rows * cols)
+        rr, cc = np.indices(grid.shape)
+        np.add.at(cube, (rr[mask], cc[mask], grid[mask]), 1)
+    if cube is None:
+        logger.error("No valid samples found in %s", samples_dir)
+        return
+    np.save(outfile, cube)
+    logger.info("Prior saved to %s", outfile)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    if len(sys.argv) == 3:
+        dump_prior(sys.argv[1], sys.argv[2])
+
+
+def select_modules(
+    grid: np.ndarray, target: Optional[int] = None
+) -> List[str]:
     """Select up to ``CORE_LIMIT`` modules based on weights and scores."""
     if os.getenv("FORCE_FULL_SCAN", "0") == "1":
         mods = list(REGISTERED_MODULES_BRAIN)
     else:
         base_modules = brain.get_core_modules()
         scores = {
-            m: np.mean(get_module_score(m, grid, target=target)) for m in base_modules
+            m: np.mean(get_module_score(m, grid, target=target))
+            for m in base_modules
         }
         mods = sorted(scores, key=scores.get, reverse=True)
 
@@ -241,7 +308,9 @@ def _cached_board(
     return board
 
 
-def fill_unknowns_randomly(grid: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+def fill_unknowns_randomly(
+    grid: np.ndarray, rng: np.random.Generator
+) -> np.ndarray:
     """Fill -1 cells in ``grid`` with a random permutation of remaining numbers."""
     g = np.asarray(grid, dtype=int).copy()
     blanks = np.argwhere(g == -1)
@@ -335,7 +404,9 @@ def simulate_full_board(
         axis=0,
     )
     importance_weights = np.where(g == -1, module_scores, 0).flatten()
-    importance_weights = importance_weights / (np.sum(importance_weights) + 1e-10)
+    importance_weights = importance_weights / (
+        np.sum(importance_weights) + 1e-10
+    )
 
     # Dynamic formula weights based on grid pattern
     history = {"random_entropy": 0.4, "shuffle": 0.3, "tail_cluster": 0.3}
@@ -349,22 +420,30 @@ def simulate_full_board(
     counts = defaultdict(lambda: defaultdict(int))
     focus_set = {tuple(fc) for fc in focus_cells} if focus_cells else None
     other_cells = (
-        [tuple(b) for b in blanks if tuple(b) not in focus_set] if focus_set else []
+        [tuple(b) for b in blanks if tuple(b) not in focus_set]
+        if focus_set
+        else []
     )
 
     while remain > 0:
         batch = min(4000, remain)
-        boards = generate_full_boards(rows, cols, batch, rng, formulas, weights, g)
+        boards = generate_full_boards(
+            rows, cols, batch, rng, formulas, weights, g
+        )
 
         if known.size:
-            mask = np.all(boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1)
+            mask = np.all(
+                boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1
+            )
             boards = boards[mask]
             if len(boards) == 0:
                 batch = min(batch * 2, 8000)
                 boards = generate_full_boards(
                     rows, cols, batch, rng, formulas, weights, g
                 )
-                mask = np.all(boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1)
+                mask = np.all(
+                    boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1
+                )
                 boards = boards[mask]
 
         if len(boards) > 0:
@@ -386,7 +465,11 @@ def simulate_full_board(
                 soft_fast /= soft_fast.sum() + 1e-10
                 fast = soft_fast
                 cells_iter = blanks if focus_set is None else focus_set
-                if focus_set is not None and other_cells and rng.random() < epsilon:
+                if (
+                    focus_set is not None
+                    and other_cells
+                    and rng.random() < epsilon
+                ):
                     cells_iter = list(focus_set) + [
                         other_cells[int(rng.integers(len(other_cells)))]
                     ]
@@ -418,7 +501,8 @@ def simulate_full_board(
     ]
     w = np.array([AGG_WEIGHTS[m] for m in mods_rerank])
     stack_rerank = np.stack(
-        [get_module_score(m, g, target=target_num) for m in mods_rerank], axis=0
+        [get_module_score(m, g, target=target_num) for m in mods_rerank],
+        axis=0,
     )
     final_heat = aggregate_scores(stack_rerank, w, mods_rerank)
     soft_heat = np.exp(final_heat / tau)
@@ -441,7 +525,9 @@ def simulate_full_board(
         final_prob_map[(r, c)][num] = final_score
 
     # 來自 probmap_key_patch_v2.txt
-    prob_map = {(int(r), int(c)): cell for (r, c), cell in final_prob_map.items()}
+    prob_map = {
+        (int(r), int(c)): cell for (r, c), cell in final_prob_map.items()
+    }
 
     # --- 保證所有格都有 entry ------------------------------
     if os.getenv("FORCE_FULL_SCAN", "0") == "1":
@@ -466,7 +552,8 @@ def weight_prob_by_modules(
     result = prob_map.copy()
     modules = select_modules(grid, target=target_num)
     module_scores = Parallel(n_jobs=4)(
-        delayed(get_module_score)(mod, grid, target=target_num) for mod in modules
+        delayed(get_module_score)(mod, grid, target=target_num)
+        for mod in modules
     )
     module_scores = np.array(module_scores)
 
@@ -535,7 +622,8 @@ def assign_unique_numbers(
 
 
 def global_unique(
-    prob_map: Dict[Tuple[int, int], Dict[int, float]], blanks: List[Tuple[int, int]]
+    prob_map: Dict[Tuple[int, int], Dict[int, float]],
+    blanks: List[Tuple[int, int]],
 ) -> Dict[Tuple[int, int], Tuple[int, float]]:
     try:
         assignments = assign_unique_numbers(prob_map)
@@ -547,7 +635,9 @@ def global_unique(
         logger.error(f"Global unique assignment failed: {e}")
         assigned, res = set(), {}
         for cell in sorted(
-            blanks, key=lambda p: max(prob_map[p].values() or [0]), reverse=True
+            blanks,
+            key=lambda p: max(prob_map[p].values() or [0]),
+            reverse=True,
         ):
             for n, p in sorted(
                 prob_map[cell].items(), key=lambda x: x[1], reverse=True
@@ -646,7 +736,9 @@ def mcts(grid: np.ndarray, iterations: int = 1000):
     Parallel(n_jobs=4, require="sharedmem")(
         delayed(simulate)(root) for _ in range(iterations // 4)
     )
-    best_child = max(root.children, key=lambda c: c.value / c.visits, default=root)
+    best_child = max(
+        root.children, key=lambda c: c.value / c.visits, default=root
+    )
     return best_child.grid
 
 
@@ -677,7 +769,11 @@ def predict_scratch_card(
     ]  # 來自 probmap_key_patch_v2.txt
 
     if not blanks:
-        return {"mode": "no_blanks", "predictions": [], "full_probabilities": {}}
+        return {
+            "mode": "no_blanks",
+            "predictions": [],
+            "full_probabilities": {},
+        }
 
     modules = [
         ("EXT_Q1_ProximityEntropy_Vec", "Proximity and entropy scoring"),
@@ -685,7 +781,10 @@ def predict_scratch_card(
         ("EXT_Q5_GlobalEntropy_Vec", "Global entropy and clustering"),
         ("EXT_Q14_TargetAffinity_Vec", "Target number affinity"),
         ("EXT_Q15_GlobalSpread_Vec", "Global spread preference"),
-        ("EXT_Q16_NumericalRelationalPattern_Vec", "Numerical relational patterns"),
+        (
+            "EXT_Q16_NumericalRelationalPattern_Vec",
+            "Numerical relational patterns",
+        ),
     ]
 
     mod_names = [m for m, _ in modules]
@@ -700,7 +799,9 @@ def predict_scratch_card(
     final_score_map = (weights[:, None, None] * score_stack).sum(axis=0)
     if gamma_history > 0.0 and target_num is not None:
         try:
-            hist = compute_history_frequency(history_dir, target_num, rows, cols)
+            hist = compute_history_frequency(
+                history_dir, target_num, rows, cols
+            )
             if hist.max() > 0:
                 final_score_map += gamma_history * (hist / float(hist.max()))
         except Exception as exc:  # pragma: no cover - history load failures
@@ -750,7 +851,9 @@ def predict_scratch_card(
         key=lambda x: x[2],
         reverse=True,
     )
-    focus_cells = [(r, c) for r, c, _ in ranked[: max(1, min(top_n, len(ranked)))]]
+    focus_cells = [
+        (r, c) for r, c, _ in ranked[: max(1, min(top_n, len(ranked)))]
+    ]
 
     if phase2 > 0:
         refine_map = simulate_full_board(
@@ -807,14 +910,17 @@ def predict_scratch_card(
                 "row": r,
                 "col": c,
                 "candidates": [target_num],
-                "probability": prob_map.get((r, c), {}).get(target_num, 0.0) * 100,
+                "probability": prob_map.get((r, c), {}).get(target_num, 0.0)
+                * 100,
             }
             for r, c in prob_map.keys()
         ]  # 改用 .get()
         rank.sort(key=lambda x: x["probability"], reverse=True)
 
         module_scores = {
-            mod: get_module_score(mod, grid_np, priors=priors, target=target_num)
+            mod: get_module_score(
+                mod, grid_np, priors=priors, target=target_num
+            )
             for mod, _ in modules
         }
         for pred in rank[:3]:
@@ -865,7 +971,9 @@ def predict_scratch_card(
                 max(
                     weight_prob_by_modules(  # <<< 你自己已有的函式
                         best_grid,  # - 當前最佳棋盤
-                        {(r, c): prob_map.get((r, c), {})},  # - 只帶單一候選格的機率
+                        {
+                            (r, c): prob_map.get((r, c), {})
+                        },  # - 只帶單一候選格的機率
                     )
                     .get((r, c), {})
                     .values(),  # 取回各模組加權後的機率們
@@ -877,7 +985,12 @@ def predict_scratch_card(
 
         if new_conf <= old_conf * 0.95:
             preds = [
-                {"row": r, "col": c, "candidates": [n], "probability": float(p) * 100}
+                {
+                    "row": r,
+                    "col": c,
+                    "candidates": [n],
+                    "probability": float(p) * 100,
+                }
                 for (r, c), (n, p) in assign.items()
             ]
             mode = "unique"
@@ -886,7 +999,9 @@ def predict_scratch_card(
             mode = "mcts_unique"
 
         module_scores = {
-            mod: get_module_score(mod, grid_np, priors=priors, target=target_num)
+            mod: get_module_score(
+                mod, grid_np, priors=priors, target=target_num
+            )
             for mod, _ in modules
         }
         for pred in preds[:3]:
@@ -941,14 +1056,17 @@ def predict_scratch_card(
         for mod, score, desc in top_modules:
             if score > 0.5:
                 reasons.append(f"{desc} (score: {score:.2f})")
-        pred["reasons"] = reasons if reasons else ["No dominant module contribution"]
+        pred["reasons"] = (
+            reasons if reasons else ["No dominant module contribution"]
+        )
         pred["module_scores"] = {
             mod: float(module_scores[mod][pred["row"], pred["col"]])
             for mod, _ in modules
         }
 
     preds.sort(
-        key=lambda x: x["probability"][0] if x["probability"] else 0, reverse=True
+        key=lambda x: x["probability"][0] if x["probability"] else 0,
+        reverse=True,
     )
     return {
         "mode": "top3",
@@ -1019,7 +1137,9 @@ def monte_carlo_prob_map(
     if k is not None:
         counts = np.zeros((rows, cols), dtype=int)
     else:
-        counts = {int(val): np.zeros((rows, cols), dtype=int) for val in remain}
+        counts = {
+            int(val): np.zeros((rows, cols), dtype=int) for val in remain
+        }
 
     for _ in range(max(1, n_iter)):
         sample = rng.permutation(remain)

--- a/analyzer.py
+++ b/analyzer.py
@@ -119,24 +119,49 @@ def compute_position_probabilities(
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
     """Return per-cell number probabilities from all samples."""
     cached = Path(samples_dir) / "prior.npy"
+
+    # ── ① 有快取：直接讀 ──────────────────────────────
     if cached.exists():
+        logger.info("[PRIOR] 🔷 using cached prior from %s", cached)
+
         cube = np.load(cached, mmap_mode="r")
         if cube.shape[:2] != (rows, cols):
             logger.warning("Cached prior shape mismatch: %s", cube.shape)
-        else:
-            logger.info("Loaded prior from %s", cached)
-            prob_map: Dict[Tuple[int, int], Dict[int, float]] = {}
+        else:                                  # ← shape 正確，組合成字典後就 return
+            result: Dict[Tuple[int, int], Dict[int, float]] = {}
             for r in range(rows):
                 for c in range(cols):
-                    dist = cube[r, c].astype(float)
-                    total = dist.sum() or 1.0
-                    probs = {
-                        i: dist[i] / total
-                        for i in range(1, dist.size)
-                        if dist[i] > 0
+                    dist = cube[r, c][1:]          # index 0 留空，1→數字1
+                    tot = dist.sum() or 1
+                    result[(r, c)] = {
+                        i: float(p) / tot
+                        for i, p in enumerate(dist, start=1) if p > 0
                     }
-                    prob_map[(r, c)] = probs
-            return prob_map
+            return result
+
+    # ── ② 沒快取或 shape 不符：掃 ZIP 重算 ─────────────
+    logger.info("[PRIOR] 🔶 prior.npy not found, scanning ZIP …")
+
+    counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
+    board_cnt = ok_zip = err_zip = 0
+    for ok, sample in iter_sample_jsons(samples_dir):
+        if not ok:
+            err_zip += 1
+            continue
+        ok_zip += 1
+        if sample["rows"] != rows or sample["cols"] != cols:
+            continue
+        board_cnt += 1
+        grid = np.asarray(sample["grid"], dtype=int)
+        mask = (grid >= 1) & (grid <= rows * cols)
+        rr, cc = np.indices(grid.shape)
+        np.add.at(counts, (rr[mask], cc[mask], grid[mask]), 1)
+
+    logger.info(
+        "[PRIOR] ✔ rows=%d cols=%d | boards=%d | zip_ok=%d | zip_err=%d",
+        rows, cols, board_cnt, ok_zip, err_zip
+    )
+
 
     counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
     total = 0

--- a/analyzer.py
+++ b/analyzer.py
@@ -119,49 +119,24 @@ def compute_position_probabilities(
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
     """Return per-cell number probabilities from all samples."""
     cached = Path(samples_dir) / "prior.npy"
-
-    # ── ① 有快取：直接讀 ──────────────────────────────
     if cached.exists():
-        logger.info("[PRIOR] 🔷 using cached prior from %s", cached)
-
         cube = np.load(cached, mmap_mode="r")
         if cube.shape[:2] != (rows, cols):
             logger.warning("Cached prior shape mismatch: %s", cube.shape)
-        else:                                  # ← shape 正確，組合成字典後就 return
-            result: Dict[Tuple[int, int], Dict[int, float]] = {}
+        else:
+            logger.info("Loaded prior from %s", cached)
+            prob_map: Dict[Tuple[int, int], Dict[int, float]] = {}
             for r in range(rows):
                 for c in range(cols):
-                    dist = cube[r, c][1:]          # index 0 留空，1→數字1
-                    tot = dist.sum() or 1
-                    result[(r, c)] = {
-                        i: float(p) / tot
-                        for i, p in enumerate(dist, start=1) if p > 0
+                    dist = cube[r, c].astype(float)
+                    total = dist.sum() or 1.0
+                    probs = {
+                        i: dist[i] / total
+                        for i in range(1, dist.size)
+                        if dist[i] > 0
                     }
-            return result
-
-    # ── ② 沒快取或 shape 不符：掃 ZIP 重算 ─────────────
-    logger.info("[PRIOR] 🔶 prior.npy not found, scanning ZIP …")
-
-    counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
-    board_cnt = ok_zip = err_zip = 0
-    for ok, sample, *rest in iter_sample_jsons(samples_dir):
-        if not ok:
-            err_zip += 1
-            continue
-        ok_zip += 1
-        if sample["rows"] != rows or sample["cols"] != cols:
-            continue
-        board_cnt += 1
-        grid = np.asarray(sample["grid"], dtype=int)
-        mask = (grid >= 1) & (grid <= rows * cols)
-        rr, cc = np.indices(grid.shape)
-        np.add.at(counts, (rr[mask], cc[mask], grid[mask]), 1)
-
-    logger.info(
-        "[PRIOR] ✔ rows=%d cols=%d | boards=%d | zip_ok=%d | zip_err=%d",
-        rows, cols, board_cnt, ok_zip, err_zip
-    )
-
+                    prob_map[(r, c)] = probs
+            return prob_map
 
     counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
     total = 0

--- a/app.py
+++ b/app.py
@@ -5,9 +5,6 @@ import math
 import os
 import subprocess
 import sys
-import glob
-import zipfile
-from collections import Counter
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -22,6 +19,7 @@ from pydantic import BaseModel
 import brain
 # fmt: off
 from analyzer import predict_scratch_card, probability_heatmap, render_heatmap
+
 # fmt: on
 
 # —— Logging setup —————————————————————————————————————————————————————————————
@@ -54,29 +52,21 @@ app.add_middleware(
 HERE = Path(__file__).parent
 script = HERE / "excel_cleaner_and_formatter.py"
 
-# —— Global variables —————————————————————————————————————————————————————————
-startup_time = datetime.utcnow().isoformat() + "Z"
-priors: Dict[int, float] = {}  # 全局先驗概率
-zip_stats = {
-    "total_zips": 0,  # 掃描到的 ZIP 檔案數
-    "extracted_jsons": 0,  # 解壓出的 JSON 檔案數
-    "loaded_jsons": 0,  # 成功讀取的 JSON 檔案數
-    "failed_jsons": 0,  # 讀取失敗的 JSON 檔案數
-}
 
-# —— Environment variables ————————————————————————————————————————————————————
-os.environ.setdefault("PHASE1_ITERATIONS", "5000")
-os.environ.setdefault("PHASE2_ITERATIONS", "1000")
-os.environ.setdefault("PHASE2_TOP_N", "10")
-os.environ.setdefault("PHASE2_EPSILON", "0.05")
-os.environ.setdefault("LOG_LEVEL", "INFO")
+@app.on_event("startup")
+async def pre_startup():  # FIXME rename to avoid F811 duplicate
+    logger.info("📂 on_startup: starting Excel cleaning")
+    # 用当前 Python 解释器执行清洗脚本
+    subprocess.run([sys.executable, str(script)], check=True)
+    logger.info("📂 on_startup: cleaning script finished")
 
-PHASE1_ITER = int(os.getenv("PHASE1_ITERATIONS"))
-PHASE2_ITER = int(os.getenv("PHASE2_ITERATIONS"))
-PHASE2_TOP_N = int(os.getenv("PHASE2_TOP_N"))
-PHASE2_EPS = float(os.getenv("PHASE2_EPSILON"))
 
-# —— Schemas ——————————————————————————————————————————————————————————————————
+@app.get("/debug/priors", response_class=JSONResponse)
+async def debug_priors():
+    return priors
+
+
+# ==== Schemas ==============================================================
 class GridRequest(BaseModel):
     grid: List[List[int]]
     target_num: Optional[int] = None
@@ -88,6 +78,7 @@ class GridRequest(BaseModel):
     result_top_k: Optional[int] = None
     sample_gamma: Optional[float] = None
 
+
 class Prediction(BaseModel):
     row: int
     col: int
@@ -96,9 +87,11 @@ class Prediction(BaseModel):
     reasons: List[str]
     module_scores: Dict[str, float]
 
+
 class PredictResponse(BaseModel):
     predictions: List[Prediction]
     full_probabilities: Dict[str, Dict[str, float]]
+
 
 class HeatmapRequest(BaseModel):
     grid: List[List[int]]
@@ -108,11 +101,32 @@ class HeatmapRequest(BaseModel):
     seed: int = 0
     output_format: str = "base64"
 
+
 class HeatmapResponse(BaseModel):
     prob_map: Union[List[List[float]], Dict[str, List[List[float]]]]
     heatmap: Optional[str] = None
 
-# —— Helpers ——————————————————————————————————————————————————————————————————
+
+# ==== Startup & ENV parsing =================================================
+startup_time = datetime.utcnow().isoformat() + "Z"
+
+# 默认环境变量
+os.environ.setdefault("PHASE1_ITERATIONS", "5000")
+os.environ.setdefault("PHASE2_ITERATIONS", "1000")
+os.environ.setdefault("PHASE2_TOP_N", "10")
+os.environ.setdefault("PHASE2_EPSILON", "0.05")
+os.environ.setdefault("LOG_LEVEL", "INFO")
+
+PHASE1_ITER = int(os.getenv("PHASE1_ITERATIONS"))
+PHASE2_ITER = int(os.getenv("PHASE2_ITERATIONS"))
+PHASE2_TOP_N = int(os.getenv("PHASE2_TOP_N"))
+PHASE2_EPS = float(os.getenv("PHASE2_EPSILON"))
+
+# 全局先验概率（来自 Excel 样本）
+priors: Dict[int, float] = {}
+
+
+# ==== Helpers: sanitize floats ===============================================
 def safe_float(x: Any) -> float:
     try:
         v = float(x)
@@ -121,6 +135,7 @@ def safe_float(x: Any) -> float:
     if math.isnan(v) or math.isinf(v):
         return 0.0
     return v
+
 
 def sanitize_floats(obj: Any) -> Any:
     if isinstance(obj, dict):
@@ -131,91 +146,24 @@ def sanitize_floats(obj: Any) -> Any:
         return safe_float(obj)
     return obj
 
-# —— Startup events ———————————————————————————————————————————————————————————
-@app.on_event("startup")
-async def pre_startup():  # FIXME rename to avoid F811 duplicate
-    logger.info("📂 on_startup: starting Excel cleaning")
-    subprocess.run([sys.executable, str(script)], check=True)
-    logger.info("📂 on_startup: cleaning script finished")
 
-@app.on_event("startup")
-async def on_startup():
-    global priors, zip_stats
-    try:
-        # 執行 Excel 清洗
-        subprocess.run(["python", "excel_cleaner_and_formatter.py"], check=True)
+# ==== Routes ==============================================================
 
-        # 處理 samples/*.zip 檔案
-        samples_path = HERE / "samples"
-        samples_path.mkdir(exist_ok=True)  # 確保 samples 資料夾存在
-        zip_files = glob.glob(str(samples_path / "*.zip"))
-        zip_stats["total_zips"] = len(zip_files)
 
-        # 解壓 ZIP 並計數 JSON
-        extract_path = samples_path / "extracted"
-        extract_path.mkdir(exist_ok=True)  # 確保 extracted 資料夾存在
-        json_files = []
-        for zip_file in zip_files:
-            try:
-                with zipfile.ZipFile(zip_file, 'r') as z:
-                    z.extractall(extract_path)
-                json_files.extend(
-                    glob.glob(str(extract_path / "*.json"))
-                )
-            except Exception as e:
-                logger.warning("Failed to extract ZIP %s: %s", zip_file, e)
-        zip_stats["extracted_jsons"] = len(json_files)
-
-        # 讀取 JSON 並計數成功/失敗
-        for json_file in json_files:
-            try:
-                with open(json_file, 'r', encoding='utf-8') as f:
-                    json.load(f)
-                zip_stats["loaded_jsons"] += 1
-            except Exception as e:
-                zip_stats["failed_jsons"] += 1
-                logger.warning("Failed to load JSON %s: %s", json_file, e)
-
-        # 載入先驗資料
-        p = Path("output/cleaned_data.json")
-        if p.exists():
-            priors = json.loads(p.read_text(encoding="utf-8"))
-        else:
-            priors = {}
-        brain.priors = priors
-
-        # 簡易顯示計數（單行 log）
-        stats_str = (
-            f"Zips: {zip_stats['total_zips']}, "
-            f"Extracted JSONs: {zip_stats['extracted_jsons']}, "
-            f"Loaded JSONs: {zip_stats['loaded_jsons']}, "
-            f"Failed JSONs: {zip_stats['failed_jsons']}"
-        )
-        logger.info("Startup stats | %s", stats_str)
-
-    except Exception as e:
-        logger.warning("Startup failed: %s", e)
-
-@app.on_event("shutdown")
-async def on_shutdown():
-    logger.info("Shutdown complete")
-
-# —— Routes ——————————————————————————————————————————————————————————————————
 @app.get("/", response_class=JSONResponse, status_code=status.HTTP_200_OK)
 async def root() -> Dict[str, Any]:
     return {"status": "OK", "startup": startup_time}
+
 
 @app.head("/", response_class=PlainTextResponse, status_code=status.HTTP_200_OK)
 async def root_head() -> str:
     return ""
 
+
 @app.get("/debug/ping", response_class=JSONResponse, status_code=200)
 async def ping() -> Dict[str, str]:
     return {"ping": "pong"}
 
-@app.get("/debug/priors", response_class=JSONResponse)
-async def debug_priors():
-    return priors
 
 @app.post(
     "/predict",
@@ -294,6 +242,7 @@ async def predict(req: GridRequest):
         logger.error("Prediction failed", exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
 
+
 @app.post(
     "/heatmap",
     response_model=HeatmapResponse,
@@ -325,11 +274,34 @@ async def heatmap(req: HeatmapRequest):
         logger.error("Heatmap failed", exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
 
-# —— Main ————————————————————————————————————————————————————————————————————
+
+@app.on_event("startup")
+async def on_startup():
+    # 自动清洗 Excel 并加载先验
+    try:
+        subprocess.run(["python", "excel_cleaner_and_formatter.py"], check=True)
+        p = Path("output/cleaned_data.json")
+        global priors
+        if p.exists():
+            priors = json.loads(p.read_text(encoding="utf-8"))
+        else:
+            priors = {}
+        brain.priors = priors
+        logger.info("Loaded priors from cleaned_data.json")
+    except Exception as e:
+        logger.warning("Could not load priors on startup: %s", e)
+
+
+@app.on_event("shutdown")
+async def on_shutdown():
+    logger.info("Shutdown complete")
+
+
 def run_api() -> None:
     port = int(os.getenv("PORT", "10000"))
     logger.info("Starting API on port %d", port)
     uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
+
 
 if __name__ == "__main__":
     run_api()

--- a/app.py
+++ b/app.py
@@ -5,6 +5,9 @@ import math
 import os
 import subprocess
 import sys
+import glob
+import zipfile
+from collections import Counter
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -19,7 +22,6 @@ from pydantic import BaseModel
 import brain
 # fmt: off
 from analyzer import predict_scratch_card, probability_heatmap, render_heatmap
-
 # fmt: on
 
 # —— Logging setup —————————————————————————————————————————————————————————————
@@ -52,65 +54,17 @@ app.add_middleware(
 HERE = Path(__file__).parent
 script = HERE / "excel_cleaner_and_formatter.py"
 
-
-@app.on_event("startup")
-async def pre_startup():  # FIXME rename to avoid F811 duplicate
-    logger.info("📂 on_startup: starting Excel cleaning")
-    # 用当前 Python 解释器执行清洗脚本
-    subprocess.run([sys.executable, str(script)], check=True)
-    logger.info("📂 on_startup: cleaning script finished")
-
-
-@app.get("/debug/priors", response_class=JSONResponse)
-async def debug_priors():
-    return priors
-
-
-# ==== Schemas ==============================================================
-class GridRequest(BaseModel):
-    grid: List[List[int]]
-    target_num: Optional[int] = None
-    iterations: Optional[int] = None
-    global_iter: Optional[int] = None
-    focus_iter: Optional[int] = None
-    top_n: Optional[int] = None
-    epsilon: Optional[float] = None
-    result_top_k: Optional[int] = None
-    sample_gamma: Optional[float] = None
-
-
-class Prediction(BaseModel):
-    row: int
-    col: int
-    candidates: List[int]
-    probability: float  # percentage
-    reasons: List[str]
-    module_scores: Dict[str, float]
-
-
-class PredictResponse(BaseModel):
-    predictions: List[Prediction]
-    full_probabilities: Dict[str, Dict[str, float]]
-
-
-class HeatmapRequest(BaseModel):
-    grid: List[List[int]]
-    k: Optional[int] = None
-    target_num: Optional[int] = None
-    iterations: int = 1000
-    seed: int = 0
-    output_format: str = "base64"
-
-
-class HeatmapResponse(BaseModel):
-    prob_map: Union[List[List[float]], Dict[str, List[List[float]]]]
-    heatmap: Optional[str] = None
-
-
-# ==== Startup & ENV parsing =================================================
+# —— Global variables —————————————————————————————————————————————————————————
 startup_time = datetime.utcnow().isoformat() + "Z"
+priors: Dict[int, float] = {}  # 全局先驗概率
+zip_stats = {
+    "total_zips": 0,  # 掃描到的 ZIP 檔案數
+    "extracted_jsons": 0,  # 解壓出的 JSON 檔案數
+    "loaded_jsons": 0,  # 成功讀取的 JSON 檔案數
+    "failed_jsons": 0,  # 讀取失敗的 JSON 檔案數
+}
 
-# 默认环境变量
+# —— Environment variables ————————————————————————————————————————————————————
 os.environ.setdefault("PHASE1_ITERATIONS", "5000")
 os.environ.setdefault("PHASE2_ITERATIONS", "1000")
 os.environ.setdefault("PHASE2_TOP_N", "10")
@@ -122,11 +76,43 @@ PHASE2_ITER = int(os.getenv("PHASE2_ITERATIONS"))
 PHASE2_TOP_N = int(os.getenv("PHASE2_TOP_N"))
 PHASE2_EPS = float(os.getenv("PHASE2_EPSILON"))
 
-# 全局先验概率（来自 Excel 样本）
-priors: Dict[int, float] = {}
+# —— Schemas ——————————————————————————————————————————————————————————————————
+class GridRequest(BaseModel):
+    grid: List[List[int]]
+    target_num: Optional[int] = None
+    iterations: Optional[int] = None
+    global_iter: Optional[int] = None
+    focus_iter: Optional[int] = None
+    top_n: Optional[int] = None
+    epsilon: Optional[float] = None
+    result_top_k: Optional[int] = None
+    sample_gamma: Optional[float] = None
 
+class Prediction(BaseModel):
+    row: int
+    col: int
+    candidates: List[int]
+    probability: float  # percentage
+    reasons: List[str]
+    module_scores: Dict[str, float]
 
-# ==== Helpers: sanitize floats ===============================================
+class PredictResponse(BaseModel):
+    predictions: List[Prediction]
+    full_probabilities: Dict[str, Dict[str, float]]
+
+class HeatmapRequest(BaseModel):
+    grid: List[List[int]]
+    k: Optional[int] = None
+    target_num: Optional[int] = None
+    iterations: int = 1000
+    seed: int = 0
+    output_format: str = "base64"
+
+class HeatmapResponse(BaseModel):
+    prob_map: Union[List[List[float]], Dict[str, List[List[float]]]]
+    heatmap: Optional[str] = None
+
+# —— Helpers ——————————————————————————————————————————————————————————————————
 def safe_float(x: Any) -> float:
     try:
         v = float(x)
@@ -135,7 +121,6 @@ def safe_float(x: Any) -> float:
     if math.isnan(v) or math.isinf(v):
         return 0.0
     return v
-
 
 def sanitize_floats(obj: Any) -> Any:
     if isinstance(obj, dict):
@@ -146,24 +131,91 @@ def sanitize_floats(obj: Any) -> Any:
         return safe_float(obj)
     return obj
 
+# —— Startup events ———————————————————————————————————————————————————————————
+@app.on_event("startup")
+async def pre_startup():  # FIXME rename to avoid F811 duplicate
+    logger.info("📂 on_startup: starting Excel cleaning")
+    subprocess.run([sys.executable, str(script)], check=True)
+    logger.info("📂 on_startup: cleaning script finished")
 
-# ==== Routes ==============================================================
+@app.on_event("startup")
+async def on_startup():
+    global priors, zip_stats
+    try:
+        # 執行 Excel 清洗
+        subprocess.run(["python", "excel_cleaner_and_formatter.py"], check=True)
 
+        # 處理 samples/*.zip 檔案
+        samples_path = HERE / "samples"
+        samples_path.mkdir(exist_ok=True)  # 確保 samples 資料夾存在
+        zip_files = glob.glob(str(samples_path / "*.zip"))
+        zip_stats["total_zips"] = len(zip_files)
 
+        # 解壓 ZIP 並計數 JSON
+        extract_path = samples_path / "extracted"
+        extract_path.mkdir(exist_ok=True)  # 確保 extracted 資料夾存在
+        json_files = []
+        for zip_file in zip_files:
+            try:
+                with zipfile.ZipFile(zip_file, 'r') as z:
+                    z.extractall(extract_path)
+                json_files.extend(
+                    glob.glob(str(extract_path / "*.json"))
+                )
+            except Exception as e:
+                logger.warning("Failed to extract ZIP %s: %s", zip_file, e)
+        zip_stats["extracted_jsons"] = len(json_files)
+
+        # 讀取 JSON 並計數成功/失敗
+        for json_file in json_files:
+            try:
+                with open(json_file, 'r', encoding='utf-8') as f:
+                    json.load(f)
+                zip_stats["loaded_jsons"] += 1
+            except Exception as e:
+                zip_stats["failed_jsons"] += 1
+                logger.warning("Failed to load JSON %s: %s", json_file, e)
+
+        # 載入先驗資料
+        p = Path("output/cleaned_data.json")
+        if p.exists():
+            priors = json.loads(p.read_text(encoding="utf-8"))
+        else:
+            priors = {}
+        brain.priors = priors
+
+        # 簡易顯示計數（單行 log）
+        stats_str = (
+            f"Zips: {zip_stats['total_zips']}, "
+            f"Extracted JSONs: {zip_stats['extracted_jsons']}, "
+            f"Loaded JSONs: {zip_stats['loaded_jsons']}, "
+            f"Failed JSONs: {zip_stats['failed_jsons']}"
+        )
+        logger.info("Startup stats | %s", stats_str)
+
+    except Exception as e:
+        logger.warning("Startup failed: %s", e)
+
+@app.on_event("shutdown")
+async def on_shutdown():
+    logger.info("Shutdown complete")
+
+# —— Routes ——————————————————————————————————————————————————————————————————
 @app.get("/", response_class=JSONResponse, status_code=status.HTTP_200_OK)
 async def root() -> Dict[str, Any]:
     return {"status": "OK", "startup": startup_time}
-
 
 @app.head("/", response_class=PlainTextResponse, status_code=status.HTTP_200_OK)
 async def root_head() -> str:
     return ""
 
-
 @app.get("/debug/ping", response_class=JSONResponse, status_code=200)
 async def ping() -> Dict[str, str]:
     return {"ping": "pong"}
 
+@app.get("/debug/priors", response_class=JSONResponse)
+async def debug_priors():
+    return priors
 
 @app.post(
     "/predict",
@@ -242,7 +294,6 @@ async def predict(req: GridRequest):
         logger.error("Prediction failed", exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
 
-
 @app.post(
     "/heatmap",
     response_model=HeatmapResponse,
@@ -274,34 +325,11 @@ async def heatmap(req: HeatmapRequest):
         logger.error("Heatmap failed", exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
 
-
-@app.on_event("startup")
-async def on_startup():
-    # 自动清洗 Excel 并加载先验
-    try:
-        subprocess.run(["python", "excel_cleaner_and_formatter.py"], check=True)
-        p = Path("output/cleaned_data.json")
-        global priors
-        if p.exists():
-            priors = json.loads(p.read_text(encoding="utf-8"))
-        else:
-            priors = {}
-        brain.priors = priors
-        logger.info("Loaded priors from cleaned_data.json")
-    except Exception as e:
-        logger.warning("Could not load priors on startup: %s", e)
-
-
-@app.on_event("shutdown")
-async def on_shutdown():
-    logger.info("Shutdown complete")
-
-
+# —— Main ————————————————————————————————————————————————————————————————————
 def run_api() -> None:
     port = int(os.getenv("PORT", "10000"))
     logger.info("Starting API on port %d", port)
     uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
-
 
 if __name__ == "__main__":
     run_api()

--- a/app.py
+++ b/app.py
@@ -66,12 +66,15 @@ async def debug_priors():
     return priors
 
 @app.on_event("startup")
-async def check_prior_cache():
-    cache_file = Path("samples/prior.npy")
-    if cache_file.exists():
-        logger.info("[PRIOR] 🔷 cached prior detected at startup (%s)", cache_file)
+async def check_prior_and_prewarm():
+    cache = Path("samples/prior.npy")
+    if cache.exists():
+        logger.info("[PRIOR] 🔷 cached prior detected at startup (%s)", cache)
     else:
-        logger.info("[PRIOR] 🔶 NO prior.npy at startup, will scan ZIP on first request")
+        logger.info("[PRIOR] 🔶 prior.npy not found at startup")
+        logger.info("[PRIOR] 🔶 scanning ZIP now…")
+        # 直接 call 一次 compute_position_probabilities() 觸發掃描
+        compute_position_probabilities("samples", ROWS, COLS)
 # ==== Schemas ==============================================================
 class GridRequest(BaseModel):
     grid: List[List[int]]

--- a/app.py
+++ b/app.py
@@ -65,7 +65,13 @@ async def pre_startup():  # FIXME rename to avoid F811 duplicate
 async def debug_priors():
     return priors
 
-
+@app.on_event("startup")
+async def check_prior_cache():
+    cache_file = Path("samples/prior.npy")
+    if cache_file.exists():
+        logger.info("[PRIOR] 🔷 cached prior detected at startup (%s)", cache_file)
+    else:
+        logger.info("[PRIOR] 🔶 NO prior.npy at startup, will scan ZIP on first request")
 # ==== Schemas ==============================================================
 class GridRequest(BaseModel):
     grid: List[List[int]]

--- a/app.py
+++ b/app.py
@@ -12,9 +12,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, status
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
-from pydantic import BaseModel
+皮膚from pydantic import BaseModel
 from analyzer import compute_position_probabilities
 import brain
 # fmt: off
@@ -66,15 +65,12 @@ async def debug_priors():
     return priors
 
 @app.on_event("startup")
-async def check_prior_and_prewarm():
-    cache = Path("samples/prior.npy")
-    if cache.exists():
-        logger.info("[PRIOR] 🔷 cached prior detected at startup (%s)", cache)
+async def check_prior_cache():
+    cache_file = Path("samples/prior.npy")
+    if cache_file.exists():
+        logger.info("[PRIOR] 🔷 cached prior detected at startup (%s)", cache_file)
     else:
-        logger.info("[PRIOR] 🔶 prior.npy not found at startup")
-        logger.info("[PRIOR] 🔶 scanning ZIP now…")
-        # 直接 call 一次 compute_position_probabilities() 觸發掃描
-        compute_position_probabilities("samples", ROWS, COLS)
+        logger.info("[PRIOR] 🔶 NO prior.npy at startup, will scan ZIP on first request")
 # ==== Schemas ==============================================================
 class GridRequest(BaseModel):
     grid: List[List[int]]

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from fastapi import FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel
-
+from analyzer import compute_position_probabilities
 import brain
 # fmt: off
 from analyzer import predict_scratch_card, probability_heatmap, render_heatmap

--- a/app.py
+++ b/app.py
@@ -12,9 +12,10 @@ from typing import Any, Dict, List, Optional, Union
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
-皮膚from pydantic import BaseModel
-from analyzer import compute_position_probabilities
+from pydantic import BaseModel
+
 import brain
 # fmt: off
 from analyzer import predict_scratch_card, probability_heatmap, render_heatmap
@@ -64,13 +65,7 @@ async def pre_startup():  # FIXME rename to avoid F811 duplicate
 async def debug_priors():
     return priors
 
-@app.on_event("startup")
-async def check_prior_cache():
-    cache_file = Path("samples/prior.npy")
-    if cache_file.exists():
-        logger.info("[PRIOR] 🔷 cached prior detected at startup (%s)", cache_file)
-    else:
-        logger.info("[PRIOR] 🔶 NO prior.npy at startup, will scan ZIP on first request")
+
 # ==== Schemas ==============================================================
 class GridRequest(BaseModel):
     grid: List[List[int]]

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import ray
 
 # fmt: off
 # isort: off
+import analyzer
 from analyzer import (
     probability_heatmap,
     predict_scratch_card,
@@ -59,8 +60,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Phase-2 focused iteration count",
     )
-    parser.add_argument("--top-n", type=int, default=10, help="Top cells to refine")
-    parser.add_argument("--epsilon", type=float, default=0.05, help="Exploration rate")
+    parser.add_argument(
+        "--top-n", type=int, default=10, help="Top cells to refine"
+    )
+    parser.add_argument(
+        "--epsilon", type=float, default=0.05, help="Exploration rate"
+    )
     parser.add_argument(
         "--target", type=int, default=None, help="Target number to predict"
     )
@@ -102,7 +107,9 @@ def parse_grid(grid_str: str) -> List[List[int]]:
             raise ValueError("Grid must be a 2D matrix")
         r, c = grid_np.shape
         if r < 2 or c < 2:
-            raise ValueError("Grid must be at least 2x2 with consistent row length")
+            raise ValueError(
+                "Grid must be at least 2x2 with consistent row length"
+            )
         return grid_np.tolist()
     except ValueError as e:
         logging.error(f"Invalid grid format: {e}")
@@ -113,7 +120,9 @@ def main():
     """Main function to run scratch card prediction."""
     args = parse_args()
     try:
-        subprocess.run(["python", "excel_cleaner_and_formatter.py"], check=True)
+        subprocess.run(
+            ["python", "excel_cleaner_and_formatter.py"], check=True
+        )
         p = Path("output/cleaned_data.json")
         global priors
         if p.exists():
@@ -172,7 +181,9 @@ def main():
             logging.info(
                 f"Cell ({pred['row']}, {pred['col']}): {pred['candidates']} with probability {pred['probability']:.2f}%"
             )
-        logging.info("Full probabilities available in result['full_probabilities']")
+        logging.info(
+            "Full probabilities available in result['full_probabilities']"
+        )
         logging.info("Complete!")
         return result
     except (ValueError, Exception) as e:
@@ -181,4 +192,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) == 4 and sys.argv[1] == "dump_prior":
+        analyzer.dump_prior(sys.argv[2], sys.argv[3])
+    else:
+        main()

--- a/tests/test_prior_load.py
+++ b/tests/test_prior_load.py
@@ -1,0 +1,23 @@
+import json
+import zipfile
+
+import numpy as np
+
+import analyzer
+
+
+def test_prior_load(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    grid = [[1, 2], [3, 4]]
+    data = {"rows": 2, "cols": 2, "grid": grid}
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("d.json", json.dumps(data))
+    cube = np.zeros((2, 2, 5), dtype=np.int64)
+    arr = np.array(grid)
+    rr, cc = np.indices(arr.shape)
+    mask = arr >= 1
+    np.add.at(cube, (rr[mask], cc[mask], arr[mask]), 1)
+    np.save(samples / "prior.npy", cube)
+    probs = analyzer.compute_position_probabilities(str(samples), 2, 2)
+    assert probs[(0, 0)][1] == 1.0


### PR DESCRIPTION
## Summary
- add offline prior cache loader and dump CLI helper
- summarize JSON load counts in logs
- provide test for prior cache

## Testing
- `isort analyzer.py main.py tests/test_prior_load.py --check --diff`
- `black analyzer.py main.py tests/test_prior_load.py --line-length 79`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb102eec88324a64f52005b044f8c