### PR TITLE
Add detailed heatmap response

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1320,17 +1320,51 @@ def probability_heatmap(
     n_iter: int = 6000,
     *,
     seed: int = 0,
+    sample_gamma: float = 0.0,
+    history_dir: str = "samples",
 ) -> Union[np.ndarray, Dict[int, np.ndarray]]:
-    """Heatmap simulation using :func:`simulate_full_board`."""
+    """Heatmap simulation using :func:`simulate_full_board`.
+
+    Parameters
+    ----------
+    grid : List[List[int]] or np.ndarray
+        Board matrix with ``-1`` for unknown cells.
+    k : int or None
+        Target number to estimate.
+    n_iter : int
+        Simulation iterations.
+    seed : int
+        RNG seed for reproducibility.
+    sample_gamma : float
+        Weight for prior probabilities derived from ``history_dir``.
+    history_dir : str
+        Directory containing sample ``*.zip`` files.
+    """
 
     rng = np.random.default_rng(seed)
     grid_np = np.asarray(grid, dtype=int)
     prob_map_dict = simulate_full_board(grid_np, k, n_iter=n_iter, rng=rng)
 
+    if sample_gamma > 0.0 and k is not None:
+        try:
+            pos_probs = compute_position_probabilities(history_dir, *grid_np.shape)
+        except Exception as exc:  # pragma: no cover - history load failures
+            logger.error("heatmap prior load failed: %s", exc)
+            pos_probs = {}
+    else:
+        pos_probs = {}
+
     if k is not None:
         out = np.zeros_like(grid_np, dtype=float)
         for (r, c), cell in prob_map_dict.items():
-            out[r, c] = cell.get(k, 0.0)
+            val = cell.get(k, 0.0)
+            if pos_probs:
+                val = (1.0 - sample_gamma) * val + sample_gamma * pos_probs.get(
+                    (r, c), {}
+                ).get(k, 0.0)
+            out[r, c] = val
+        if out.max() > 0:
+            out = out / float(out.max())
         return out
 
     numbers = {n for cell in prob_map_dict.values() for n in cell}

--- a/app.py
+++ b/app.py
@@ -106,11 +106,16 @@ class HeatmapRequest(BaseModel):
     iterations: int = 1000
     seed: int = 0
     output_format: str = "base64"
+    sample_gamma: float = 0.0
 
 
 class HeatmapResponse(BaseModel):
     prob_map: Union[List[List[float]], Dict[str, List[List[float]]]]
     heatmap: Optional[str] = None
+    predictions: Optional[List[Prediction]] = None
+    top_predictions: Optional[List[Prediction]] = None
+    full_probabilities: Optional[Dict[str, Dict[str, float]]] = None
+    final_recommendations: Optional[List[Dict[str, Any]]] = None
 
 
 # ==== Startup & ENV parsing =================================================
@@ -271,17 +276,74 @@ async def heatmap(req: HeatmapRequest):
             else req.iterations
         )
         k_eff = req.k if req.k is not None else req.target_num
-        prob = probability_heatmap(req.grid, k_eff, iters, seed=req.seed)
+        prob = probability_heatmap(
+            req.grid,
+            k_eff,
+            iters,
+            seed=req.seed,
+            sample_gamma=req.sample_gamma,
+            history_dir="samples",
+        )
+
+        rows, cols = len(req.grid), len(req.grid[0])
+        key = (rows, cols)
+        if key not in brain.priors_map:
+            brain.priors_map[key] = compute_position_probabilities(
+                "samples", rows, cols
+            )
+
+        pred_result = predict_scratch_card(
+            grid=req.grid,
+            target_num=req.target_num,
+            iterations=PHASE1_ITER,
+            global_iter=None,
+            focus_iter=PHASE2_ITER,
+            top_n=PHASE2_TOP_N,
+            epsilon=PHASE2_EPS,
+            result_top_k=3,
+            priors=brain.priors_map[key],
+            sample_gamma=req.sample_gamma,
+        )
+
+        full_probs = pred_result.get("full_probabilities", {})
+        clean_probs: Dict[str, Dict[str, float]] = {}
+        for loc, prob_map in full_probs.items():
+            loc_key = f"{int(loc[0])},{int(loc[1])}"
+            inner: Dict[str, float] = {}
+            for num, p in prob_map.items():
+                inner[str(int(num))] = safe_float(p) * 100
+            clean_probs[loc_key] = inner
 
         if isinstance(prob, dict):
             pm = {str(int(k)): v.tolist() for k, v in prob.items()}
-            resp = {"prob_map": pm, "heatmap": None}
+            resp = {
+                "prob_map": pm,
+                "heatmap": None,
+                "predictions": pred_result.get("predictions"),
+                "top_predictions": pred_result.get("top_predictions"),
+                "full_probabilities": clean_probs,
+                "final_recommendations": pred_result.get("final_recommendations"),
+            }
         elif req.output_format.lower() == "raw":
-            resp = {"prob_map": prob.tolist(), "heatmap": None}
+            resp = {
+                "prob_map": prob.tolist(),
+                "heatmap": None,
+                "predictions": pred_result.get("predictions"),
+                "top_predictions": pred_result.get("top_predictions"),
+                "full_probabilities": clean_probs,
+                "final_recommendations": pred_result.get("final_recommendations"),
+            }
         else:
             img = render_heatmap(prob, req.output_format)
             b64 = base64.b64encode(img).decode() if isinstance(img, bytes) else img
-            resp = {"prob_map": prob.tolist(), "heatmap": b64}
+            resp = {
+                "prob_map": prob.tolist(),
+                "heatmap": b64,
+                "predictions": pred_result.get("predictions"),
+                "top_predictions": pred_result.get("top_predictions"),
+                "full_probabilities": clean_probs,
+                "final_recommendations": pred_result.get("final_recommendations"),
+            }
 
         return JSONResponse(content=sanitize_floats(resp), status_code=200)
     except Exception as exc:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,3 +54,7 @@ def test_heatmap_basic(client):
     assert isinstance(heat, str)
     # PNG base64 一定會以 iVBOR 開頭
     assert heat.startswith("iVBOR")
+    assert isinstance(body.get("predictions"), list)
+    assert isinstance(body.get("top_predictions"), list)
+    assert isinstance(body.get("full_probabilities"), dict)
+    assert isinstance(body.get("final_recommendations"), list)


### PR DESCRIPTION
## Summary
- enrich `probability_heatmap` with optional prior blending
- include sample priors and prediction details in `/heatmap`
- extend heatmap API schema for module scores and top predictions
- validate new fields in API tests

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613efcee1c83248cf0859de8599682