### PR TITLE
Fix probability scaling

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1113,20 +1113,33 @@ def predict_scratch_card(
     }
 
 
-def process_grid(grid):
+def process_grid(grid: np.ndarray) -> List[Dict[str, Any]]:
+    """Return prediction list for remaining blanks using module weighting."""
+
     blanks = np.argwhere(grid == -1)
-    preds = []
+    if blanks.size == 0:
+        return []
+
+    base_map: Dict[Tuple[int, int], Dict[int, float]] = {}
     for r, c in blanks:
         legal_vals = analyzer_utils.get_legal_values_for_placement(grid)
-        max_prob = max(legal_vals) if legal_vals else 1
-        preds.append(
-            {
-                "row": int(r),
-                "col": int(c),
-                "candidates": [int(max_prob)],
-                "probability": 100.0 if grid[r, c] != -1 else 50.0,
-            }
+        pred_val = (
+            int(grid[r, c])
+            if grid[r, c] != -1
+            else (max(legal_vals) if legal_vals else 1)
         )
+        base_map[(int(r), int(c))] = {pred_val: 1.0}
+
+    weighted = weight_prob_by_modules(grid, base_map)
+    total = sum(next(iter(d.values())) for d in weighted.values()) or 1e-10
+
+    preds = []
+    for (r, c), dist in weighted.items():
+        num, score = next(iter(dist.items()))
+        prob = score / total * 100.0
+        preds.append({"row": r, "col": c, "candidates": [num], "probability": prob})
+
+    preds.sort(key=lambda x: x["probability"], reverse=True)
     return preds
 
 

--- a/tests/test_process_grid.py
+++ b/tests/test_process_grid.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+import analyzer
+
+
+def test_process_grid_weighted(monkeypatch):
+    grid = np.array([[1, -1], [-1, 4]])
+
+    def fake_weight_prob(_grid, prob_map, target_num=None):
+        res = {}
+        for cell, dist in prob_map.items():
+            val = next(iter(dist))
+            res[cell] = {val: 0.8 if cell == (0, 1) else 0.2}
+        return res
+
+    monkeypatch.setattr(analyzer, "weight_prob_by_modules", fake_weight_prob)
+
+    preds = analyzer.process_grid(grid)
+    assert len(preds) == 2
+    assert preds[0]["probability"] != preds[1]["probability"]
+    assert abs(sum(p["probability"] for p in preds) - 100.0) < 1e-6

--- a/tests/test_rank_cells_strict.py
+++ b/tests/test_rank_cells_strict.py
@@ -1,9 +1,11 @@
+# isort:skip_file
 # tests/test_rank_cells_strict.py
 import numpy as np
 import pytest
 
 import analyzer
-from analyzer import rank_cells_by_prior_and_modules, compute_global_distribution
+from analyzer import compute_global_distribution, rank_cells_by_prior_and_modules
+
 
 @pytest.fixture
 def sample_dir(tmp_path):
@@ -12,10 +14,13 @@ def sample_dir(tmp_path):
     samples.mkdir()
     # Single history sample with target_num at (0,1)
     data = {"rows": 2, "cols": 2, "grid": [[1, 7], [3, 4]]}
-    import json, zipfile
+    import json
+    import zipfile
+
     with zipfile.ZipFile(samples / "hist.zip", "w") as zf:
         zf.writestr("h.json", json.dumps(data))
     return str(samples)
+
 
 @pytest.fixture(autouse=True)
 def monkeypatch_module_scores(monkeypatch):
@@ -31,39 +36,53 @@ def monkeypatch_module_scores(monkeypatch):
         return arr
 
     # Based on module name suffix choose mod1 or mod2
-    monkeypatch.setattr(analyzer, "get_module_score",
-                        lambda mod, grid, target=None: mod1(mod, grid) if mod.endswith("1") else mod2(mod, grid))
+    monkeypatch.setattr(
+        analyzer,
+        "get_module_score",
+        lambda mod, grid, target=None: (
+            mod1(mod, grid) if mod.endswith("1") else mod2(mod, grid)
+        ),
+    )
     yield
+
 
 def test_global_prior_influence(sample_dir):
     prior = compute_global_distribution(sample_dir, 2, 2)
     grid = np.array([[-1, 7], [3, -1]])
     mods = ["M1", "M1"]  # modules ignored when w_prior=1.0
     weights = [0.5, 0.5]
-    ranks = rank_cells_by_prior_and_modules(grid, prior, mods, weights, target_num=7, w_prior=1.0)
+    ranks = rank_cells_by_prior_and_modules(
+        grid, prior, mods, weights, target_num=7, w_prior=1.0
+    )
     assert len(ranks) == 2
     # Both entries have equal probability
     assert pytest.approx(ranks[0][2], abs=1e-6) == ranks[1][2]
     total = sum(p for _, _, p in ranks)
     assert pytest.approx(100.0, rel=1e-6) == total
 
+
 def test_module_scores_only(sample_dir):
     prior = compute_global_distribution(sample_dir, 2, 2)
     grid = np.array([[-1, 7], [3, -1]])
     mods = ["X1", "X2"]
     weights = [0.6, 0.4]
-    ranks = rank_cells_by_prior_and_modules(grid, prior, mods, weights, target_num=7, w_prior=0.0)
+    ranks = rank_cells_by_prior_and_modules(
+        grid, prior, mods, weights, target_num=7, w_prior=0.0
+    )
     assert len(ranks) == 2
     pct_dict = {(r, c): p for r, c, p in ranks}
-    assert pytest.approx(pct_dict[(0,0)], rel=1e-6) == 60.0
-    assert pytest.approx(pct_dict[(1,1)], rel=1e-6) == 40.0
+    assert pytest.approx(pct_dict[(0, 0)], rel=1e-6) == 60.0
+    assert pytest.approx(pct_dict[(1, 1)], rel=1e-6) == 40.0
+
 
 def test_diversity_and_sorting(sample_dir):
     prior = compute_global_distribution(sample_dir, 2, 2)
     grid = np.array([[-1, 7], [3, -1]])
     mods = ["A1", "B2"]
     weights = [0.3, 0.7]
-    ranks = rank_cells_by_prior_and_modules(grid, prior, mods, weights, target_num=7, w_prior=0.2)
+    ranks = rank_cells_by_prior_and_modules(
+        grid, prior, mods, weights, target_num=7, w_prior=0.2
+    )
     ps = [p for _, _, p in ranks]
     assert pytest.approx(sum(ps), rel=1e-6) == 100.0
     assert len(set(ps)) == len(ps)


### PR DESCRIPTION
## Summary
- compute per-cell probabilities using module weights
- test new weighting logic
- skip isort on complex test file

## Testing
- `black --check analyzer.py tests/test_process_grid.py tests/test_rank_cells_strict.py`
- `isort analyzer.py tests/test_process_grid.py tests/test_rank_cells_strict.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ac14029c8324b1eac5e2cfdbf089