### PR TITLE
Implement nearest value fallback strategies

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1511,6 +1511,7 @@ def probability_heatmap(
     seed: int = 0,
     sample_gamma: float = 0.0,
     history_dir: str = "samples",
+    nearest_weight: float = 0.0,
 ) -> Union[np.ndarray, Dict[int, np.ndarray]]:
     """Heatmap simulation using :func:`simulate_full_board`.
 
@@ -1555,6 +1556,11 @@ def probability_heatmap(
                     k, 0.0
                 )
             out[r, c] = val
+        if nearest_weight > 0:
+            from modules import nearest_value_affinity
+
+            near = nearest_value_affinity(grid_np, k, tolerance=1, radius=1)
+            out = (1.0 - nearest_weight) * out + nearest_weight * near
         if out.max() > 0:
             out = out / float(out.max())
         return out

--- a/brain.py
+++ b/brain.py
@@ -950,6 +950,31 @@ def EXT_GM20_Skip_Pattern_Confidence_Vec(
     return scores
 
 
+def compute_nearest_value_heatmap(
+    grid: np.ndarray,
+    *,
+    target: int,
+    cooc_prob: Dict[Tuple[int, int], Dict[int, Dict[int, float]]],
+    k: int,
+) -> np.ndarray:
+    rows, cols = grid.shape
+    coords = np.argwhere(grid != -1)
+    values = grid[grid != -1].astype(int)
+    order = np.argsort(np.abs(values - target))[:k]
+    heat = np.zeros((rows, cols), dtype=float)
+    for (r, c), val in zip(coords[order], values[order]):
+        for off, mapping in cooc_prob.items():
+            p = mapping.get(val, {}).get(target)
+            if p is None:
+                continue
+            nr, nc = r + off[0], c + off[1]
+            if 0 <= nr < rows and 0 <= nc < cols and grid[nr, nc] == -1:
+                heat[nr, nc] += p
+    if heat.sum() > 0:
+        heat /= heat.sum()
+    return heat
+
+
 @batchable
 def EXT_X_CRFInference(
     grid: np.ndarray,
@@ -960,9 +985,19 @@ def EXT_X_CRFInference(
     lambda_unary: float = 1.0,
     lambda_pairwise: float = 1.0,
     iterations: int = 5,
+    nearest_k: int = 0,
+    alpha_local: float = 0.3,
     request_id: Optional[str] = "N/A",
 ) -> np.ndarray:
-    """Approximate CRF inference combining unary and pairwise potentials."""
+    """Approximate CRF inference combining unary and pairwise potentials.
+
+    Parameters
+    ----------
+    nearest_k : int, optional
+        Use local co-occurrence heatmap from ``k`` closest values when ``>0``.
+    alpha_local : float, optional
+        Blend weight for the local heatmap. Defaults to ``0.3``.
+    """
 
     grid = np.asarray(grid, dtype=int)
     rows, cols = grid.shape
@@ -970,6 +1005,17 @@ def EXT_X_CRFInference(
 
     if heatmap_scores is None:
         heatmap_scores = EXT_Q5_GlobalEntropy_Vec(grid, request_id=request_id)
+
+    if nearest_k > 0 and target is not None and cooc_prob:
+        local = compute_nearest_value_heatmap(
+            grid, target=target, cooc_prob=cooc_prob, k=nearest_k
+        )
+        if heatmap_scores.ndim == 2:
+            heatmap_scores = (1 - alpha_local) * heatmap_scores + alpha_local * local
+        else:
+            heatmap_scores[..., target] = (1 - alpha_local) * heatmap_scores[
+                ..., target
+            ] + alpha_local * local
 
     if heatmap_scores.ndim == 2:
         unary = np.exp(lambda_unary * heatmap_scores)[..., None]

--- a/modules.py
+++ b/modules.py
@@ -189,6 +189,7 @@ def neighbor_value_distribution(
     target: Optional[int] = None,
     tolerance: int = 1,
     radius: int = 1,
+    nearest_k: int = 0,
 ) -> np.ndarray:
     """Score hidden cells based on nearby values.
 
@@ -202,6 +203,9 @@ def neighbor_value_distribution(
         Acceptable absolute difference from ``target``. Defaults to ``1``.
     radius : int, optional
         Neighborhood radius for local counting. Defaults to ``1``.
+    nearest_k : int, optional
+        Number of closest values used when no cell falls within ``tolerance``.
+        Defaults to ``0`` (disabled).
 
     Returns
     -------
@@ -226,6 +230,18 @@ def neighbor_value_distribution(
 
     mask_hidden = boards == -1
     mask_near = (boards != -1) & (np.abs(boards - target) <= tolerance)
+    # 回退：若找不到任意符合 tolerance 的位置，則用最近的 nearest_k 個值
+    if not mask_near.any() and nearest_k > 0:
+        for i, board in enumerate(boards):
+            if (np.abs(board - target) <= tolerance).any():
+                continue
+            known = np.unique(board[board != -1])
+            if known.size:
+                idx = np.argsort(np.abs(known - target))[:nearest_k]
+                near_k = known[idx]
+                mask_near[i] = np.isin(board, near_k)
+            else:
+                mask_near[i] = False
     dist = ndi.distance_transform_edt(~mask_near)
     kernel = np.ones((2 * radius + 1, 2 * radius + 1), dtype=float)
     mask_float = mask_near.astype(float)
@@ -240,3 +256,18 @@ def neighbor_value_distribution(
     base = 0.6 * (1 - dist_norm) + 0.4 * counts_norm
     score = mask_hidden.astype(float) * base
     return score[0] if single else score
+
+
+def nearest_value_affinity(
+    boards: np.ndarray,
+    target: Optional[int],
+    k: int = 3,
+    *,
+    tolerance: int = 1,
+    radius: int = 1,
+) -> np.ndarray:
+    """Wrapper for ``neighbor_value_distribution`` using ``nearest_k`` fallback."""
+
+    return neighbor_value_distribution(
+        boards, target, tolerance=tolerance, radius=radius, nearest_k=k
+    )

--- a/tests/test_nearest_strategy.py
+++ b/tests/test_nearest_strategy.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+import brain
+from analyzer import probability_heatmap
+from modules import neighbor_value_distribution
+
+
+def test_neighbor_value_fallback():
+    grid = np.array([[1, -1], [10, 15]])
+    base = neighbor_value_distribution(grid, target=50, tolerance=0)
+    near = neighbor_value_distribution(grid, target=50, tolerance=0, nearest_k=1)
+    assert near[0, 1] > base[0, 1]
+
+
+def test_probability_heatmap_nearest_weight():
+    grid = np.array([[1, -1], [2, -1]])
+    hm = probability_heatmap(grid, 2, n_iter=8, seed=1, nearest_weight=0.5)
+    assert hm.shape == grid.shape
+    assert np.all(np.isfinite(hm))
+
+
+def test_crf_nearest_value_integration():
+    grid = np.array([[1, -1], [2, 3]])
+    cooc = {(-1, 0): {1: {2: 1.0}}, (1, 0): {}, (0, -1): {}, (0, 1): {}}
+    out = brain.EXT_X_CRFInference(
+        grid,
+        target=2,
+        cooc_prob=cooc,
+        nearest_k=1,
+        iterations=1,
+    )
+    assert out.shape == (grid.shape[0], grid.shape[1], grid.size + 1)
+    assert np.allclose(out.sum(axis=2)[grid == -1], 1.0, atol=1e-6)


### PR DESCRIPTION
## Summary
- add nearest_k fallback in `neighbor_value_distribution`
- expose helper `nearest_value_affinity`
- mix nearest-value heatmap in `probability_heatmap`
- compute nearest-value heatmap and integrate in CRF inference
- test new nearest-value logic

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629600164083248fcd79c049e847f6