### PR TITLE
Add prior-module ranking and global distribution

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -55,9 +55,7 @@ def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
                 with zf.open(name) as f:
                     data = json.load(f)
             except Exception as exc:  # pragma: no cover - corrupted JSON
-                logger.error(
-                    "Failed to read %s:%s: %s", zip_path.name, name, exc
-                )
+                logger.error("Failed to read %s:%s: %s", zip_path.name, name, exc)
                 continue
             grid = data.get("grid")
             if not isinstance(grid, list) or not all(
@@ -68,9 +66,7 @@ def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
             rows = data.get("rows", len(grid))
             cols = data.get("cols", len(grid[0]) if grid else 0)
             if rows != len(grid) or any(len(r) != cols for r in grid):
-                logger.warning(
-                    "Row/col mismatch in %s:%s", zip_path.name, name
-                )
+                logger.warning("Row/col mismatch in %s:%s", zip_path.name, name)
                 continue
             count += 1
             yield {"rows": rows, "cols": cols, "grid": grid}
@@ -131,9 +127,7 @@ def compute_position_probabilities(
                     dist = cube[r, c].astype(float)
                     total = dist.sum() or 1.0
                     probs = {
-                        i: dist[i] / total
-                        for i in range(1, dist.size)
-                        if dist[i] > 0
+                        i: dist[i] / total for i in range(1, dist.size) if dist[i] > 0
                     }
                     prob_map[(r, c)] = probs
             return prob_map
@@ -172,12 +166,47 @@ def compute_position_probabilities(
     return prob_map
 
 
+@lru_cache(maxsize=8)
+def compute_global_distribution(samples_dir: str, rows: int, cols: int) -> np.ndarray:
+    """Return per-cell number probability cube from history samples."""
+    cached = Path(samples_dir) / "prior.npy"
+    if cached.exists():
+        cube = np.load(cached, mmap_mode="r")
+        if cube.shape[:2] != (rows, cols):
+            logger.warning("Cached prior shape mismatch: %s", cube.shape)
+        else:
+            logger.info("Loaded prior cube from %s", cached)
+            totals = cube.sum(axis=2, keepdims=True)
+            totals[totals == 0] = 1
+            return cube.astype(float) / totals
+
+    counts = np.zeros((rows, cols, rows * cols + 1), dtype=np.int64)
+    total = 0
+    for sample in iter_sample_jsons(samples_dir):
+        if sample["rows"] != rows or sample["cols"] != cols:
+            continue
+        total += 1
+        grid = np.asarray(sample["grid"], dtype=int)
+        mask = (grid >= 1) & (grid <= rows * cols)
+        rr, cc = np.indices(grid.shape)
+        np.add.at(counts, (rr[mask], cc[mask], grid[mask]), 1)
+
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    probs = counts.astype(float) / totals
+    logger.info(
+        "Global distribution for %d×%d processed %d samples",
+        rows,
+        cols,
+        total,
+    )
+    return probs
+
+
 # Count-Min Sketch (optimized for low memory)
 class CountMinSketch:
     def __init__(self, width: int = 1024, depth: int = 1):
-        self.w = max(
-            1024, min(2048, int(8e9 / (depth * 4)))
-        )  # 8 GB RAM 動態調整
+        self.w = max(1024, min(2048, int(8e9 / (depth * 4))))  # 8 GB RAM 動態調整
         self.d = depth
         self.table = np.zeros((depth, self.w), dtype=np.uint32)
         self.seeds = [i * 0x9E3779B1 for i in range(depth)]
@@ -190,9 +219,7 @@ class CountMinSketch:
             self.table[i, self._idx(key, s)] += value
 
     def query(self, key: bytes) -> int:
-        return min(
-            self.table[i, self._idx(key, s)] for i, s in enumerate(self.seeds)
-        )
+        return min(self.table[i, self._idx(key, s)] for i, s in enumerate(self.seeds))
 
 
 def pack_key(cell_idx: int, num: int) -> bytes:
@@ -201,9 +228,7 @@ def pack_key(cell_idx: int, num: int) -> bytes:
 
 # Precompute skip scores with LRU cache
 @lru_cache(maxsize=1024)
-def precompute_skip_scores(
-    grid_bytes: bytes, rows: int, cols: int
-) -> np.ndarray:
+def precompute_skip_scores(grid_bytes: bytes, rows: int, cols: int) -> np.ndarray:
     grid = bytes_to_grid(grid_bytes, (rows, cols))
     return EXT_GM20_Skip_Pattern_Confidence_Vec(grid)
 
@@ -244,17 +269,14 @@ if __name__ == "__main__":  # pragma: no cover - CLI helper
         dump_prior(sys.argv[1], sys.argv[2])
 
 
-def select_modules(
-    grid: np.ndarray, target: Optional[int] = None
-) -> List[str]:
+def select_modules(grid: np.ndarray, target: Optional[int] = None) -> List[str]:
     """Select up to ``CORE_LIMIT`` modules based on weights and scores."""
     if os.getenv("FORCE_FULL_SCAN", "0") == "1":
         mods = list(REGISTERED_MODULES_BRAIN)
     else:
         base_modules = brain.get_core_modules()
         scores = {
-            m: np.mean(get_module_score(m, grid, target=target))
-            for m in base_modules
+            m: np.mean(get_module_score(m, grid, target=target)) for m in base_modules
         }
         mods = sorted(scores, key=scores.get, reverse=True)
 
@@ -308,9 +330,7 @@ def _cached_board(
     return board
 
 
-def fill_unknowns_randomly(
-    grid: np.ndarray, rng: np.random.Generator
-) -> np.ndarray:
+def fill_unknowns_randomly(grid: np.ndarray, rng: np.random.Generator) -> np.ndarray:
     """Fill -1 cells in ``grid`` with a random permutation of remaining numbers."""
     g = np.asarray(grid, dtype=int).copy()
     blanks = np.argwhere(g == -1)
@@ -404,9 +424,7 @@ def simulate_full_board(
         axis=0,
     )
     importance_weights = np.where(g == -1, module_scores, 0).flatten()
-    importance_weights = importance_weights / (
-        np.sum(importance_weights) + 1e-10
-    )
+    importance_weights = importance_weights / (np.sum(importance_weights) + 1e-10)
 
     # Dynamic formula weights based on grid pattern
     history = {"random_entropy": 0.4, "shuffle": 0.3, "tail_cluster": 0.3}
@@ -420,30 +438,22 @@ def simulate_full_board(
     counts = defaultdict(lambda: defaultdict(int))
     focus_set = {tuple(fc) for fc in focus_cells} if focus_cells else None
     other_cells = (
-        [tuple(b) for b in blanks if tuple(b) not in focus_set]
-        if focus_set
-        else []
+        [tuple(b) for b in blanks if tuple(b) not in focus_set] if focus_set else []
     )
 
     while remain > 0:
         batch = min(4000, remain)
-        boards = generate_full_boards(
-            rows, cols, batch, rng, formulas, weights, g
-        )
+        boards = generate_full_boards(rows, cols, batch, rng, formulas, weights, g)
 
         if known.size:
-            mask = np.all(
-                boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1
-            )
+            mask = np.all(boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1)
             boards = boards[mask]
             if len(boards) == 0:
                 batch = min(batch * 2, 8000)
                 boards = generate_full_boards(
                     rows, cols, batch, rng, formulas, weights, g
                 )
-                mask = np.all(
-                    boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1
-                )
+                mask = np.all(boards[:, known[:, 0], known[:, 1]] == known_vals, axis=1)
                 boards = boards[mask]
 
         if len(boards) > 0:
@@ -465,11 +475,7 @@ def simulate_full_board(
                 soft_fast /= soft_fast.sum() + 1e-10
                 fast = soft_fast
                 cells_iter = blanks if focus_set is None else focus_set
-                if (
-                    focus_set is not None
-                    and other_cells
-                    and rng.random() < epsilon
-                ):
+                if focus_set is not None and other_cells and rng.random() < epsilon:
                     cells_iter = list(focus_set) + [
                         other_cells[int(rng.integers(len(other_cells)))]
                     ]
@@ -525,9 +531,7 @@ def simulate_full_board(
         final_prob_map[(r, c)][num] = final_score
 
     # 來自 probmap_key_patch_v2.txt
-    prob_map = {
-        (int(r), int(c)): cell for (r, c), cell in final_prob_map.items()
-    }
+    prob_map = {(int(r), int(c)): cell for (r, c), cell in final_prob_map.items()}
 
     # --- 保證所有格都有 entry ------------------------------
     if os.getenv("FORCE_FULL_SCAN", "0") == "1":
@@ -552,8 +556,7 @@ def weight_prob_by_modules(
     result = prob_map.copy()
     modules = select_modules(grid, target=target_num)
     module_scores = Parallel(n_jobs=4)(
-        delayed(get_module_score)(mod, grid, target=target_num)
-        for mod in modules
+        delayed(get_module_score)(mod, grid, target=target_num) for mod in modules
     )
     module_scores = np.array(module_scores)
 
@@ -580,6 +583,47 @@ def weight_prob_by_modules(
             result[(r, c)] = {k: v / total for k, v in probs.items()}
 
     return _native_dict(result)
+
+
+def rank_cells_by_prior_and_modules(
+    grid: np.ndarray,
+    prior_cube: np.ndarray,
+    modules: List[str],
+    module_weights: Optional[List[float]] = None,
+    *,
+    target_num: int,
+    w_prior: float = 0.5,
+) -> List[Tuple[int, int, float]]:
+    """Return top-3 unknown cells ranked by fused prior and module scores."""
+
+    rows, cols = grid.shape
+    if prior_cube.shape[:2] != (rows, cols):
+        raise ValueError("prior cube shape mismatch")
+
+    if module_weights is None:
+        module_weights = [1.0] * len(modules)
+    if len(module_weights) != len(modules):
+        raise ValueError("weights length mismatch")
+
+    agg = np.zeros((rows, cols), dtype=float)
+    for mod, w in zip(modules, module_weights):
+        agg += w * get_module_score(mod, grid, target=target_num)
+
+    prior_k = (
+        prior_cube[:, :, target_num]
+        if prior_cube.shape[2] > target_num
+        else np.zeros((rows, cols), dtype=float)
+    )
+    final = w_prior * prior_k + (1.0 - w_prior) * agg
+
+    results = [
+        (int(r), int(c), float(final[r, c]))
+        for r in range(rows)
+        for c in range(cols)
+        if grid[r, c] == -1
+    ]
+    results.sort(key=lambda x: x[2], reverse=True)
+    return results[:3]
 
 
 def assign_unique_numbers(
@@ -736,9 +780,7 @@ def mcts(grid: np.ndarray, iterations: int = 1000):
     Parallel(n_jobs=4, require="sharedmem")(
         delayed(simulate)(root) for _ in range(iterations // 4)
     )
-    best_child = max(
-        root.children, key=lambda c: c.value / c.visits, default=root
-    )
+    best_child = max(root.children, key=lambda c: c.value / c.visits, default=root)
     return best_child.grid
 
 
@@ -799,9 +841,7 @@ def predict_scratch_card(
     final_score_map = (weights[:, None, None] * score_stack).sum(axis=0)
     if gamma_history > 0.0 and target_num is not None:
         try:
-            hist = compute_history_frequency(
-                history_dir, target_num, rows, cols
-            )
+            hist = compute_history_frequency(history_dir, target_num, rows, cols)
             if hist.max() > 0:
                 final_score_map += gamma_history * (hist / float(hist.max()))
         except Exception as exc:  # pragma: no cover - history load failures
@@ -851,9 +891,7 @@ def predict_scratch_card(
         key=lambda x: x[2],
         reverse=True,
     )
-    focus_cells = [
-        (r, c) for r, c, _ in ranked[: max(1, min(top_n, len(ranked)))]
-    ]
+    focus_cells = [(r, c) for r, c, _ in ranked[: max(1, min(top_n, len(ranked)))]]
 
     if phase2 > 0:
         refine_map = simulate_full_board(
@@ -910,17 +948,14 @@ def predict_scratch_card(
                 "row": r,
                 "col": c,
                 "candidates": [target_num],
-                "probability": prob_map.get((r, c), {}).get(target_num, 0.0)
-                * 100,
+                "probability": prob_map.get((r, c), {}).get(target_num, 0.0) * 100,
             }
             for r, c in prob_map.keys()
         ]  # 改用 .get()
         rank.sort(key=lambda x: x["probability"], reverse=True)
 
         module_scores = {
-            mod: get_module_score(
-                mod, grid_np, priors=priors, target=target_num
-            )
+            mod: get_module_score(mod, grid_np, priors=priors, target=target_num)
             for mod, _ in modules
         }
         for pred in rank[:3]:
@@ -971,9 +1006,7 @@ def predict_scratch_card(
                 max(
                     weight_prob_by_modules(  # <<< 你自己已有的函式
                         best_grid,  # - 當前最佳棋盤
-                        {
-                            (r, c): prob_map.get((r, c), {})
-                        },  # - 只帶單一候選格的機率
+                        {(r, c): prob_map.get((r, c), {})},  # - 只帶單一候選格的機率
                     )
                     .get((r, c), {})
                     .values(),  # 取回各模組加權後的機率們
@@ -999,9 +1032,7 @@ def predict_scratch_card(
             mode = "mcts_unique"
 
         module_scores = {
-            mod: get_module_score(
-                mod, grid_np, priors=priors, target=target_num
-            )
+            mod: get_module_score(mod, grid_np, priors=priors, target=target_num)
             for mod, _ in modules
         }
         for pred in preds[:3]:
@@ -1056,9 +1087,7 @@ def predict_scratch_card(
         for mod, score, desc in top_modules:
             if score > 0.5:
                 reasons.append(f"{desc} (score: {score:.2f})")
-        pred["reasons"] = (
-            reasons if reasons else ["No dominant module contribution"]
-        )
+        pred["reasons"] = reasons if reasons else ["No dominant module contribution"]
         pred["module_scores"] = {
             mod: float(module_scores[mod][pred["row"], pred["col"]])
             for mod, _ in modules
@@ -1137,9 +1166,7 @@ def monte_carlo_prob_map(
     if k is not None:
         counts = np.zeros((rows, cols), dtype=int)
     else:
-        counts = {
-            int(val): np.zeros((rows, cols), dtype=int) for val in remain
-        }
+        counts = {int(val): np.zeros((rows, cols), dtype=int) for val in remain}
 
     for _ in range(max(1, n_iter)):
         sample = rng.permutation(remain)

--- a/tests/test_prior_module_rank.py
+++ b/tests/test_prior_module_rank.py
@@ -1,0 +1,48 @@
+import json
+import zipfile
+
+import numpy as np
+
+import analyzer
+
+
+def _make_samples(path):
+    data1 = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    data2 = {"rows": 2, "cols": 2, "grid": [[2, 1], [4, 3]]}
+    with zipfile.ZipFile(path / "s.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps(data1))
+        zf.writestr("b.json", json.dumps(data2))
+
+
+def test_compute_global_distribution(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    _make_samples(samples)
+    cube = analyzer.compute_global_distribution(str(samples), 2, 2)
+    assert cube.shape == (2, 2, 5)
+    assert abs(cube[0, 0, 1] - 0.5) < 1e-6
+    assert cube[1, 1, 1] == 0.0
+    for r in range(2):
+        for c in range(2):
+            total = cube[r, c, 1:].sum()
+            assert abs(total - 1.0) < 1e-6
+
+
+def test_rank_cells_by_prior_and_modules(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    _make_samples(samples)
+    cube = analyzer.compute_global_distribution(str(samples), 2, 2)
+    grid = np.array([[-1, 2], [3, -1]])
+    mods = ["EXT_Q1_ProximityEntropy_Vec"]
+    ranks = analyzer.rank_cells_by_prior_and_modules(
+        grid,
+        cube,
+        mods,
+        [1.0],
+        target_num=1,
+        w_prior=1.0,
+    )
+    assert ranks[0][:2] == (0, 0)
+    assert len(ranks) == 2
+    assert all(grid[r, c] == -1 for r, c, _ in ranks)


### PR DESCRIPTION
## Summary
- implement `compute_global_distribution` to load prior probabilities
- add `rank_cells_by_prior_and_modules` to fuse prior and module scores
- test new prior+module ranking logic

## Testing
- `black --check analyzer.py tests/test_prior_module_rank.py`
- `isort --check analyzer.py tests/test_prior_module_rank.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_prior_module_rank.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686020af1f40832487848ee1f36b2221