### PR TITLE
Normalize fused scores before ranking

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -616,11 +616,15 @@ def rank_cells_by_prior_and_modules(
     )
     final = w_prior * prior_k + (1.0 - w_prior) * agg
 
+    mask = grid == -1
+    total = final[mask].sum() or 1.0
+    final[mask] = final[mask] / total
+
     results = [
-        (int(r), int(c), float(final[r, c]))
+        (int(r), int(c), float(final[r, c] * 100.0))
         for r in range(rows)
         for c in range(cols)
-        if grid[r, c] == -1
+        if mask[r, c]
     ]
     results.sort(key=lambda x: x[2], reverse=True)
     return results[:3]

--- a/tests/test_prior_module_rank.py
+++ b/tests/test_prior_module_rank.py
@@ -46,3 +46,34 @@ def test_rank_cells_by_prior_and_modules(tmp_path):
     assert ranks[0][:2] == (0, 0)
     assert len(ranks) == 2
     assert all(grid[r, c] == -1 for r, c, _ in ranks)
+
+
+def test_rank_cells_normalization(tmp_path, monkeypatch):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps(data))
+    cube = analyzer.compute_global_distribution(str(samples), 2, 2)
+
+    grid = np.array([[-1, -1], [3, -1]])
+
+    monkeypatch.setattr(
+        analyzer,
+        "get_module_score",
+        lambda mod, g, target=None: np.ones_like(g, dtype=float),
+    )
+
+    ranks = analyzer.rank_cells_by_prior_and_modules(
+        grid,
+        cube,
+        ["DUMMY"],
+        [1.0],
+        target_num=1,
+        w_prior=0.5,
+    )
+
+    total_prob = sum(p / 100.0 for _, _, p in ranks)
+    assert abs(total_prob - 1.0) < 1e-6
+    assert ranks[0][2] < 100.0
+    assert ranks[0][2] >= ranks[1][2] >= ranks[2][2]


### PR DESCRIPTION
## Summary
- normalize fused scores across unknown cells to prevent 100% ties
- return probabilities as percentages
- test normalization in `rank_cells_by_prior_and_modules`

## Testing
- `black analyzer.py tests/test_prior_module_rank.py --check`
- `isort --check-only analyzer.py tests/test_prior_module_rank.py`
- `flake8 analyzer.py tests/test_prior_module_rank.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68602e03028c8324a568a197764724b3