### PR TITLE
Add fusion_alpha support

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -590,6 +590,28 @@ def weight_prob_by_modules(
     return _native_dict(result)
 
 
+def _compute_final_recommendations(
+    prob_map: Dict[Tuple[int, int], Dict[int, float]],
+    module_norm: np.ndarray,
+    target_num: Optional[int],
+    fusion_alpha: float,
+    top_k: int,
+) -> List[Dict[str, Any]]:
+    """Return fused ranking of cells based on probabilities and module scores."""
+    recs: List[Dict[str, Any]] = []
+    for (r, c), dist in prob_map.items():
+        if target_num is not None:
+            prob = dist.get(target_num, 0.0)
+        else:
+            prob = max(dist.values()) if dist else 0.0
+        score = fusion_alpha * float(module_norm[r, c]) + (1.0 - fusion_alpha) * float(
+            prob
+        )
+        recs.append({"row": int(r), "col": int(c), "score": score})
+    recs.sort(key=lambda x: x["score"], reverse=True)
+    return recs[:top_k]
+
+
 def rank_cells_by_prior_and_modules(
     grid: np.ndarray,
     prior_cube: np.ndarray,
@@ -812,6 +834,8 @@ def predict_scratch_card(
     history_dir: str = "samples",
     gamma_history: float = 0.0,
     sample_gamma: float = 0.0,
+    fusion_alpha: float = 0.5,
+    pseudo_count: float = 0.0,
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
     rows, cols = grid_np.shape
@@ -868,6 +892,17 @@ def predict_scratch_card(
                 final_score_map += sample_gamma * sample_map
         except Exception as exc:  # pragma: no cover - history load failures
             logger.error("position frequency failed: %s", exc)
+
+    mask = grid_np == -1
+    if mask.any():
+        sub = final_score_map[mask]
+        mn, mx = sub.min(), sub.max()
+        if mx - mn > 1e-9:
+            module_norm = (final_score_map - mn) / (mx - mn + 1e-9)
+        else:
+            module_norm = np.zeros_like(final_score_map)
+    else:
+        module_norm = np.zeros_like(final_score_map)
 
     phase1 = global_iter if global_iter is not None else iterations or 5000
     phase2 = focus_iter if focus_iter is not None else 1000
@@ -926,6 +961,17 @@ def predict_scratch_card(
         except Exception as exc:  # pragma: no cover - history load failures
             logger.error("position frequency blend failed: %s", exc)
 
+    if pseudo_count > 0.0 and priors:
+        for key, dist in prob_map.items():
+            prior = priors.get(key, {})
+            all_nums = set(dist) | set(prior)
+            new_d: Dict[int, float] = {}
+            for num in all_nums:
+                p_sim = dist.get(num, 0.0)
+                p_prior = prior.get(num, 0.0)
+                new_d[num] = (p_sim + pseudo_count * p_prior) / (1.0 + pseudo_count)
+            prob_map[key] = new_d
+
     # 后置正規化避免混權後機率失真
     for dist in prob_map.values():
         total = sum(dist.values()) or 1e-12
@@ -950,6 +996,10 @@ def predict_scratch_card(
     if target_num is not None:
         for key, p in prob_map.items():
             prob_map[key] = {target_num: p.get(target_num, 0.0)}
+
+    final_recs = _compute_final_recommendations(
+        prob_map, module_norm, target_num, fusion_alpha, top_k
+    )
 
     if target_num is not None:
         rank = [
@@ -992,6 +1042,7 @@ def predict_scratch_card(
             "predictions": _trim(rank),
             "top_predictions": top_predictions,
             "full_probabilities": prob_map,
+            "final_recommendations": final_recs,
         }
 
     if unique and target_num is None:
@@ -1071,6 +1122,7 @@ def predict_scratch_card(
             "predictions": _trim(preds),
             "top_predictions": top_predictions,
             "full_probabilities": prob_map,
+            "final_recommendations": final_recs,
         }
 
     preds = []
@@ -1116,6 +1168,7 @@ def predict_scratch_card(
         "predictions": _trim(preds),
         "top_predictions": top_predictions,
         "full_probabilities": prob_map,
+        "final_recommendations": final_recs,
     }
 
 

--- a/app.py
+++ b/app.py
@@ -79,6 +79,8 @@ class GridRequest(BaseModel):
     epsilon: Optional[float] = None
     result_top_k: Optional[int] = None
     sample_gamma: Optional[float] = None
+    fusion_alpha: Optional[float] = None
+    pseudo_count: Optional[float] = None
 
 
 class Prediction(BaseModel):
@@ -94,6 +96,7 @@ class PredictResponse(BaseModel):
     predictions: List[Prediction]
     top_predictions: List[Prediction]
     full_probabilities: Dict[str, Dict[str, float]]
+    final_recommendations: List[Dict[str, Any]]
 
 
 class HeatmapRequest(BaseModel):
@@ -224,6 +227,8 @@ async def predict(req: GridRequest):
             result_top_k=top_k,
             priors=brain.priors_map[key],
             sample_gamma=req.sample_gamma or 0.0,
+            fusion_alpha=req.fusion_alpha or 0.5,
+            pseudo_count=req.pseudo_count or 0.0,
         )
 
         # 清洗 full_probabilities
@@ -241,6 +246,7 @@ async def predict(req: GridRequest):
             "top_predictions": result.get("top_predictions", []),
             "full_probabilities": clean_probs,
             "sample_gamma_used": req.sample_gamma or 0.0,
+            "final_recommendations": result.get("final_recommendations", []),
         }
         safe_payload = sanitize_floats(payload)
         logger.info("✅ Response ready")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,6 +39,7 @@ def test_predict_basic(client):
     assert isinstance(body.get("predictions"), list) and len(body["predictions"]) > 0
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
+    assert isinstance(body.get("final_recommendations"), list)
 
 
 def test_heatmap_basic(client):

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -43,6 +43,7 @@ def test_predict_valid_grid():
     assert "top_predictions" in body
     assert "full_probabilities" in body
     assert isinstance(body["predictions"], list)
+    assert isinstance(body.get("final_recommendations"), list)
 
 
 def test_invalid_duplicate_numbers():


### PR DESCRIPTION
## Summary
- extend predict schema with `fusion_alpha` and `pseudo_count`
- return `final_recommendations` from `/predict`
- fuse heatmap probabilities with module scores
- test API and prediction for new field

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68612a17d6b48324ac05848a86bb61a9