### PR TITLE
Implement 1-based indexing for API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Execute all unit tests with:
 pytest -q
 ```
 
+## Indexing Convention
+
+All API responses and configuration parameters use **1-based** row/column
+indices. Internally, algorithms still operate with NumPy's 0-based indexing. For
+example, a prediction for the top-left cell will be returned as `(row=1, col=1)`.
+
 ## Continuous Integration
 
 GitHub Actions run linting and the test suite on every push and pull request. Slow tests are executed separately on a scheduled or manual trigger.

--- a/app.py
+++ b/app.py
@@ -155,6 +155,32 @@ def sanitize_floats(obj: Any) -> Any:
     return obj
 
 
+def _to_1_based(preds: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    """Convert row/col fields in predictions to 1-based indexing."""
+    if not preds:
+        return []
+    result = []
+    for p in preds:
+        p = p.copy()
+        if "row" in p:
+            p["row"] = int(p["row"]) + 1
+        if "col" in p:
+            p["col"] = int(p["col"]) + 1
+        result.append(p)
+    return result
+
+
+def _full_probs_to_1_based(
+    probs: Dict[Tuple[int, int], Dict[int, float]],
+) -> Dict[str, Dict[str, float]]:
+    converted: Dict[str, Dict[str, float]] = {}
+    for (r, c), pmap in probs.items():
+        key = f"{int(r) + 1},{int(c) + 1}"
+        inner = {str(int(num)): safe_float(p) * 100 for num, p in pmap.items()}
+        converted[key] = inner
+    return converted
+
+
 # ==== Routes ==============================================================
 
 
@@ -236,22 +262,19 @@ async def predict(req: GridRequest):
             pseudo_count=req.pseudo_count or 0.0,
         )
 
-        # 清洗 full_probabilities
         full_probs = result.get("full_probabilities", {})
-        clean_probs: Dict[str, Dict[str, float]] = {}
-        for loc, prob_map in full_probs.items():
-            key = f"{int(loc[0])},{int(loc[1])}"
-            inner: Dict[str, float] = {}
-            for num, p in prob_map.items():
-                inner[str(int(num))] = safe_float(p) * 100
-            clean_probs[key] = inner
+        clean_probs = _full_probs_to_1_based(full_probs)
+
+        preds = _to_1_based(result.get("predictions"))
+        tops = _to_1_based(result.get("top_predictions"))
+        recs = _to_1_based(result.get("final_recommendations"))
 
         payload = {
-            "predictions": result.get("predictions", []),
-            "top_predictions": result.get("top_predictions", []),
+            "predictions": preds,
+            "top_predictions": tops,
             "full_probabilities": clean_probs,
             "sample_gamma_used": req.sample_gamma or 0.0,
-            "final_recommendations": result.get("final_recommendations", []),
+            "final_recommendations": recs,
         }
         safe_payload = sanitize_floats(payload)
         logger.info("✅ Response ready")
@@ -306,32 +329,30 @@ async def heatmap(req: HeatmapRequest):
         )
 
         full_probs = pred_result.get("full_probabilities", {})
-        clean_probs: Dict[str, Dict[str, float]] = {}
-        for loc, prob_map in full_probs.items():
-            loc_key = f"{int(loc[0])},{int(loc[1])}"
-            inner: Dict[str, float] = {}
-            for num, p in prob_map.items():
-                inner[str(int(num))] = safe_float(p) * 100
-            clean_probs[loc_key] = inner
+        clean_probs = _full_probs_to_1_based(full_probs)
+
+        preds = _to_1_based(pred_result.get("predictions"))
+        tops = _to_1_based(pred_result.get("top_predictions"))
+        recs = _to_1_based(pred_result.get("final_recommendations"))
 
         if isinstance(prob, dict):
             pm = {str(int(k)): v.tolist() for k, v in prob.items()}
             resp = {
                 "prob_map": pm,
                 "heatmap": None,
-                "predictions": pred_result.get("predictions"),
-                "top_predictions": pred_result.get("top_predictions"),
+                "predictions": preds,
+                "top_predictions": tops,
                 "full_probabilities": clean_probs,
-                "final_recommendations": pred_result.get("final_recommendations"),
+                "final_recommendations": recs,
             }
         elif req.output_format.lower() in ("raw", "json"):
             resp = {
                 "prob_map": prob.tolist(),
                 "heatmap": None,
-                "predictions": pred_result.get("predictions"),
-                "top_predictions": pred_result.get("top_predictions"),
+                "predictions": preds,
+                "top_predictions": tops,
                 "full_probabilities": clean_probs,
-                "final_recommendations": pred_result.get("final_recommendations"),
+                "final_recommendations": recs,
                 "sample_gamma_used": req.sample_gamma or 0.0,
             }
         else:
@@ -340,10 +361,10 @@ async def heatmap(req: HeatmapRequest):
             resp = {
                 "prob_map": prob.tolist(),
                 "heatmap": b64,
-                "predictions": pred_result.get("predictions"),
-                "top_predictions": pred_result.get("top_predictions"),
+                "predictions": preds,
+                "top_predictions": tops,
                 "full_probabilities": clean_probs,
-                "final_recommendations": pred_result.get("final_recommendations"),
+                "final_recommendations": recs,
             }
 
         return JSONResponse(content=sanitize_floats(resp), status_code=200)

--- a/main.py
+++ b/main.py
@@ -168,8 +168,10 @@ def main():
                     logging.info("Heatmap base64 saved to heatmap.txt")
         logging.info("Prediction results:")
         for pred in result["predictions"]:
+            r = int(pred["row"]) + 1
+            c = int(pred["col"]) + 1
             logging.info(
-                f"Cell ({pred['row']}, {pred['col']}): {pred['candidates']} with probability {pred['probability']:.2f}%"
+                f"Cell ({r}, {c}): {pred['candidates']} with probability {pred['probability']:.2f}%"
             )
         logging.info("Full probabilities available in result['full_probabilities']")
         logging.info("Complete!")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,3 +74,25 @@ def test_heatmap_json(client):
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
     assert isinstance(body.get("final_recommendations"), list)
+
+
+def test_predict_1_based_top_left(client):
+    grid = [[-1, 2], [3, 4]]
+    payload = {"grid": grid, "target_num": 1, "iterations": 2}
+    resp = client.post("/predict", json=payload)
+    body = resp.json()
+    pred = body["predictions"][0]
+    assert pred["row"] == 1
+    assert pred["col"] == 1
+    assert "1,1" in body["full_probabilities"]
+
+
+def test_predict_1_based_bottom_right(client):
+    grid = [[1, 2], [3, -1]]
+    payload = {"grid": grid, "target_num": 4, "iterations": 2}
+    resp = client.post("/predict", json=payload)
+    body = resp.json()
+    pred = body["predictions"][0]
+    assert pred["row"] == 2
+    assert pred["col"] == 2
+    assert "2,2" in body["full_probabilities"]


### PR DESCRIPTION
## Summary
- convert prediction coordinates to 1-based before returning to clients
- update CLI output and documentation to mention 1-based indexing
- test API boundaries for (1,1) and (M,N)

## Testing
- `isort --check app.py main.py tests/test_api.py`
- `black --check app.py main.py tests/test_api.py`
- `flake8 app.py main.py tests/test_api.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f5529fec8324b8221b4887c94bff