### PR TITLE
Centralize scoring weights

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -21,7 +21,6 @@ import brain
 # fmt: off
 # isort: off
 from brain import (
-    AGG_WEIGHTS,
     REGISTERED_MODULES_BRAIN,
     BoardAnalyzerUtils,
     aggregate_scores,
@@ -30,6 +29,7 @@ from brain import (
 # fmt: on
 # isort: on
 from modules import FORMULA_REGISTRY, generate_unique_grid
+from weights import AGG_WEIGHTS
 
 # Logger configuration
 logging.basicConfig(

--- a/brain.py
+++ b/brain.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import numpy as np
 
 import modern_predictor
-from modules import DEFAULT_WEIGHTS as DEFAULT_AGG_WEIGHTS
 from modules import STRATEGY_REGISTRY, fuse_scores
+from weights import AGG_WEIGHTS as DEFAULT_AGG_WEIGHTS
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,8 @@ def _read_performance(file_path: str) -> Dict[str, float]:
 
 
 def _load_weights() -> Dict[str, float]:
-    w = DEFAULT_AGG_WEIGHTS.copy()
+    w = {name: strat.weight for name, strat in STRATEGY_REGISTRY.items()}
+    w.update(DEFAULT_AGG_WEIGHTS)
     perf_file = os.getenv("PERFORMANCE_FILE", "module_performance.txt")
     perf = _read_performance(perf_file)
     if perf:

--- a/modern_predictor.py
+++ b/modern_predictor.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import brain
 from modules import fuse_scores
+from weights import AGG_WEIGHTS
 
 
 def predict_location(
@@ -14,7 +15,7 @@ def predict_location(
     arr = np.asarray(grid, dtype=int)
     mods = list(brain.REGISTERED_MODULES_BRAIN)
     scores = {name: brain.get_module_score(name, arr, target=target) for name in mods}
-    fused = fuse_scores(scores, arr, brain.AGG_WEIGHTS)
+    fused = fuse_scores(scores, arr, AGG_WEIGHTS)
     blanks = np.argwhere(arr == -1)
     preds = [
         {"row": int(r), "col": int(c), "score": float(fused[r, c])} for r, c in blanks

--- a/modules.py
+++ b/modules.py
@@ -5,6 +5,8 @@ import numpy as np
 from scipy import ndimage as ndi
 from scipy.signal import convolve2d
 
+from weights import BASE_WEIGHTS
+
 # Formula registry for Monte Carlo simulation
 FORMULA_REGISTRY: Dict[
     str,
@@ -586,9 +588,6 @@ def entropy_spread_score(grid: np.ndarray) -> np.ndarray:
     return score
 
 
-DEFAULT_WEIGHTS = {name: strat.weight for name, strat in STRATEGY_REGISTRY.items()}
-
-
 def fuse_scores(
     gridscores: Dict[str, np.ndarray],
     grid: np.ndarray,
@@ -596,7 +595,7 @@ def fuse_scores(
 ) -> np.ndarray:
     """Fuse score arrays from multiple modules."""
     if weights is None:
-        weights = DEFAULT_WEIGHTS
+        weights = BASE_WEIGHTS
     final = np.zeros_like(grid, dtype=float)
     for name, arr in gridscores.items():
         final += weights.get(name, 0.0) * arr

--- a/weights.py
+++ b/weights.py
@@ -1,0 +1,43 @@
+"""
+集中管理所有模組 (conn / focus / tail …) 的權重設定。
+其他程式僅需 `from weights import BASE_WEIGHTS, AGG_WEIGHTS`。
+"""
+
+# ======  (1)  基本權重  =================================================
+BASE_WEIGHTS = {
+    "conn": 0.40,  # Connectivity Heatmap
+    "focus": 0.30,  # 3×3 Density
+    "tail": 0.01,  # Sequence Tail  ← 已大幅降低
+    "diff": 0.05,  # Difference Trend
+    "mirror": 0.05,  # Mirror Pattern
+}
+
+# ======  (2)  給 linear-fusion / legacy 用的權重表  ====================
+AGG_WEIGHTS = {
+    **BASE_WEIGHTS,
+    "skip": 0.15,
+    "affinity": 0.0,
+    "gradient_affinity": 0.0,
+    "row_col_bias": 0.0,
+    "row_col_frequency_score": 0.0,
+    "entropy_spread_score": 0.0,
+    "diag": 0.0,
+}
+
+
+# ======  (3)  支援環境變數動態覆寫  ====================================
+def _env_override(env_key: str, key: str, table: dict = BASE_WEIGHTS):
+    import decimal
+    import os
+
+    if env_key in os.environ:
+        try:
+            table[key] = float(decimal.Decimal(os.environ[env_key]))
+        except Exception:
+            pass  # 忽略非法數值
+
+
+_env_override("CONN_W", "conn")
+_env_override("FOCUS_W", "focus")
+_env_override("TAIL_W", "tail")
+# ======================================================================


### PR DESCRIPTION
## Summary
- introduce `weights.py` for centralized module weights and env overrides
- import centralized weights in main modules
- default fusion now pulls weights from `weights.py`

## Testing
- `isort --check weights.py brain.py modules.py modern_predictor.py`
- `black --check analyzer.py brain.py modern_predictor.py modules.py weights.py`
- `flake8 analyzer.py brain.py modern_predictor.py modules.py weights.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686750a5b2f0832494bfcbc65707cfe0