### PR TITLE
Support JSON heatmap output

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import math
 import os
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, status
@@ -105,8 +105,8 @@ class HeatmapRequest(BaseModel):
     target_num: Optional[int] = None
     iterations: int = 1000
     seed: int = 0
-    output_format: str = "base64"
-    sample_gamma: float = 0.0
+    output_format: Literal["base64", "raw", "json"] = "base64"
+    sample_gamma: Optional[float] = None
 
 
 class HeatmapResponse(BaseModel):
@@ -281,7 +281,7 @@ async def heatmap(req: HeatmapRequest):
             k_eff,
             iters,
             seed=req.seed,
-            sample_gamma=req.sample_gamma,
+            sample_gamma=req.sample_gamma or 0.0,
             history_dir="samples",
         )
 
@@ -302,7 +302,7 @@ async def heatmap(req: HeatmapRequest):
             epsilon=PHASE2_EPS,
             result_top_k=3,
             priors=brain.priors_map[key],
-            sample_gamma=req.sample_gamma,
+            sample_gamma=req.sample_gamma or 0.0,
         )
 
         full_probs = pred_result.get("full_probabilities", {})
@@ -324,7 +324,7 @@ async def heatmap(req: HeatmapRequest):
                 "full_probabilities": clean_probs,
                 "final_recommendations": pred_result.get("final_recommendations"),
             }
-        elif req.output_format.lower() == "raw":
+        elif req.output_format.lower() in ("raw", "json"):
             resp = {
                 "prob_map": prob.tolist(),
                 "heatmap": None,
@@ -332,6 +332,7 @@ async def heatmap(req: HeatmapRequest):
                 "top_predictions": pred_result.get("top_predictions"),
                 "full_probabilities": clean_probs,
                 "final_recommendations": pred_result.get("final_recommendations"),
+                "sample_gamma_used": req.sample_gamma or 0.0,
             }
         else:
             img = render_heatmap(prob, req.output_format)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,3 +58,19 @@ def test_heatmap_basic(client):
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
     assert isinstance(body.get("final_recommendations"), list)
+
+
+def test_heatmap_json(client):
+    """POST /heatmap with output_format=json → prob_map JSON"""
+    grid = empty_grid(2, 2)
+    payload = {"grid": grid, "target_num": 1, "iterations": 4, "output_format": "json"}
+    resp = client.post("/heatmap", json=payload)
+    body = resp.json()
+
+    assert resp.status_code == 200
+    assert isinstance(body.get("prob_map"), list)
+    assert body.get("heatmap") is None
+    assert isinstance(body.get("predictions"), list)
+    assert isinstance(body.get("top_predictions"), list)
+    assert isinstance(body.get("full_probabilities"), dict)
+    assert isinstance(body.get("final_recommendations"), list)


### PR DESCRIPTION
## Summary
- allow `json` output for /heatmap
- track sample_gamma_used for JSON/raw heatmaps
- test /heatmap JSON

## Testing
- `isort --check .`
- `black --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686149360b588324ac5aa9e23a876062