### PR TITLE
Fix API to skip filled positions

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -959,6 +959,7 @@ def predict_scratch_card(
     sample_gamma: float = 0.0,
     fusion_alpha: float = 0.5,
     pseudo_count: float = 0.0,
+    exclude_filled: bool = False,
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
     rows, cols = grid_np.shape
@@ -1100,6 +1101,11 @@ def predict_scratch_card(
         total = sum(dist.values()) or 1e-12
         for k in dist:
             dist[k] /= total
+
+    if exclude_filled:
+        prob_map = {
+            (r, c): dist for (r, c), dist in prob_map.items() if grid_np[r, c] == -1
+        }
 
     module_scores = {
         mod: get_module_score(mod, grid_np, priors=priors, target=target_num)

--- a/app.py
+++ b/app.py
@@ -83,6 +83,7 @@ class GridRequest(BaseModel):
     sample_gamma: Optional[float] = None
     fusion_alpha: Optional[float] = None
     pseudo_count: Optional[float] = None
+    exclude_filled: bool = True
 
 
 class Prediction(BaseModel):
@@ -262,6 +263,7 @@ async def predict(req: GridRequest):
             sample_gamma=req.sample_gamma or 0.0,
             fusion_alpha=req.fusion_alpha or 0.5,
             pseudo_count=req.pseudo_count or 0.0,
+            exclude_filled=req.exclude_filled,
         )
 
         full_probs = result.get("full_probabilities", {})
@@ -328,6 +330,7 @@ async def heatmap(req: HeatmapRequest):
             result_top_k=3,
             priors=brain.priors_map[key],
             sample_gamma=req.sample_gamma or 0.0,
+            exclude_filled=True,
         )
 
         full_probs = pred_result.get("full_probabilities", {})

--- a/main.py
+++ b/main.py
@@ -89,6 +89,11 @@ def parse_args() -> argparse.Namespace:
         default=0.0,
         help="Weight for sample-based frequency prior",
     )
+    parser.add_argument(
+        "--exclude-filled",
+        action="store_true",
+        help="Exclude already filled cells from predictions",
+    )
     return parser.parse_args()
 
 
@@ -145,6 +150,7 @@ def main():
             result_top_k=None,
             priors=priors,
             sample_gamma=args.sample_gamma,
+            exclude_filled=args.exclude_filled,
         )
         ray.shutdown()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,3 +96,13 @@ def test_predict_1_based_bottom_right(client):
     assert pred["row"] == 2
     assert pred["col"] == 2
     assert "2,2" in body["full_probabilities"]
+
+
+def test_predict_excludes_filled_cells(client):
+    grid = [[1, -1], [-1, 4]]
+    payload = {"grid": grid, "target_num": 3, "iterations": 2}
+    resp = client.post("/predict", json=payload)
+    body = resp.json()
+    coords = {(p["row"], p["col"]) for p in body["predictions"]}
+    assert (1, 1) not in coords
+    assert (2, 2) not in coords


### PR DESCRIPTION
## Summary
- add `exclude_filled` option to request schema and CLI
- ensure `predict_scratch_card` filters filled cells when requested
- pass the flag in API routes
- test that predictions never include non-empty cells

## Testing
- `black --check app.py analyzer.py main.py tests/test_api.py`
- `isort --check-only app.py main.py tests/test_api.py`
- `flake8 app.py analyzer.py main.py tests/test_api.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640eff53788324be10f5ded43e5994