### PR TITLE
Ensure predictions stay within empty cells

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -990,7 +990,7 @@ def predict_scratch_card(
     sample_gamma: float = 0.0,
     fusion_alpha: float = 0.5,
     pseudo_count: float = 0.0,
-    exclude_filled: bool = False,
+    exclude_filled: bool = True,
     strategy: str = "legacy",
 ) -> Dict[str, Any]:
     grid_np = np.array(grid, dtype=np.int64)
@@ -1134,10 +1134,9 @@ def predict_scratch_card(
         for k in dist:
             dist[k] /= total
 
-    if exclude_filled:
-        prob_map = {
-            (r, c): dist for (r, c), dist in prob_map.items() if grid_np[r, c] == -1
-        }
+    prob_map = {
+        (r, c): dist for (r, c), dist in prob_map.items() if grid_np[r, c] == -1
+    }
 
     module_scores = {
         mod: get_module_score(mod, grid_np, priors=priors, target=target_num)

--- a/app.py
+++ b/app.py
@@ -282,7 +282,6 @@ async def predict(req: GridRequest):
             sample_gamma=req.sample_gamma or 0.0,
             fusion_alpha=req.fusion_alpha or 0.5,
             pseudo_count=req.pseudo_count or 0.0,
-            exclude_filled=req.exclude_filled,
             strategy=req.strategy,
         )
 
@@ -350,7 +349,6 @@ async def heatmap(req: HeatmapRequest):
             result_top_k=3,
             priors=brain.priors_map[key],
             sample_gamma=req.sample_gamma or 0.0,
-            exclude_filled=True,
         )
 
         full_probs = pred_result.get("full_probabilities", {})

--- a/main.py
+++ b/main.py
@@ -96,11 +96,6 @@ def parse_args() -> argparse.Namespace:
         help="Weight for sample-based frequency prior",
     )
     parser.add_argument(
-        "--exclude-filled",
-        action="store_true",
-        help="Exclude already filled cells from predictions",
-    )
-    parser.add_argument(
         "--strategy",
         type=str,
         choices=["legacy", "modern"],
@@ -163,7 +158,6 @@ def main():
             result_top_k=args.top_k,
             priors=priors,
             sample_gamma=args.sample_gamma,
-            exclude_filled=args.exclude_filled,
             strategy=args.strategy,
         )
         ray.shutdown()

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -86,3 +86,16 @@ def test_probabilities_not_uniform():
     prob_map = simulate_full_board(grid, None, n_iter=20)
     cell = prob_map[(1, 1)]
     assert len(cell) == 1 and next(iter(cell.values())) == 1.0
+
+
+def test_predict_always_excludes_filled_cells():
+    grid = [[1, -1], [-1, 4]]
+    res = analyzer.predict_scratch_card(
+        grid,
+        target_num=3,
+        iterations=4,
+        exclude_filled=False,
+    )
+    coords = {(p["row"], p["col"]) for p in res["predictions"]}
+    assert (0, 0) not in coords
+    assert (1, 1) not in coords


### PR DESCRIPTION
## Summary
- enforce that predictor always excludes filled cells
- remove unused CLI option
- adjust API usage accordingly
- add regression test to confirm behaviour

## Testing
- `pytest tests/test_analyzer.py::test_predict_always_excludes_filled_cells -q`

------
https://chatgpt.com/codex/tasks/task_e_68653259cbe48324b0ba364b24a5c25a