### PR TITLE
Implement modern predictor strategy

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -991,6 +991,7 @@ def predict_scratch_card(
     fusion_alpha: float = 0.5,
     pseudo_count: float = 0.0,
     exclude_filled: bool = False,
+    strategy: str = "legacy",
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
     rows, cols = grid_np.shape
@@ -1160,6 +1161,11 @@ def predict_scratch_card(
     final_recs = _compute_final_recommendations(
         prob_map, module_norm, target_num, fusion_alpha, top_k
     )
+    if strategy == "modern":
+        try:
+            final_recs = brain.REGISTERED_MODULES["modern"](grid, target_num)[:top_k]
+        except Exception as exc:  # pragma: no cover - unexpected failure
+            logger.error("modern predictor failed: %s", exc)
 
     if target_num is not None:
         rank = [

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ import brain
 from analyzer import (compute_position_probabilities, iter_sample_jsons,
                       predict_scratch_card, probability_heatmap,
                       render_heatmap)
+from position_prior import build_position_prior_map
 
 # fmt: on
 brain.priors_map: Dict[Tuple[int, int], Dict[int, float]] = {}
@@ -81,6 +82,10 @@ async def _load_samples_background():
 async def startup_event():
     asyncio.create_task(_load_samples_background())
     analyzer.load_global_pos_freq("samples")
+    try:
+        brain.priors_map = build_position_prior_map("samples")
+    except Exception as exc:  # pragma: no cover - optional failure
+        logger.error("position prior build failed: %s", exc)
 
 
 # ==== Schemas ==============================================================
@@ -97,6 +102,7 @@ class GridRequest(BaseModel):
     fusion_alpha: Optional[float] = None
     pseudo_count: Optional[float] = None
     exclude_filled: bool = True
+    strategy: Literal["legacy", "modern"] = "legacy"
 
 
 class Prediction(BaseModel):
@@ -277,6 +283,7 @@ async def predict(req: GridRequest):
             fusion_alpha=req.fusion_alpha or 0.5,
             pseudo_count=req.pseudo_count or 0.0,
             exclude_filled=req.exclude_filled,
+            strategy=req.strategy,
         )
 
         full_probs = result.get("full_probabilities", {})

--- a/brain.py
+++ b/brain.py
@@ -6,8 +6,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 
+import modern_predictor
 from modules import DEFAULT_WEIGHTS as DEFAULT_AGG_WEIGHTS
-from modules import STRATEGY_REGISTRY
+from modules import STRATEGY_REGISTRY, fuse_scores
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,12 @@ def bytes_to_grid(grid_bytes: bytes, shape):
 
 REGISTERED_MODULES_BRAIN: Dict[str, Callable[[np.ndarray], np.ndarray]] = {
     name: strat.func for name, strat in STRATEGY_REGISTRY.items()
+}
+
+# predictor registry for ranking strategies
+REGISTERED_MODULES: Dict[str, Callable] = {
+    "modern": modern_predictor.predict_location,
+    "legacy": fuse_scores,
 }
 
 

--- a/main.py
+++ b/main.py
@@ -60,6 +60,12 @@ def parse_args() -> argparse.Namespace:
         help="Phase-2 focused iteration count",
     )
     parser.add_argument("--top-n", type=int, default=10, help="Top cells to refine")
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=None,
+        help="Number of top candidates to output",
+    )
     parser.add_argument("--epsilon", type=float, default=0.05, help="Exploration rate")
     parser.add_argument(
         "--target", type=int, default=None, help="Target number to predict"
@@ -93,6 +99,13 @@ def parse_args() -> argparse.Namespace:
         "--exclude-filled",
         action="store_true",
         help="Exclude already filled cells from predictions",
+    )
+    parser.add_argument(
+        "--strategy",
+        type=str,
+        choices=["legacy", "modern"],
+        default="legacy",
+        help="Prediction ranking strategy",
     )
     return parser.parse_args()
 
@@ -147,10 +160,11 @@ def main():
             focus_iter=args.focus_iter,
             top_n=args.top_n,
             epsilon=args.epsilon,
-            result_top_k=None,
+            result_top_k=args.top_k,
             priors=priors,
             sample_gamma=args.sample_gamma,
             exclude_filled=args.exclude_filled,
+            strategy=args.strategy,
         )
         ray.shutdown()
 

--- a/position_prior.py
+++ b/position_prior.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Dict, Tuple
 
 import numpy as np
 
@@ -40,3 +41,20 @@ def build_position_prior(samples_dir: str, outfile: str, buckets: int = 20) -> N
     freq = counts.astype(float) / totals
     np.savez_compressed(outfile, freq=freq)
     logger.info("position prior saved to %s", outfile)
+
+
+def build_position_prior_map(
+    samples_dir: str, buckets: int = 20
+) -> Dict[Tuple[int, int], Dict[Tuple[int, int], Dict[int, float]]]:
+    """Return per-board position probability maps for all sample sizes."""
+    from analyzer import compute_position_probabilities
+
+    dims: set[Tuple[int, int]] = set()
+    for sample in iter_sample_jsons(str(samples_dir)):
+        dims.add((sample["rows"], sample["cols"]))
+
+    priors: Dict[Tuple[int, int], Dict[Tuple[int, int], Dict[int, float]]] = {}
+    for rows, cols in sorted(dims):
+        priors[(rows, cols)] = compute_position_probabilities(samples_dir, rows, cols)
+    logger.info("position prior map built for %d board sizes", len(priors))
+    return priors

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -120,3 +120,11 @@ def test_predict_excludes_filled_cells(client):
     coords = {(p["row"], p["col"]) for p in body["predictions"]}
     assert (1, 1) not in coords
     assert (2, 2) not in coords
+
+
+def test_predict_strategy_modern(client):
+    grid = [[1, -1], [2, -1]]
+    payload = {"grid": grid, "strategy": "modern"}
+    resp = client.post("/predict", json=payload)
+    assert resp.status_code == 200
+    assert "final_recommendations" in resp.json()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,3 +23,25 @@ def test_cli_quick_exit(tmp_path):
     assert cp.returncode == 0
     assert "Prediction" in cp.stderr
     assert "Complete!" in cp.stderr
+
+
+def test_cli_top_k(tmp_path):
+    board = [[1, 2], [3, -1]]
+    grid_str = ";".join(",".join(str(x) for x in row) for row in board)
+    cp = subprocess.run(
+        [
+            sys.executable,
+            "main.py",
+            "--grid",
+            grid_str,
+            "--iterations",
+            "4",
+            "--target",
+            "4",
+            "--top-k",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert cp.returncode == 0

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -21,6 +21,7 @@ def test_modules_registered():
     for name in names:
         assert name in brain.REGISTERED_MODULES_BRAIN
         assert name in brain.AGG_WEIGHTS
+    assert "modern" in brain.REGISTERED_MODULES
 
 
 def test_module_shapes(make_grid):

--- a/tests/test_position_prior_map.py
+++ b/tests/test_position_prior_map.py
@@ -1,0 +1,16 @@
+import json
+import zipfile
+
+from position_prior import build_position_prior_map
+
+
+def test_build_position_prior_map(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps(data))
+
+    priors = build_position_prior_map(str(samples))
+    assert (2, 2) in priors
+    assert priors[(2, 2)][(0, 0)][1] == 1.0


### PR DESCRIPTION
## Summary
- register modern predictor in brain
- support strategy parameter in analyzer.predict_scratch_card
- add global position prior map loader on startup
- wire strategy through API and CLI
- add --top-k option for CLI output control
- test new predictor strategy and prior map builder
- test CLI top-k argument

## Testing
- `black --check analyzer.py app.py brain.py main.py position_prior.py tests/test_api.py tests/test_cli.py tests/test_new_modules.py tests/test_position_prior_map.py`
- `isort --check app.py analyzer.py brain.py main.py position_prior.py tests/test_api.py tests/test_cli.py tests/test_new_modules.py tests/test_position_prior_map.py`
- `flake8 app.py analyzer.py brain.py main.py position_prior.py tests/test_api.py tests/test_cli.py tests/test_new_modules.py tests/test_position_prior_map.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651f5555788324931c4e75c486222a