### PR TITLE
Add Row/Col Bias heuristic

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -421,6 +421,23 @@ def EXT_Q7_VariancePrior_Vec(
 
 
 @batchable
+def EXT_Q17_RowColBias_Vec(
+    grid: np.ndarray, request_id: Optional[str] = "N/A"
+) -> np.ndarray:
+    """Prefer rows/cols with more blanks using vectorized counts."""
+
+    known = grid != -1
+    row_missing = (~known).sum(axis=1).astype(float)[:, None]
+    col_missing = (~known).sum(axis=0).astype(float)[None, :]
+    score = row_missing + col_missing
+    score[known] = 0
+    mx = score.max(initial=0.0)
+    if mx > 0:
+        score /= mx
+    return score.astype(np.float32)
+
+
+@batchable
 def EXT_Q8_SpatialKL_Vec(
     grid: np.ndarray, request_id: Optional[str] = "N/A", win=5
 ) -> np.ndarray:
@@ -1163,6 +1180,7 @@ mods = {
     "EXT_Q14_TargetAffinity_Vec": EXT_Q14_TargetAffinity_Vec,
     "EXT_Q15_GlobalSpread_Vec": EXT_Q15_GlobalSpread_Vec,
     "EXT_Q16_NumericalRelationalPattern_Vec": EXT_Q16_NumericalRelationalPattern_Vec,
+    "EXT_Q17_RowColBias_Vec": EXT_Q17_RowColBias_Vec,
     "EXT_M1_Tail_Pattern_Vec": EXT_M1_Tail_Pattern_Vec,
     "EXT_M3_Local_Focus_Vec": EXT_M3_Local_Focus_Vec,
     "EXT_M10_Sequence_Block_Vec": EXT_M10_Sequence_Block_Vec,
@@ -1191,6 +1209,7 @@ FAST_PHASE = [
     "EXT_Q1_ProximityEntropy_Vec",
     "EXT_Q2_PotentialPath_Vec",
     "EXT_Q5_GlobalEntropy_Vec",
+    "EXT_Q17_RowColBias_Vec",
     "EXT_Q8_SpatialKL_Vec",
     "EXT_M12_RestoreOriginalValue_Vec",
     "EXT_Q15_GlobalSpread_Vec",
@@ -1225,6 +1244,7 @@ AGG_WEIGHTS = {
     "EXT_Q14_TargetAffinity_Vec": 0.05,
     "EXT_Q15_GlobalSpread_Vec": 0.04,
     "EXT_Q16_NumericalRelationalPattern_Vec": 0.05,
+    "EXT_Q17_RowColBias_Vec": 0.03,
     "EXT_M11_Mirror_Sequence_Vec": -0.03,
 }
 

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -10,6 +10,7 @@ def test_new_modules_registered():
         "EXT_Q14_TargetAffinity_Vec",
         "EXT_Q15_GlobalSpread_Vec",
         "EXT_Q16_NumericalRelationalPattern_Vec",
+        "EXT_Q17_RowColBias_Vec",
     ]:
         assert name in brain.REGISTERED_MODULES_BRAIN
         assert name in brain.AGG_WEIGHTS
@@ -23,7 +24,8 @@ def test_new_module_shapes(make_grid):
     s2 = brain.EXT_Q14_TargetAffinity_Vec(grid, target=3)
     s3 = brain.EXT_Q15_GlobalSpread_Vec(grid)
     s4 = brain.EXT_Q16_NumericalRelationalPattern_Vec(grid)
-    for s in (s1, s2, s3, s4):
+    s5 = brain.EXT_Q17_RowColBias_Vec(grid)
+    for s in (s1, s2, s3, s4, s5):
         assert s.shape == grid.shape
         assert np.isfinite(s).all()
 

--- a/tests/test_row_col_bias.py
+++ b/tests/test_row_col_bias.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+import brain
+
+
+def test_row_col_bias_shape_and_range():
+    grid = np.array([[1, -1], [2, -1]])
+    s = brain.EXT_Q17_RowColBias_Vec(grid)
+    assert s.shape == grid.shape
+    assert np.all(s[grid != -1] == 0)
+    assert np.all(s >= 0)
+    assert float(s.max()) <= 1.0


### PR DESCRIPTION
## Summary
- implement `EXT_Q17_RowColBias_Vec` heuristic in `brain.py`
- register new module with weight and include in fast phase
- extend tests to cover new module
- add dedicated test for row/col bias

## Testing
- `black --check brain.py tests/test_new_modules.py tests/test_row_col_bias.py`
- `isort --check brain.py tests/test_new_modules.py tests/test_row_col_bias.py`
- `flake8 brain.py tests/test_new_modules.py tests/test_row_col_bias.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e8c0e2a48324b3947d8e3837c7c4