### PR TITLE
Add top_predictions to /predict response

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -985,10 +985,12 @@ def predict_scratch_card(
                 for mod, _ in modules
             }
 
+        top_predictions = rank[:3]
         return {
             "mode": "target",
             "target": target_num,
             "predictions": _trim(rank),
+            "top_predictions": top_predictions,
             "full_probabilities": prob_map,
         }
 
@@ -1063,9 +1065,11 @@ def predict_scratch_card(
             }
 
         preds.sort(key=lambda x: x["probability"], reverse=True)
+        top_predictions = preds[:3]
         return {
             "mode": mode,
             "predictions": _trim(preds),
+            "top_predictions": top_predictions,
             "full_probabilities": prob_map,
         }
 
@@ -1106,9 +1110,11 @@ def predict_scratch_card(
         key=lambda x: x["probability"][0] if x["probability"] else 0,
         reverse=True,
     )
+    top_predictions = preds[:3]
     return {
         "mode": "top3",
         "predictions": _trim(preds),
+        "top_predictions": top_predictions,
         "full_probabilities": prob_map,
     }
 

--- a/app.py
+++ b/app.py
@@ -92,6 +92,7 @@ class Prediction(BaseModel):
 
 class PredictResponse(BaseModel):
     predictions: List[Prediction]
+    top_predictions: List[Prediction]
     full_probabilities: Dict[str, Dict[str, float]]
 
 
@@ -237,6 +238,7 @@ async def predict(req: GridRequest):
 
         payload = {
             "predictions": result.get("predictions", []),
+            "top_predictions": result.get("top_predictions", []),
             "full_probabilities": clean_probs,
             "sample_gamma_used": req.sample_gamma or 0.0,
         }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,7 @@ def test_predict_basic(client):
 
     assert resp.status_code == 200
     assert isinstance(body.get("predictions"), list) and len(body["predictions"]) > 0
+    assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
 
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -40,6 +40,7 @@ def test_predict_valid_grid():
     assert res.status_code == 200
     body = res.json()
     assert "predictions" in body
+    assert "top_predictions" in body
     assert "full_probabilities" in body
     assert isinstance(body["predictions"], list)
 


### PR DESCRIPTION
## Summary
- expose `top_predictions` from `predict_scratch_card`
- update API response model and handler
- adjust tests to expect `top_predictions`

## Testing
- `black --check app.py main.py analyzer.py brain.py modules.py tests/test_api.py tests/test_predict.py`
- `isort --check app.py main.py analyzer.py brain.py modules.py tests/test_api.py tests/test_predict.py`
- `flake8 app.py main.py analyzer.py brain.py modules.py tests/test_api.py tests/test_predict.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68612239b3e88324b23ecbca8d6aa9fb