### PR TITLE
Implement global normalized position priors

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -34,6 +34,29 @@ logger = logging.getLogger(__name__)
 math_utils = MathUtils()
 analyzer_utils = BoardAnalyzerUtils()
 
+# Global position prior cache
+_POS_FREQ_CACHE: Dict[str, np.ndarray] = {}
+
+
+def load_global_pos_freq(samples_dir: str) -> None:
+    """Load global position frequency tensor from samples_dir if available."""
+    path = Path(samples_dir) / "pos_freq.npz"
+    try:
+        if path.exists():
+            arr = np.load(path)["freq"]
+            _POS_FREQ_CACHE[str(path)] = arr.astype(float)
+            logger.info("Loaded global position freq from %s", path)
+    except Exception as exc:  # pragma: no cover - corrupted file
+        logger.error("failed to load %s: %s", path, exc)
+
+
+def _get_global_pos_freq(samples_dir: str) -> Optional[np.ndarray]:
+    path = Path(samples_dir) / "pos_freq.npz"
+    key = str(path)
+    if key not in _POS_FREQ_CACHE and path.exists():
+        load_global_pos_freq(samples_dir)
+    return _POS_FREQ_CACHE.get(key)
+
 
 # 來自 probmap_key_patch_v2.txt
 def _native_coord(k):
@@ -113,7 +136,24 @@ def compute_history_frequency(
 def compute_position_probabilities(
     samples_dir: str, rows: int, cols: int
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
-    """Return per-cell number probabilities from all samples."""
+    """Return per-cell number probabilities from history samples."""
+    global_freq = _get_global_pos_freq(samples_dir)
+    if global_freq is not None:
+        buckets = global_freq.shape[1]
+        prob_map: Dict[Tuple[int, int], Dict[int, float]] = {}
+        for r in range(rows):
+            for c in range(cols):
+                u = r / (rows - 1) if rows > 1 else 0.0
+                v = c / (cols - 1) if cols > 1 else 0.0
+                i = min(int(u * buckets), buckets - 1)
+                j = min(int(v * buckets), buckets - 1)
+                dist = global_freq[:, i, j].astype(float)
+                dist = dist[: rows * cols + 1]
+                tot = dist.sum() or 1.0
+                probs = {k: dist[k] / tot for k in range(1, dist.size) if dist[k] > 0}
+                prob_map[(r, c)] = probs
+        return prob_map
+
     cached = Path(samples_dir) / "prior.npy"
     if cached.exists():
         cube = np.load(cached, mmap_mode="r")

--- a/app.py
+++ b/app.py
@@ -13,8 +13,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel
 
-import brain
 # fmt: off
+import analyzer
+import brain
 from analyzer import (compute_position_probabilities, iter_sample_jsons,
                       predict_scratch_card, probability_heatmap,
                       render_heatmap)
@@ -66,6 +67,7 @@ async def _load_samples_background():
 @app.on_event("startup")
 async def startup_event():
     asyncio.create_task(_load_samples_background())
+    analyzer.load_global_pos_freq("samples")
 
 
 # ==== Schemas ==============================================================

--- a/position_prior.py
+++ b/position_prior.py
@@ -1,0 +1,48 @@
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from analyzer import iter_sample_jsons
+
+logger = logging.getLogger(__name__)
+
+
+def build_position_prior(samples_dir: str, outfile: str, buckets: int = 20) -> None:
+    """Build global position prior from ``samples_dir`` and save to ``outfile``."""
+    path = Path(samples_dir)
+    # first pass to determine max digit
+    max_digit = 0
+    for sample in iter_sample_jsons(str(path)):
+        grid = np.asarray(sample["grid"], dtype=int)
+        if grid.size:
+            max_digit = max(max_digit, int(grid.max()))
+    if max_digit == 0:
+        raise ValueError("no valid samples found")
+
+    counts = np.zeros((max_digit + 1, buckets, buckets), dtype=np.int64)
+    for sample in iter_sample_jsons(str(path)):
+        grid = np.asarray(sample["grid"], dtype=int)
+        rows, cols = sample["rows"], sample["cols"]
+        for r in range(rows):
+            for c in range(cols):
+                k = int(grid[r, c])
+                if k <= 0:
+                    continue
+                u = r / (rows - 1) if rows > 1 else 0.0
+                v = c / (cols - 1) if cols > 1 else 0.0
+                i = min(int(u * buckets), buckets - 1)
+                j = min(int(v * buckets), buckets - 1)
+                counts[k, i, j] += 1
+
+    totals = counts.sum(axis=(1, 2), keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts.astype(float) / totals
+    np.savez_compressed(outfile, freq=freq)
+    logger.info("position prior saved to %s", outfile)
+
+
+def load_position_prior(path: str) -> np.ndarray:
+    """Load position prior tensor from ``path``."""
+    arr = np.load(path)["freq"]
+    return np.asarray(arr, dtype=float)

--- a/tests/test_global_pos_prior.py
+++ b/tests/test_global_pos_prior.py
@@ -1,0 +1,21 @@
+import json
+import zipfile
+
+import analyzer
+from position_prior import build_position_prior
+
+
+def test_global_position_prior(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps(data))
+
+    out = samples / "pos_freq.npz"
+    build_position_prior(str(samples), str(out), buckets=2)
+
+    analyzer.load_global_pos_freq(str(samples))
+    probs = analyzer.compute_position_probabilities(str(samples), 2, 2)
+    assert probs[(0, 0)][1] == 1.0
+    assert probs[(0, 1)][2] == 1.0


### PR DESCRIPTION
## Summary
- implement `position_prior.py` to compute and load global position priors
- cache bucketed priors in `analyzer` and use in `compute_position_probabilities`
- load global priors on API startup
- add regression test for new prior logic

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861fc7237508324bb2bd11be0b3475e