### PR TITLE
Integrate dead-code checks into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           pip install -U pip
           pip install -r requirements.txt
           # CI 需要的額外工具
-          pip install ruff mypy pytest hypothesis pytest-xdist pytest-cov
+          pip install ruff mypy pytest hypothesis pytest-xdist pytest-cov vulture
 
       # ▒▒▒ 下載隱藏測資（若 SECRET_ZIP_URL 有設值） ▒▒▒
       - name: Download secret cases
@@ -62,6 +62,23 @@ jobs:
         run: |
           ruff check .
           mypy . --strict
+
+      - name: Weights smoke test
+        run: |
+          python - <<'PY'
+import brain
+want = {"gdiff": 0.4, "conn": 0.05}
+got = {k: round(brain.AGG_WEIGHTS.get(k, 0.0), 2) for k in want}
+assert got == want, f"weights mismatch {got}"
+PY
+
+      - name: Dead code scan
+        run: |
+          python dead_code_autorun.py --root .
+          if [ $(wc -l < dead_code_report.md) -gt 6 ]; then
+            cat dead_code_report.md
+            exit 1
+          fi
 
       # ▒▒▒ Quality Gate：命中率 ≥93%、單次 <100 ms ▒▒▒
       - name: Quality Gate

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
 import uvicorn
 from fastapi import FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware

--- a/dead_code_autorun.py
+++ b/dead_code_autorun.py
@@ -23,9 +23,7 @@ from vulture import Vulture
 #######################
 parser = argparse.ArgumentParser()
 parser.add_argument("--root", default=".", help="專案根資料夾")
-parser.add_argument(
-    "--confidence", type=int, default=80, help="Vulture 最低信心分數"
-)
+parser.add_argument("--confidence", type=int, default=80, help="Vulture 最低信心分數")
 args = parser.parse_args()
 ROOT = Path(args.root).resolve()
 
@@ -35,9 +33,11 @@ ROOT = Path(args.root).resolve()
 v = Vulture()
 v.scavenge([str(ROOT)])  # 把整個樹丟進去掃
 unused_items = [
-    item for item in v.get_unused_code(min_confidence=args.confidence)
+    item
+    for item in v.get_unused_code(min_confidence=args.confidence)
     if item.typ in {"function", "class", "method"}
 ]
+
 
 #######################
 # 3. 工具函式
@@ -57,7 +57,8 @@ def safe_call(obj):
     mandatory = [
         p
         for p in params
-        if p.default is inspect._empty and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        if p.default is inspect._empty
+        and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
     ]
     if mandatory:
         return f"skip (requires {len(mandatory)} arg)"
@@ -66,6 +67,7 @@ def safe_call(obj):
         return f"OK → {result!r}"
     except Exception as exc:
         return f"ERROR: {exc.__class__.__name__}: {exc}"
+
 
 #######################
 # 4. 一一 import & 測試

--- a/tests/test_registry_references.py
+++ b/tests/test_registry_references.py
@@ -12,8 +12,10 @@ from modules import (
     detect_mirror_sequences,
     detect_skip_patterns,
     entropy_spread_score,
+    full_range_arith_score,
     gradient_affinity,
     row_col_bias,
+    row_col_frequency_score,
     sequence_tail_analyzer,
     target_affinity,
 )
@@ -31,7 +33,9 @@ from modules import (
         target_affinity,
         gradient_affinity,
         row_col_bias,
+        row_col_frequency_score,
         entropy_spread_score,
+        full_range_arith_score,
     ],
 )
 def test_function_is_callable(fn):


### PR DESCRIPTION
## Summary
- update CI workflow to run a weights smoke test and the dead-code scanner
- format `dead_code_autorun.py`
- ensure registry reference test covers all strategy functions
- minor import formatting fix in `app.py`

## Testing
- `black --check $(git ls-files '*.py')`
- `isort --check $(git ls-files '*.py')`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867baa3ef508324a71193df0a25321e