### PR TITLE
Implement module evaluation and dynamic weighting

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -1251,7 +1251,7 @@ RERANK_PHASE = [
 ]
 
 # Static weights for module aggregation
-AGG_WEIGHTS = {
+DEFAULT_AGG_WEIGHTS = {
     "EXT_Q1_ProximityEntropy_Vec": 0.20,
     "EXT_Q2_PotentialPath_Vec": 0.15,
     "EXT_Q3_DiscontinuitySym_Vec": 0.10,
@@ -1274,9 +1274,37 @@ AGG_WEIGHTS = {
 }
 
 
+def _read_performance(file_path: str) -> Dict[str, float]:
+    """Return mapping of module to accuracy from performance file."""
+    acc: Dict[str, float] = {}
+    if os.path.exists(file_path):
+        with open(file_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                parts = line.strip().split()
+                if len(parts) < 2:
+                    continue
+                try:
+                    acc[parts[0]] = float(parts[1])
+                except ValueError:
+                    continue
+    return acc
+
+
 def _load_weights() -> Dict[str, float]:
-    """Return normalized weights with ENV overrides."""
-    w = AGG_WEIGHTS.copy()
+    """Return normalized weights with performance and ENV overrides."""
+    w = DEFAULT_AGG_WEIGHTS.copy()
+
+    perf_file = os.getenv("PERFORMANCE_FILE", "module_performance.txt")
+    perf = _read_performance(perf_file)
+    if perf:
+        total = sum(perf.get(m, 0.0) for m in w)
+        if total > 0:
+            norm = {m: perf.get(m, 0.0) / total for m in w}
+            min_w = float(os.getenv("MIN_WEIGHT", "0.05"))
+            floored = {k: max(v, min_w) for k, v in norm.items()}
+            total_f = sum(floored.values()) or 1.0
+            w = {k: floored[k] / total_f for k in w}
+
     for name in w:
         env_key = f"WEIGHT_{name.split('_')[1]}"
         env_val = os.getenv(env_key)
@@ -1285,6 +1313,7 @@ def _load_weights() -> Dict[str, float]:
                 w[name] = float(env_val)
             except ValueError:
                 logger.warning("Invalid weight for %s: %s", env_key, env_val)
+
     total = sum(w.values())
     if not math.isclose(total, 1.0, rel_tol=1e-3):
         logger.info("Normalizing module weights (sum %.3f)", total)
@@ -1368,12 +1397,24 @@ def get_module_score(
 def aggregate_scores(
     stack: np.ndarray, weights: np.ndarray, names: Optional[list[str]] | None = None
 ) -> np.ndarray:
-    """Normalize score maps then combine via weighted sum."""
+    """Normalize score maps then combine via dynamic weighted sum."""
     mu = stack.mean(axis=(1, 2), keepdims=True)
     sigma = stack.std(axis=(1, 2), keepdims=True) + 1e-6
     stack_z = (stack - mu) / sigma
-    weights_normalized = weights / (weights.sum() + 1e-10)
-    final = np.tensordot(weights_normalized, stack_z, axes=(0, 0))
+
+    weights = np.asarray(weights, dtype=float)
+    base = weights / (weights.sum() + 1e-10)
+
+    conf = stack_z.max(axis=(1, 2)) - stack_z.mean(axis=(1, 2))
+    conf = np.clip(conf, 0.0, None)
+    if conf.sum() > 0:
+        conf /= conf.sum()
+        alpha = float(os.getenv("WEIGHT_ALPHA", "0.8"))
+        weights = alpha * base + (1.0 - alpha) * conf
+    else:
+        weights = base
+
+    final = np.tensordot(weights, stack_z, axes=(0, 0))
     if names:
         pass
     return final

--- a/eval_modules.py
+++ b/eval_modules.py
@@ -1,0 +1,65 @@
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+import brain
+from analyzer import iter_sample_jsons
+
+MODULES: List[str] = list(brain.AGG_WEIGHTS.keys())
+
+
+def _evaluate_module(
+    module: str, board: np.ndarray, target: int, hidden_pos: Tuple[int, int]
+) -> Tuple[bool, bool, int]:
+    """Return (top1, top3, rank) for the given module on a single board."""
+    scores = brain.get_module_score(module, board, target=target)
+    flat = scores.ravel()
+    order = np.argsort(flat)[::-1]
+    rows, cols = board.shape
+    preds = [(idx // cols, idx % cols) for idx in order]
+    rank = preds.index(hidden_pos) + 1 if hidden_pos in preds else len(preds) + 1
+    return preds[0] == hidden_pos, hidden_pos in preds[:3], rank
+
+
+def main(samples_dir: str = "samples") -> None:
+    metrics: Dict[str, Dict[str, float]] = {
+        m: {"top1": 0, "top3": 0, "rr_sum": 0.0, "total": 0} for m in MODULES
+    }
+    for sample in iter_sample_jsons(samples_dir):
+        grid = np.asarray(sample.get("grid"))
+        target = sample.get("target_num")
+        if grid is None or target is None:
+            continue
+        loc = np.argwhere(grid == target)
+        if loc.size == 0:
+            continue
+        r, c = map(int, loc[0])
+        board = grid.copy()
+        board[r, c] = -1
+        for mod in MODULES:
+            t1, t3, rank = _evaluate_module(mod, board, target, (r, c))
+            metrics[mod]["total"] += 1
+            metrics[mod]["top1"] += int(t1)
+            metrics[mod]["top3"] += int(t3)
+            metrics[mod]["rr_sum"] += 1.0 / rank
+
+    lines = []
+    for mod in MODULES:
+        data = metrics[mod]
+        if data["total"] == 0:
+            top1 = top3 = mrr = 0.0
+        else:
+            top1 = data["top1"] / data["total"]
+            top3 = data["top3"] / data["total"]
+            mrr = data["rr_sum"] / data["total"]
+        lines.append((mod, top1, top3, mrr))
+
+    lines.sort(key=lambda x: x[1], reverse=True)
+    with open("module_performance.txt", "w", encoding="utf-8") as f:
+        for mod, t1, t3, mrr in lines:
+            f.write(f"{mod} {t1:.4f} {t3:.4f} {mrr:.4f}\n")
+    print("module_performance.txt generated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dynamic_weights.py
+++ b/tests/test_dynamic_weights.py
@@ -1,0 +1,19 @@
+import importlib
+
+import brain
+
+
+def test_dynamic_weight_loading(tmp_path, monkeypatch):
+    perf = tmp_path / "perf.txt"
+    perf.write_text("EXT_Q1_ProximityEntropy_Vec 0.8\nEXT_Q2_PotentialPath_Vec 0.2\n")
+    monkeypatch.setenv("PERFORMANCE_FILE", str(perf))
+    monkeypatch.setenv("MIN_WEIGHT", "0.05")
+    mod = importlib.reload(brain)
+    assert abs(sum(mod.AGG_WEIGHTS.values()) - 1.0) < 1e-6
+    assert (
+        mod.AGG_WEIGHTS["EXT_Q1_ProximityEntropy_Vec"]
+        > mod.AGG_WEIGHTS["EXT_Q2_PotentialPath_Vec"]
+    )
+    monkeypatch.delenv("PERFORMANCE_FILE", raising=False)
+    monkeypatch.delenv("MIN_WEIGHT", raising=False)
+    importlib.reload(brain)


### PR DESCRIPTION
## Summary
- add `eval_modules.py` for scoring each module against sample boards
- load module weights from `module_performance.txt` with floor support
- adjust `aggregate_scores` to mix global and per-board weights
- test dynamic weight loading

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626949881883249fb53d76b52ff10c