### PR TITLE
Implement fused recommendations

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -590,6 +590,41 @@ def weight_prob_by_modules(
     return _native_dict(result)
 
 
+def fuse_prob_with_scores(
+    prob_map: Dict[Tuple[int, int], Dict[int, float]],
+    module_map: np.ndarray,
+    *,
+    blanks: List[Tuple[int, int]],
+    alpha: float = 0.5,
+    pseudo_count: float = 1.0,
+) -> List[Tuple[int, int, float]]:
+    """Fuse module scores with probability map and return ranked cells."""
+
+    if not blanks:
+        return []
+
+    rows, cols = module_map.shape
+    ms = module_map.astype(float)
+    ms_min, ms_max = ms.min(), ms.max()
+    if ms_max > ms_min:
+        ms = (ms - ms_min) / (ms_max - ms_min)
+    else:
+        ms.fill(0.5)
+
+    p_best = np.zeros((rows, cols), dtype=float)
+    for (r, c), dist in prob_map.items():
+        if dist:
+            p_best[r, c] = max(dist.values())
+
+    uniform = 1.0 / float(len(blanks))
+    p_smooth = (p_best + pseudo_count * uniform) / (1.0 + pseudo_count)
+    final = alpha * ms + (1.0 - alpha) * p_smooth
+
+    ranking = [(int(r), int(c), float(final[r, c])) for r, c in blanks]
+    ranking.sort(key=lambda x: x[2], reverse=True)
+    return ranking
+
+
 def rank_cells_by_prior_and_modules(
     grid: np.ndarray,
     prior_cube: np.ndarray,
@@ -812,6 +847,8 @@ def predict_scratch_card(
     history_dir: str = "samples",
     gamma_history: float = 0.0,
     sample_gamma: float = 0.0,
+    fusion_alpha: float = 0.5,
+    pseudo_count: float = 1.0,
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
     rows, cols = grid_np.shape
@@ -947,6 +984,14 @@ def predict_scratch_card(
     )[:3]
     logger.info("prob_map top3: %s", top3)
 
+    fused_rank = fuse_prob_with_scores(
+        prob_map,
+        final_score_map,
+        blanks=blanks,
+        alpha=fusion_alpha,
+        pseudo_count=pseudo_count,
+    )
+
     if target_num is not None:
         for key, p in prob_map.items():
             prob_map[key] = {target_num: p.get(target_num, 0.0)}
@@ -992,6 +1037,9 @@ def predict_scratch_card(
             "predictions": _trim(rank),
             "top_predictions": top_predictions,
             "full_probabilities": prob_map,
+            "final_recommendations": [
+                {"row": r, "col": c, "score": s} for r, c, s in fused_rank[:top_k]
+            ],
         }
 
     if unique and target_num is None:
@@ -1071,6 +1119,9 @@ def predict_scratch_card(
             "predictions": _trim(preds),
             "top_predictions": top_predictions,
             "full_probabilities": prob_map,
+            "final_recommendations": [
+                {"row": r, "col": c, "score": s} for r, c, s in fused_rank[:top_k]
+            ],
         }
 
     preds = []
@@ -1116,6 +1167,9 @@ def predict_scratch_card(
         "predictions": _trim(preds),
         "top_predictions": top_predictions,
         "full_probabilities": prob_map,
+        "final_recommendations": [
+            {"row": r, "col": c, "score": s} for r, c, s in fused_rank[:top_k]
+        ],
     }
 
 

--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ class GridRequest(BaseModel):
     epsilon: Optional[float] = None
     result_top_k: Optional[int] = None
     sample_gamma: Optional[float] = None
+    fusion_alpha: Optional[float] = None
 
 
 class Prediction(BaseModel):
@@ -90,10 +91,17 @@ class Prediction(BaseModel):
     module_scores: Dict[str, float]
 
 
+class CellScore(BaseModel):
+    row: int
+    col: int
+    score: float
+
+
 class PredictResponse(BaseModel):
     predictions: List[Prediction]
     top_predictions: List[Prediction]
     full_probabilities: Dict[str, Dict[str, float]]
+    final_recommendations: List[CellScore]
 
 
 class HeatmapRequest(BaseModel):
@@ -199,9 +207,14 @@ async def predict(req: GridRequest):
         top_n = req.top_n or PHASE2_TOP_N
         eps = req.epsilon or PHASE2_EPS
         top_k = req.result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
+        fusion_alpha = (
+            req.fusion_alpha
+            if req.fusion_alpha is not None
+            else float(os.getenv("FUSION_ALPHA", "0.5"))
+        )
 
         logger.info(
-            "Predict | size=%dx%d | target=%s | ph1=%d | ph2=%d | top_k=%d | top_n=%d | eps=%.3f",
+            "Predict | size=%dx%d | target=%s | ph1=%d | ph2=%d | top_k=%d | top_n=%d | eps=%.3f | alpha=%.2f",
             rows,
             cols,
             str(req.target_num),
@@ -210,6 +223,7 @@ async def predict(req: GridRequest):
             top_k,
             top_n,
             eps,
+            fusion_alpha,
         )
 
         # 调用核心推理
@@ -224,6 +238,7 @@ async def predict(req: GridRequest):
             result_top_k=top_k,
             priors=brain.priors_map[key],
             sample_gamma=req.sample_gamma or 0.0,
+            fusion_alpha=fusion_alpha,
         )
 
         # 清洗 full_probabilities
@@ -240,6 +255,7 @@ async def predict(req: GridRequest):
             "predictions": result.get("predictions", []),
             "top_predictions": result.get("top_predictions", []),
             "full_probabilities": clean_probs,
+            "final_recommendations": result.get("final_recommendations", []),
             "sample_gamma_used": req.sample_gamma or 0.0,
         }
         safe_payload = sanitize_floats(payload)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,6 +39,7 @@ def test_predict_basic(client):
     assert isinstance(body.get("predictions"), list) and len(body["predictions"]) > 0
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
+    assert isinstance(body.get("final_recommendations"), list)
 
 
 def test_heatmap_basic(client):

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -42,6 +42,7 @@ def test_predict_valid_grid():
     assert "predictions" in body
     assert "top_predictions" in body
     assert "full_probabilities" in body
+    assert "final_recommendations" in body
     assert isinstance(body["predictions"], list)
 
 


### PR DESCRIPTION
## Summary
- add function `fuse_prob_with_scores` to combine module and simulation scores
- expose `fusion_alpha` param in API
- return `final_recommendations` from `/predict`
- test the new response field

## Testing
- `black app.py analyzer.py main.py brain.py modules.py tests/*.py`
- `isort --check --filter-files app.py analyzer.py main.py brain.py modules.py tests/test_api.py tests/test_predict.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68612a17d6b48324ac05848a86bb61a9