### PR TITLE
Refactor configuration handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import base64
 import logging
 import math
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
@@ -121,7 +121,7 @@ class HeatmapResponse(BaseModel):
 
 
 # ==== Startup & ENV parsing =================================================
-startup_time = datetime.utcnow().isoformat() + "Z"
+startup_time = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 # 默认环境变量
 os.environ.setdefault("PHASE1_ITERATIONS", "5000")

--- a/brain.py
+++ b/brain.py
@@ -1277,12 +1277,13 @@ def get_core_modules(limit: int | None = None) -> list[str]:
     The limit defaults to the ``CORE_LIMIT`` environment variable (8) and is
     clamped to the range 5–10.
     """
+    limit_env_str = os.getenv("CORE_LIMIT", "8")
     try:
-        limit_env = int(os.getenv("CORE_LIMIT", "8"))
+        limit_env = int(limit_env_str)
     except ValueError:  # FIXME invalid env value
         logger.warning(
             "Invalid CORE_LIMIT '%s', using default 8",
-            os.getenv("CORE_LIMIT"),
+            limit_env_str,
         )
         limit_env = 8
     if limit is None:

--- a/modules.py
+++ b/modules.py
@@ -1,16 +1,7 @@
-import json
-import logging
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from scipy import ndimage as ndi
-
-# Logging configuration
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler()],
-)
 
 # Formula registry for Monte Carlo simulation
 FORMULA_REGISTRY: Dict[
@@ -140,42 +131,6 @@ def gen_tail_cluster(
     board[low_idx] = low_nums
     board[high_idx] = high_nums
     return board.reshape(rows, cols)
-
-
-class AdaptiveWeights:
-    """Manages dynamic weight adjustments for formulas based on performance."""
-
-    def __init__(self, initial_weights: Dict[str, float]):
-        self.weights = initial_weights.copy()
-        self.history: Dict[str, float] = {
-            name: 0.0 for name in initial_weights
-        }  # noqa: E501
-        self.total_trials = 0
-
-    def update(
-        self, success_rate: float, module_scores: Dict[str, float]
-    ) -> None:  # noqa: E501
-        """Update weights based on success rate and module scores."""
-        self.total_trials += 1
-        for name in self.weights:
-            score = module_scores.get(name, success_rate)
-            hist = self.history[name] * (self.total_trials - 1) + score
-            self.history[name] = hist / self.total_trials
-            self.weights[name] = max(
-                0.1,
-                min(0.9, self.history[name] * 1.05),
-            )
-        total = sum(self.weights.values()) or 1e-10
-        for name in self.weights:
-            self.weights[name] /= total
-
-    def save_history(self, path: str) -> None:
-        """Save weight history to file."""
-        try:
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump(self.history, f, ensure_ascii=False)
-        except OSError as e:
-            logging.error(f"Failed to save weights history: {e}")
 
 
 def global_offset_cooccurrence(

--- a/tests/test_core_modules.py
+++ b/tests/test_core_modules.py
@@ -20,3 +20,10 @@ def test_get_core_modules_warn_invalid_env(monkeypatch, caplog):
         brain.get_core_modules()
     assert any("Invalid CORE_LIMIT" in r.message for r in caplog.records)
     monkeypatch.delenv("CORE_LIMIT", raising=False)
+
+
+def test_get_core_modules_invalid_env_default(monkeypatch):
+    monkeypatch.setenv("CORE_LIMIT", "bad")
+    mods = brain.get_core_modules()
+    assert len(mods) == 8
+    monkeypatch.delenv("CORE_LIMIT", raising=False)


### PR DESCRIPTION
## Summary
- remove unused `AdaptiveWeights` helper
- use timezone aware `startup_time`
- handle invalid `CORE_LIMIT` value via helper variable
- test default when `CORE_LIMIT` envvar invalid

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686205b32cf48324a4fcaba4e4e7b12a