### PR TITLE
Add strategy registry and evaluation test

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1,3 +1,4 @@
+# isort: skip_file
 import base64
 import heapq
 import json
@@ -19,6 +20,7 @@ from numba import njit
 import brain
 
 # fmt: off
+# isort: off
 from brain import (
     AGG_WEIGHTS,
     REGISTERED_MODULES_BRAIN,
@@ -28,9 +30,9 @@ from brain import (
     bytes_to_grid,
     get_module_score,
 )
-
 # fmt: on
-from modules import FORMULA_REGISTRY, detect_skip_patterns
+# isort: on
+from modules import FORMULA_REGISTRY, detect_skip_patterns, generate_unique_grid
 
 # Logger configuration
 logging.basicConfig(
@@ -1611,3 +1613,40 @@ def probability_heatmap(
         for n, p in cell.items():
             result[int(n)][r, c] = p
     return result
+
+
+def evaluate_prediction_accuracy(num_trials: int = 50, seed: int = 0) -> float:
+    """Return top-1 accuracy over randomly generated boards."""
+
+    rng = np.random.default_rng(seed)
+    hits = 0
+    trials = 0
+    for _ in range(num_trials):
+        rows = int(rng.integers(4, 21))
+        cols = int(rng.integers(5, 21))
+        full = generate_unique_grid(rows, cols, rng=rng)
+        mask = rng.random((rows, cols)) < 0.5
+        board = full.copy()
+        board[mask] = -1
+        blanks = np.argwhere(board == -1)
+        if blanks.size == 0:
+            continue
+        r, c = blanks[rng.integers(len(blanks))]
+        target = int(full[r, c])
+        board[r, c] = -1
+        res = predict_scratch_card(
+            board.tolist(),
+            target_num=target,
+            iterations=20,
+            global_iter=10,
+            focus_iter=5,
+            top_n=5,
+            epsilon=0.1,
+        )
+        preds = res.get("predictions", [])
+        trials += 1
+        if preds and preds[0]["row"] == r and preds[0]["col"] == c:
+            hits += 1
+    if trials == 0:
+        return 0.0
+    return hits / float(trials)

--- a/app.py
+++ b/app.py
@@ -16,13 +16,9 @@ from pydantic import BaseModel
 # fmt: off
 import analyzer
 import brain
-from analyzer import (
-    compute_position_probabilities,
-    iter_sample_jsons,
-    predict_scratch_card,
-    probability_heatmap,
-    render_heatmap,
-)
+from analyzer import (compute_position_probabilities, iter_sample_jsons,
+                      predict_scratch_card, probability_heatmap,
+                      render_heatmap)
 
 # fmt: on
 brain.priors_map: Dict[Tuple[int, int], Dict[int, float]] = {}

--- a/brain.py
+++ b/brain.py
@@ -7,14 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import numpy as np
 
 from modules import DEFAULT_WEIGHTS as DEFAULT_AGG_WEIGHTS
-from modules import (
-    compute_difference_trend,
-    compute_focus_score,
-    connectivity_heatmap,
-    detect_mirror_sequences,
-    detect_skip_patterns,
-    sequence_tail_analyzer,
-)
+from modules import STRATEGY_REGISTRY
 
 logger = logging.getLogger(__name__)
 
@@ -72,12 +65,7 @@ def bytes_to_grid(grid_bytes: bytes, shape):
 
 
 REGISTERED_MODULES_BRAIN: Dict[str, Callable[[np.ndarray], np.ndarray]] = {
-    "focus": compute_focus_score,
-    "skip": detect_skip_patterns,
-    "diff": compute_difference_trend,
-    "mirror": detect_mirror_sequences,
-    "conn": connectivity_heatmap,
-    "tail": sequence_tail_analyzer,
+    name: strat.func for name, strat in STRATEGY_REGISTRY.items()
 }
 
 

--- a/modules.py
+++ b/modules.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -9,6 +10,27 @@ FORMULA_REGISTRY: Dict[
     str,
     Callable[[int, int, np.random.Generator], np.ndarray],
 ] = {}
+
+
+@dataclass
+class ModuleStrategy:
+    """Container for a scoring module."""
+
+    func: Callable[[np.ndarray], np.ndarray]
+    weight: float
+
+
+STRATEGY_REGISTRY: Dict[str, ModuleStrategy] = {}
+
+
+def register_strategy(name: str, *, weight: float) -> Callable[[Callable], Callable]:
+    """Decorator to register a scoring strategy."""
+
+    def _decorator(fn: Callable) -> Callable:
+        STRATEGY_REGISTRY[name] = ModuleStrategy(fn, weight)
+        return fn
+
+    return _decorator
 
 
 def generate_unique_grid(
@@ -293,6 +315,7 @@ def nearest_value_affinity(
     return score
 
 
+@register_strategy("focus", weight=0.2)
 def compute_focus_score(grid: np.ndarray) -> np.ndarray:
     """Compute density of known cells in 3x3 neighborhood."""
     mask = (grid != -1).astype(int)
@@ -306,6 +329,7 @@ def compute_focus_score(grid: np.ndarray) -> np.ndarray:
     return result
 
 
+@register_strategy("skip", weight=0.15)
 def detect_skip_patterns(grid: np.ndarray) -> np.ndarray:
     """Detect arithmetic skip patterns along rows and columns."""
     M, N = grid.shape
@@ -335,6 +359,7 @@ def detect_skip_patterns(grid: np.ndarray) -> np.ndarray:
     return score
 
 
+@register_strategy("diff", weight=0.15)
 def compute_difference_trend(grid: np.ndarray) -> np.ndarray:
     """Infer values based on local difference trend."""
     M, N = grid.shape
@@ -350,6 +375,7 @@ def compute_difference_trend(grid: np.ndarray) -> np.ndarray:
     return score
 
 
+@register_strategy("mirror", weight=0.2)
 def detect_mirror_sequences(grid: np.ndarray) -> np.ndarray:
     """Check horizontal and vertical mirror symmetry."""
     M, N = grid.shape
@@ -375,6 +401,7 @@ def detect_mirror_sequences(grid: np.ndarray) -> np.ndarray:
     return score
 
 
+@register_strategy("conn", weight=0.15)
 def connectivity_heatmap(grid: np.ndarray) -> np.ndarray:
     """Distance weighted sum of known numbers."""
     M, N = grid.shape
@@ -392,6 +419,7 @@ def connectivity_heatmap(grid: np.ndarray) -> np.ndarray:
     return score
 
 
+@register_strategy("tail", weight=0.15)
 def sequence_tail_analyzer(grid: np.ndarray) -> np.ndarray:
     """Analyze digit tails frequency weighted by distance."""
     M, N = grid.shape
@@ -423,14 +451,16 @@ def sequence_tail_analyzer(grid: np.ndarray) -> np.ndarray:
     return score
 
 
-DEFAULT_WEIGHTS = {
-    "focus": 0.2,
-    "skip": 0.15,
-    "diff": 0.15,
-    "mirror": 0.2,
-    "conn": 0.15,
-    "tail": 0.15,
-}
+@register_strategy("affinity", weight=0.15)
+def target_affinity(grid: np.ndarray, *, target: Optional[int] = None) -> np.ndarray:
+    """Affinity based on nearest value distribution."""
+
+    if target is None:
+        return np.zeros_like(grid, dtype=float)
+    return nearest_value_affinity(grid, target, k=3, tolerance=1, radius=1)
+
+
+DEFAULT_WEIGHTS = {name: strat.weight for name, strat in STRATEGY_REGISTRY.items()}
 
 
 def fuse_scores(

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,0 +1,6 @@
+import analyzer
+
+
+def test_evaluate_prediction_accuracy():
+    acc = analyzer.evaluate_prediction_accuracy(num_trials=3, seed=0)
+    assert 0.0 <= acc <= 1.0

--- a/tests/test_custom_modules.py
+++ b/tests/test_custom_modules.py
@@ -1,3 +1,4 @@
+# isort: skip_file
 import numpy as np
 
 from modules import (

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -5,7 +5,7 @@ import brain
 
 
 def test_modules_registered():
-    for name in ["focus", "skip", "diff", "mirror", "conn", "tail"]:
+    for name in ["focus", "skip", "diff", "mirror", "conn", "tail", "affinity"]:
         assert name in brain.REGISTERED_MODULES_BRAIN
         assert name in brain.AGG_WEIGHTS
 


### PR DESCRIPTION
## Summary
- implement `ModuleStrategy` with registration decorator
- register all scoring modules and new `affinity` heuristic
- use strategy registry in `brain` module
- add evaluation utility and accuracy test
- adjust imports and tests

## Testing
- `black . --check`
- `isort analyzer.py tests/test_custom_modules.py tests/test_accuracy.py brain.py modules.py app.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863dd670d9c8324a598a8999dbd230c