### PR TITLE
Implement position distribution stats

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -6,6 +6,7 @@ import math
 import os
 import sys
 import zipfile
+from collections import defaultdict
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -92,7 +93,14 @@ def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
                 logger.warning("Row/col mismatch in %s:%s", zip_path.name, name)
                 continue
             count += 1
-            yield {"rows": rows, "cols": cols, "grid": grid}
+            item = {
+                "rows": rows,
+                "cols": cols,
+                "grid": grid,
+                "target_num": data.get("target_num"),
+                "mode": data.get("mode"),
+            }
+            yield item
     logger.info("Loaded %s (%d JSON)", zip_path.name, count)
 
 
@@ -130,6 +138,63 @@ def compute_history_frequency(
         total,
     )
     return freq
+
+
+def compute_position_distribution(
+    samples_dir: str,
+    rows: int,
+    cols: int,
+    *,
+    mode: Optional[str] = None,
+) -> Dict[Tuple[int, int], Dict[int, int]]:
+    """Return per-cell number frequency counts from history samples."""
+    stats: Dict[Tuple[int, int], Dict[int, int]] = {
+        (r, c): defaultdict(int) for r in range(rows) for c in range(cols)
+    }
+    total = 0
+    for sample in iter_sample_jsons(samples_dir):
+        if sample["rows"] != rows or sample["cols"] != cols:
+            continue
+        if mode and sample.get("mode") != mode:
+            continue
+        total += 1
+        grid = np.asarray(sample["grid"], dtype=int)
+        for r in range(rows):
+            for c in range(cols):
+                k = int(grid[r, c])
+                stats[(r, c)][k] += 1
+    logger.info(
+        "Position distribution for %d×%d processed %d samples%s",
+        rows,
+        cols,
+        total,
+        f" mode={mode}" if mode else "",
+    )
+    return {k: dict(v) for k, v in stats.items()}
+
+
+def predict_number(
+    grid_with_blank: List[List[int]] | np.ndarray,
+    stats: Dict[Tuple[int, int], Dict[int, int]],
+) -> List[Tuple[Tuple[int, int], int, float]]:
+    """Predict numbers for blanks in ``grid_with_blank`` using precomputed stats."""
+    grid = np.asarray(grid_with_blank, dtype=int)
+    rows, cols = grid.shape
+    used = {int(v) for v in grid.ravel() if v != -1}
+    all_nums = set(range(1, rows * cols + 1))
+    remain = all_nums - used
+    predictions: List[Tuple[Tuple[int, int], int, float]] = []
+    for r in range(rows):
+        for c in range(cols):
+            if grid[r, c] == -1:
+                dist = stats.get((r, c), {})
+                total = sum(dist.get(n, 0) for n in remain) or 1
+                for n in sorted(remain):
+                    freq = dist.get(n, 0)
+                    score = float(freq) / float(total)
+                    predictions.append(((r, c), n, score))
+    predictions.sort(key=lambda x: x[2], reverse=True)
+    return predictions
 
 
 @lru_cache(maxsize=8)

--- a/tests/test_position_stats.py
+++ b/tests/test_position_stats.py
@@ -1,0 +1,39 @@
+import json
+import zipfile
+
+import analyzer
+
+
+def _make_samples(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data1 = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]], "mode": "excel"}
+    data2 = {"rows": 2, "cols": 2, "grid": [[2, 1], [3, 4]], "mode": "shuffle"}
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps(data1))
+        zf.writestr("b.json", json.dumps(data2))
+    return samples
+
+
+def test_compute_position_distribution(tmp_path):
+    samples = _make_samples(tmp_path)
+    stats = analyzer.compute_position_distribution(str(samples), 2, 2)
+    assert stats[(0, 0)][1] == 1
+    assert stats[(0, 0)][2] == 1
+    stats_excel = analyzer.compute_position_distribution(
+        str(samples), 2, 2, mode="excel"
+    )
+    assert stats_excel[(0, 0)][1] == 1
+    assert 2 not in stats_excel[(0, 0)]
+
+
+def test_predict_number(tmp_path):
+    samples = _make_samples(tmp_path)
+    stats = analyzer.compute_position_distribution(str(samples), 2, 2)
+    grid = [[-1, 2], [3, 4]]
+    preds = analyzer.predict_number(grid, stats)
+    assert preds
+    cell, num, score = preds[0]
+    assert cell == (0, 0)
+    assert num == 1
+    assert abs(score - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- extend `_iter_json_from_zip` to keep mode and target number fields
- add `compute_position_distribution` and `predict_number` helpers
- test coverage for new stats and prediction utilities

## Testing
- `black --check analyzer.py tests/test_position_stats.py`
- `isort --check analyzer.py tests/test_position_stats.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633dad18c4832495cb5b516b8e1bfd