### PR TITLE
Add nearest value fallback and heatmap fusion

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1511,6 +1511,7 @@ def probability_heatmap(
     seed: int = 0,
     sample_gamma: float = 0.0,
     history_dir: str = "samples",
+    nearest_weight: float = 0.0,
 ) -> Union[np.ndarray, Dict[int, np.ndarray]]:
     """Heatmap simulation using :func:`simulate_full_board`.
 
@@ -1528,6 +1529,8 @@ def probability_heatmap(
         Weight for prior probabilities derived from ``history_dir``.
     history_dir : str
         Directory containing sample ``*.zip`` files.
+    nearest_weight : float
+        Blend ratio for :func:`nearest_value_affinity` heatmap.
     """
 
     rng = np.random.default_rng(seed)
@@ -1555,6 +1558,11 @@ def probability_heatmap(
                     k, 0.0
                 )
             out[r, c] = val
+        if nearest_weight > 0:
+            from modules import nearest_value_affinity
+
+            near = nearest_value_affinity(grid_np, k, tolerance=1, radius=1)
+            out = (1.0 - nearest_weight) * out + nearest_weight * near
         if out.max() > 0:
             out = out / float(out.max())
         return out

--- a/brain.py
+++ b/brain.py
@@ -710,6 +710,25 @@ def EXT_M1_Tail_Pattern_Vec(
     return scores
 
 
+def compute_nearest_value_heatmap(grid, *, target, cooc_prob, k):
+    rows, cols = grid.shape
+    coords = np.argwhere(grid != -1)
+    values = grid[grid != -1].astype(int)
+    order = np.argsort(np.abs(values - target))[:k]
+    heat = np.zeros((rows, cols), dtype=float)
+    for (r, c), val in zip(coords[order], values[order]):
+        for off, mapping in cooc_prob.items():
+            p = mapping.get(val, {}).get(target)
+            if p is None:
+                continue
+            nr, nc = r + off[0], c + off[1]
+            if 0 <= nr < rows and 0 <= nc < cols and grid[nr, nc] == -1:
+                heat[nr, nc] += p
+    if heat.sum() > 0:
+        heat /= heat.sum()
+    return heat
+
+
 @batchable
 def EXT_M3_Local_Focus_Vec(
     grid: np.ndarray, request_id: Optional[str] = "N/A"
@@ -960,6 +979,8 @@ def EXT_X_CRFInference(
     lambda_unary: float = 1.0,
     lambda_pairwise: float = 1.0,
     iterations: int = 5,
+    nearest_k: int = 0,
+    alpha_local: float = 0.3,
     request_id: Optional[str] = "N/A",
 ) -> np.ndarray:
     """Approximate CRF inference combining unary and pairwise potentials."""
@@ -970,6 +991,17 @@ def EXT_X_CRFInference(
 
     if heatmap_scores is None:
         heatmap_scores = EXT_Q5_GlobalEntropy_Vec(grid, request_id=request_id)
+
+    if nearest_k > 0 and target is not None and cooc_prob:
+        local = compute_nearest_value_heatmap(
+            grid, target=target, cooc_prob=cooc_prob, k=nearest_k
+        )
+        if heatmap_scores.ndim == 2:
+            heatmap_scores = (1 - alpha_local) * heatmap_scores + alpha_local * local
+        else:
+            heatmap_scores[..., target] = (1 - alpha_local) * heatmap_scores[
+                ..., target
+            ] + alpha_local * local
 
     if heatmap_scores.ndim == 2:
         unary = np.exp(lambda_unary * heatmap_scores)[..., None]

--- a/modules.py
+++ b/modules.py
@@ -189,6 +189,7 @@ def neighbor_value_distribution(
     target: Optional[int] = None,
     tolerance: int = 1,
     radius: int = 1,
+    nearest_k: int = 0,
 ) -> np.ndarray:
     """Score hidden cells based on nearby values.
 
@@ -226,6 +227,18 @@ def neighbor_value_distribution(
 
     mask_hidden = boards == -1
     mask_near = (boards != -1) & (np.abs(boards - target) <= tolerance)
+    # 回退：若找不到任意符合 tolerance 的位置，則使用最近的 `nearest_k` 個值
+    if not mask_near.any() and nearest_k > 0:
+        for i, board in enumerate(boards):
+            if (np.abs(board - target) <= tolerance).any():
+                continue
+            known = np.unique(board[board != -1])
+            if known.size:
+                idx = np.argsort(np.abs(known - target))[:nearest_k]
+                near_k = known[idx]
+                mask_near[i] = np.isin(board, near_k)
+            else:
+                mask_near[i] = False
     dist = ndi.distance_transform_edt(~mask_near)
     kernel = np.ones((2 * radius + 1, 2 * radius + 1), dtype=float)
     mask_float = mask_near.astype(float)
@@ -240,3 +253,40 @@ def neighbor_value_distribution(
     base = 0.6 * (1 - dist_norm) + 0.4 * counts_norm
     score = mask_hidden.astype(float) * base
     return score[0] if single else score
+
+
+def nearest_value_affinity(
+    grid: np.ndarray,
+    target: Optional[int],
+    *,
+    k: int = 3,
+    tolerance: int = 1,
+    radius: int = 1,
+) -> np.ndarray:
+    """Return normalized affinity heatmap using :func:`neighbor_value_distribution`.
+
+    Parameters
+    ----------
+    grid : np.ndarray
+        Board matrix with ``-1`` for unknown cells.
+    target : int
+        Target number to search around.
+    k : int, optional
+        Number of nearest values to fall back to when no cells match ``tolerance``.
+    tolerance : int, optional
+        Acceptable absolute difference from ``target``. Defaults to ``1``.
+    radius : int, optional
+        Neighborhood radius for local counting. Defaults to ``1``.
+    """
+
+    score = neighbor_value_distribution(
+        grid,
+        target=target,
+        tolerance=tolerance,
+        radius=radius,
+        nearest_k=k,
+    )
+    mx = score.max(initial=0.0)
+    if mx > 0:
+        score = score / float(mx)
+    return score

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -33,3 +33,25 @@ def test_aggregate_scores_basic():
     out = brain.aggregate_scores(stack, weights, ["A", "B"])
     assert out.shape == (2, 2)
     assert np.all(np.isfinite(out))
+
+
+def test_compute_nearest_value_heatmap_basic():
+    grid = np.array([[1, -1], [2, 3]])
+    cooc = {(-1, 1): {2: {2: 1.0}}}
+    heat = brain.compute_nearest_value_heatmap(grid, target=2, cooc_prob=cooc, k=1)
+    assert heat.shape == grid.shape
+    assert np.isclose(heat.sum(), 1.0)
+
+
+def test_crf_nearest_value_integration():
+    grid = np.array([[1, -1], [2, 3]])
+    cooc = {(-1, 1): {1: {2: 1.0}}}
+    out = brain.EXT_X_CRFInference(
+        grid,
+        target=2,
+        cooc_prob=cooc,
+        nearest_k=1,
+        alpha_local=0.5,
+    )
+    assert out.shape == (grid.shape[0], grid.shape[1], grid.size + 1)
+    assert np.allclose(out.sum(axis=2)[grid == -1], 1.0, atol=1e-6)

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -49,3 +49,12 @@ def test_probability_heatmap_raw():
     arr = render_heatmap(prob, "raw")
     assert isinstance(arr, np.ndarray)
     assert arr.shape == grid.shape
+
+
+def test_probability_heatmap_nearest_weight():
+    grid = np.array([[1, -1], [2, -1]])
+    prob = probability_heatmap(grid, 3, n_iter=8, seed=1, nearest_weight=1.0)
+    from modules import nearest_value_affinity
+
+    near = nearest_value_affinity(grid, 3)
+    assert np.allclose(prob, near)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from modules import global_offset_cooccurrence
+from modules import global_offset_cooccurrence, neighbor_value_distribution
 
 
 def test_global_offset_cooccurrence_batch():
@@ -20,3 +20,13 @@ def test_global_offset_cooccurrence_single():
     out = global_offset_cooccurrence(board, target=1, offsets=[1])
     assert out.shape == board.shape
     assert np.all(out >= 0)
+
+
+def test_neighbor_value_distribution_fallback():
+    board = np.array([[4, 10], [5, -1]])
+    base = neighbor_value_distribution(board, target=7, tolerance=1, radius=1)
+    near = neighbor_value_distribution(
+        board, target=7, tolerance=1, radius=1, nearest_k=1
+    )
+    assert near.shape == board.shape
+    assert not np.allclose(base, near)


### PR DESCRIPTION
## Summary
- enhance `neighbor_value_distribution` with `nearest_k` fallback
- expose `nearest_value_affinity` helper
- blend global heatmap with nearest affinity in `probability_heatmap`
- add CRF local fusion via `compute_nearest_value_heatmap`
- extend tests for new functionality

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629600164083248fcd79c049e847f6