### PR TITLE
Add target locator helper

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -156,6 +156,47 @@ def gen_tail_cluster(
     return board.reshape(rows, cols)
 
 
+def generate_excel_style_card(
+    rows: int, cols: int, rng: Optional[np.random.Generator] = None
+) -> np.ndarray:
+    """Return an ``rows x cols`` grid filled with unique numbers."""
+
+    if rng is None:
+        rng = np.random.default_rng()
+    n = rows * cols
+    values = rng.choice(np.arange(1, n + 1), size=n, replace=False)
+    return values.reshape((rows, cols))
+
+
+def locate_target_by_partial_grid(
+    grid: List[List[int]], target: int
+) -> Tuple[int, int]:
+    """Predict the target's location from a partially hidden grid.
+
+    This implementation falls back to a random choice among unknown cells
+    when the target is hidden. It therefore does **not** guarantee high
+    accuracy but returns a valid coordinate.
+    """
+
+    arr = np.asarray(grid, dtype=int)
+    if arr.ndim != 2:
+        raise ValueError("grid must be a 2D array")
+
+    idx = np.argwhere(arr == target)
+    if idx.size:
+        r, c = idx[0]
+        return int(r), int(c)
+
+    hidden = np.argwhere(arr == -1)
+    if hidden.size == 0:
+        raise ValueError("target not found and no hidden cells available")
+
+    rng = np.random.default_rng()
+    choice = int(rng.integers(len(hidden)))
+    r, c = hidden[choice]
+    return int(r), int(c)
+
+
 def global_offset_cooccurrence(
     boards: np.ndarray,
     target: Optional[int] = None,

--- a/tests/test_locate_target.py
+++ b/tests/test_locate_target.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from modules import generate_excel_style_card, locate_target_by_partial_grid
+
+
+def test_locate_target_visible():
+    rng = np.random.default_rng(0)
+    board = generate_excel_style_card(4, 4, rng)
+    target = int(board[1, 2])
+    row, col = locate_target_by_partial_grid(board.tolist(), target)
+    assert (row, col) == (1, 2)
+
+
+def test_locate_target_hidden_valid_range():
+    rng = np.random.default_rng(1)
+    board = generate_excel_style_card(5, 5, rng)
+    target = int(board[2, 3])
+    board[2, 3] = -1
+    row, col = locate_target_by_partial_grid(board.tolist(), target)
+    assert 0 <= row < 5 and 0 <= col < 5


### PR DESCRIPTION
## Summary
- implement `generate_excel_style_card` and `locate_target_by_partial_grid`
- add unit tests for the helper

## Testing
- `black --check modules.py tests/test_locate_target.py`
- `isort --check modules.py tests/test_locate_target.py`
- `flake8 modules.py tests/test_locate_target.py`
- `python -m py_compile $(git ls-files '*.py')`
- `FAST_TEST=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a3efcfd8832485736a025e1f88ba