### PR TITLE
Add debug logs and restart steps

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -355,6 +355,13 @@ def generate_full_boards(
     grid: np.ndarray,
 ) -> np.ndarray:
     """Generate batch of complete boards using weighted formulas with importance sampling."""
+    logger.debug(
+        "generate_full_boards rows=%d cols=%d batch=%d formulas=%s",
+        rows,
+        cols,
+        batch,
+        formulas,
+    )
     valid = [f for f in formulas if f in FORMULA_REGISTRY]
     if not valid:
         raise ValueError("No valid formulas available")
@@ -600,6 +607,12 @@ def rank_cells_by_prior_and_modules(
     w_prior: float = 0.5,
 ) -> List[Tuple[int, int, float]]:
     """Return top-3 unknown cells ranked by fused prior and module scores."""
+    logger.debug(
+        "rank_cells_by_prior_and_modules target=%s modules=%s w_prior=%.2f",
+        target_num,
+        modules,
+        w_prior,
+    )
 
     rows, cols = grid.shape
     if prior_cube.shape[:2] != (rows, cols):

--- a/app.py
+++ b/app.py
@@ -188,6 +188,7 @@ async def ping() -> Dict[str, str]:
     status_code=200,
 )
 async def predict(req: GridRequest):
+    logger.debug("/predict called with iterations=%s", req.iterations)
     try:
         # 格式校验
         if not req.grid or not all(isinstance(row, list) for row in req.grid):
@@ -315,6 +316,9 @@ async def on_shutdown():
 
 def run_api() -> None:
     port = int(os.getenv("PORT", "10000"))
+    # Clean cached bytecode and restart any lingering uvicorn instances
+    subprocess.run("find . -name '*.pyc' -delete", shell=True, check=False)
+    subprocess.run(["pkill", "-f", "uvicorn"], check=False)
     logger.info("Starting API on port %d", port)
     uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,8 @@ import json
 import logging
 import zipfile
 
+import numpy as np
+
 import analyzer
 
 
@@ -23,3 +25,38 @@ def test_top3_logging(caplog):
         analyzer.predict_scratch_card(grid, iterations=2, global_iter=1, focus_iter=1)
     # 這行不動，如果你 log 真的有 "prob_map top3"
     assert any("prob_map top3" in r.message for r in caplog.records)
+
+
+def test_generate_full_boards_debug(caplog, make_grid):
+    grid = np.array(make_grid(2, 2))
+    rng = np.random.default_rng(0)
+    with caplog.at_level(logging.DEBUG):
+        analyzer.generate_full_boards(
+            2,
+            2,
+            1,
+            rng,
+            ("random_entropy",),
+            np.array([1.0]),
+            grid,
+        )
+    assert any("generate_full_boards" in r.message for r in caplog.records)
+
+
+def test_rank_cells_debug(caplog, tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    with zipfile.ZipFile(samples / "d.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps(data))
+    cube = analyzer.compute_global_distribution(str(samples), 2, 2)
+    grid = np.array([[-1, -1], [3, 4]])
+    with caplog.at_level(logging.DEBUG):
+        analyzer.rank_cells_by_prior_and_modules(
+            grid,
+            cube,
+            ["EXT_Q1_ProximityEntropy_Vec"],
+            [1.0],
+            target_num=1,
+        )
+    assert any("rank_cells_by_prior_and_modules" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add debug logs to `generate_full_boards` and `rank_cells_by_prior_and_modules`
- clean cached bytecode and stop existing `uvicorn` before starting API
- log when `/predict` is called
- test logging of new debug statements

## Testing
- `black --check app.py analyzer.py main.py brain.py modules.py tests/test_logging.py`
- `isort --check app.py analyzer.py main.py brain.py modules.py tests/test_logging.py`
- `flake8 app.py analyzer.py main.py brain.py modules.py tests/test_logging.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ca27ce9083249da3471016dc2485