### PR TITLE
Add reliability accuracy tests

### DIFF
--- a/tests/reliability_utils.py
+++ b/tests/reliability_utils.py
@@ -1,32 +1,72 @@
 import numpy as np
-from modules import generate_unique_grid
+
 from analyzer import probability_heatmap
-from tqdm import tqdm
+from modules import generate_unique_grid
+
+
+def _simulate_single(
+    rng: np.random.Generator, rows: int, cols: int, mask_ratio: float
+) -> bool:
+    full = generate_unique_grid(rows, cols, rng=rng)
+    mask = rng.random((rows, cols)) < mask_ratio
+    board = full.copy()
+    board[mask] = -1
+    blanks = np.argwhere(board == -1)
+    if blanks.size == 0:
+        return False
+    r, c = blanks[rng.integers(len(blanks))]
+    target = int(full[r, c])
+    heat = probability_heatmap(
+        board, target, n_iter=1000, seed=int(rng.integers(1_000_000))
+    )
+    pr, pc = divmod(int(np.argmax(heat)), cols)
+    return pr == r and pc == c
+
 
 def run_infinite_test(
-    min_size=4, max_size=20, mask_ratio=0.5,
-    max_iters=1_000_000, seed=42, log_every=1_000
-):
-    """
-    无限压力测试：命令行执行 python -m tests.reliability_utils run_infinite_test
-    """
+    min_size: int = 4,
+    max_size: int = 20,
+    mask_ratio: float = 0.5,
+    max_iters: int = 1_000_000,
+    seed: int = 42,
+    log_every: int = 1000,
+) -> None:
+    """Continuous stress test printing accuracy periodically."""
     rng = np.random.default_rng(seed)
     hits = total = 0
-    for i in tqdm(range(1, max_iters + 1), desc="Stress Testing"):
-        # …（跟之前的 run_infinite_test 一样）…
-        pass
+    for i in range(1, max_iters + 1):
+        rows = int(rng.integers(min_size, max_size + 1))
+        cols = int(rng.integers(max(min_size, 5), max_size + 1))
+        if _simulate_single(rng, rows, cols, mask_ratio):
+            hits += 1
+        total += 1
+        if i % log_every == 0:
+            acc = hits / float(total)
+            print(f"{i}: accuracy={acc:.3f}")
+
 
 def run_until_converged(
-    min_size=4, max_size=20, mask_ratio=0.5,
-    batch_size=200, delta=0.02, z=1.96, seed=0
-):
-    """
-    批次收敛测试：被 pytest 的 test_accuracy_converges 调用
-    """
+    min_size: int = 4,
+    max_size: int = 20,
+    mask_ratio: float = 0.5,
+    batch_size: int = 200,
+    delta: float = 0.02,
+    z: float = 1.96,
+    seed: int = 0,
+) -> tuple[float, float, int]:
+    """Run batches of simulations until the confidence interval is below ``delta``."""
     rng = np.random.default_rng(seed)
     hits = total = 0
     max_batches = 50
-    for batch in range(1, max_batches + 1):
-        # …（同之前）…
-        pass
-    return hits / total, z * ((hits/total)*(1-hits/total)/total)**0.5, total
+    for _ in range(max_batches):
+        for _ in range(batch_size):
+            rows = int(rng.integers(min_size, max_size + 1))
+            cols = int(rng.integers(max(min_size, 5), max_size + 1))
+            if _simulate_single(rng, rows, cols, mask_ratio):
+                hits += 1
+            total += 1
+        p = hits / float(total)
+        hw = z * ((p * (1 - p) / max(1, total)) ** 0.5)
+        if hw <= delta and total >= batch_size * 5:
+            break
+    return p, hw, total

--- a/tests/reliable_accuracy_test_suite.py
+++ b/tests/reliable_accuracy_test_suite.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from analyzer import probability_heatmap
+from modules import generate_unique_grid
+
+
+def run_accuracy_trials(n_rounds: int = 1000, seed: int = 0) -> float:
+    rng = np.random.default_rng(seed)
+    hits = 0
+    for _ in range(n_rounds):
+        rows = int(rng.integers(4, 21))
+        cols = int(rng.integers(5, 21))
+        full = generate_unique_grid(rows, cols, rng=rng)
+        mask = rng.random((rows, cols)) < 0.5
+        board = full.copy()
+        board[mask] = -1
+        blanks = np.argwhere(board == -1)
+        if blanks.size == 0:
+            continue
+        r, c = blanks[rng.integers(len(blanks))]
+        target = int(full[r, c])
+        heat = probability_heatmap(
+            board, target, n_iter=1000, seed=int(rng.integers(1_000_000))
+        )
+        pr, pc = divmod(int(np.argmax(heat)), cols)
+        if pr == r and pc == c:
+            hits += 1
+    return hits / float(n_rounds)

--- a/tests/test_accuracy_converges.py
+++ b/tests/test_accuracy_converges.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tests.reliability_utils import run_until_converged
+
+
+@pytest.mark.timeout(120)
+def test_accuracy_estimation_converges():
+    p, hw, total = run_until_converged(
+        min_size=4,
+        max_size=6,
+        batch_size=50,
+        delta=0.1,
+        seed=123,
+    )
+    assert total > 0
+    assert 0.0 <= p <= 1.0
+    assert hw <= 0.1

--- a/tests/test_reliable_accuracy.py
+++ b/tests/test_reliable_accuracy.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
-from tests.reliability_utils import run_until_converged
-from modules import generate_unique_grid
+
 from analyzer import probability_heatmap
+from modules import generate_unique_grid
+from tests.reliability_utils import run_until_converged
+
 
 @pytest.mark.timeout(120)
 def test_accuracy_converges():
@@ -13,27 +15,36 @@ def test_accuracy_converges():
     assert hw <= 0.05
     assert 0.0 <= p <= 1.0
 
+
 @pytest.mark.slow
-@pytest.mark.parametrize("rows,cols,mask_ratio", [
-    (4,4,0.5), (8,8,0.5), (12,10,0.5), (16,16,0.5),
-])
+@pytest.mark.parametrize(
+    "rows,cols,mask_ratio",
+    [
+        (4, 4, 0.5),
+        (8, 8, 0.5),
+        (12, 10, 0.5),
+        (16, 16, 0.5),
+    ],
+)
 def test_reliability_1000_runs(rows, cols, mask_ratio):
     rng = np.random.default_rng(0)
     hits = 0
     trials = 1000
     total_cells = rows * cols
     for _ in range(trials):
-        full_grid = generate_unique_grid(rows, cols, rng)
+        full_grid = generate_unique_grid(rows, cols, rng=rng)
         grid = full_grid.copy()
-        mask_idxs = rng.choice(total_cells, total_cells//2, replace=False)
+        mask_idxs = rng.choice(total_cells, total_cells // 2, replace=False)
         for idx in mask_idxs:
             r, c = divmod(idx, cols)
             grid[r][c] = -1
-        tr, tc = rng.choice([(r,c) for r in range(rows) for c in range(cols) if grid[r][c]!=-1])
+        tr, tc = rng.choice(
+            [(r, c) for r in range(rows) for c in range(cols) if grid[r][c] != -1]
+        )
         target = full_grid[tr][tc]
         heatmap = probability_heatmap(grid, target)
-        pred_pos, _ = max(heatmap.items(), key=lambda x: x[1])
-        if pred_pos == (tr, tc):
+        pr, pc = divmod(int(np.argmax(heatmap)), cols)
+        if (pr, pc) == (tr, tc):
             hits += 1
     acc = hits / trials
     assert 0.0 <= acc <= 1.0


### PR DESCRIPTION
## Summary
- implement reliability utilities for convergence tests
- provide a simple simulation suite to estimate module accuracy
- add new tests covering convergence logic and fix existing reliability test

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686416c845788324880719a57ea7510a