### PR TITLE
docs: guide for faster Render deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+.hypothesis
+tests
+*.pyc
+*.pyo
+*.pyd
+.Python
+.env
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Python dependencies early so the layer is cached
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . .
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "10000"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ example, a prediction for the top-left cell will be returned as `(row=1, col=1)`
 
 GitHub Actions run linting and the test suite on every push and pull request. Slow tests are executed separately on a scheduled or manual trigger.
 
+## Deployment on Render
+
+To reduce build time when manually deploying to Render:
+
+1. Switch your Render service to **Docker deploy** and use the provided `Dockerfile`.
+   Because dependencies are installed in an earlier layer, they will be reused as long as `requirements.txt` remains unchanged.
+2. Enable **Build Cache** under **Settings → Build & Deploy** and add the following path:
+
+```
+~/.cache/pip
+```
+
+Render will restore this cache before each build and save it afterwards, avoiding repeated downloads.


### PR DESCRIPTION
## Summary
- document using a Docker image and build cache on Render
- add a Dockerfile and `.dockerignore` for cached dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68621b04f4688324bc63445d8dffb68a