### PR TITLE
Implement dynamic grid priors loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import atexit
 import base64
-import gzip
 import json
 import logging
 import math
@@ -27,7 +26,7 @@ from analyzer import (compute_position_probabilities, iter_sample_jsons,
                       render_heatmap)
 
 # fmt: on
-brain.priors_map: Dict[Tuple[int, int], Dict[int, float]] = {}
+brain.priors_map: Dict[str, Dict[int, float]] = {}
 
 # —— Logging setup —————————————————————————————————————————————————————————————
 log_handlers = [
@@ -44,56 +43,38 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # —— Priors config ———————————————————————————————————————————————————————————
-PRIORS_PATH = Path("assets/priors_combined.json.gz")
+PRIORS_DIR = Path("assets")
 _IO_POOL = ThreadPoolExecutor(max_workers=1)
 atexit.register(_IO_POOL.shutdown)
 
-_DIM_RE = re.compile(r"^\s*(\d+)\s*x\s*(\d+)\s*$")
+_DIM_RE = re.compile(r"^(\d+)x(\d+)$")
 
 
-def _read_priors_file() -> dict[tuple[int, int], dict]:
-    raw: bytes = PRIORS_PATH.read_bytes()
-    if raw[:2] == b"\x1f\x8b":  # gzip magic
+def _load_priors_files() -> Dict[str, Dict[int, float]]:
+    priors: Dict[str, Dict[int, float]] = {}
+    for path in PRIORS_DIR.glob("priors_*.json"):
         try:
-            raw = gzip.decompress(raw)
-        except gzip.BadGzipFile:
-            pass
-
-    obj = json.loads(raw.decode("utf-8"))
-
-    priors: dict[tuple[int, int], dict] = {}
-    for k, v in obj.items():
-        if isinstance(k, str):
-            m = _DIM_RE.match(k)
-            if m:
-                priors[(int(m.group(1)), int(m.group(2)))] = v
-                continue
-        # fallback：保留原鍵
-        priors[k] = v
+            priors[path.stem.replace("priors_", "")] = json.loads(path.read_text())
+        except Exception as exc:  # pragma: no cover - corrupted JSON
+            logger.error("Failed to load %s: %s", path, exc)
+    if not priors:
+        priors["10x12"] = compute_position_probabilities("samples", 10, 12)
     return priors
 
 
-def _build_default_prior() -> Dict[Tuple[int, int], Dict[int, float]]:
-    from analyzer import compute_position_probabilities
-
-    logging.warning("[priors] Local file missing; fallback to on-the-fly build 10x12…")
-    return {(10, 12): compute_position_probabilities("samples", 10, 12)}
-
-
-async def load_priors_async() -> Dict[Tuple[int, int], Dict[int, float]]:
+async def load_priors_async() -> Dict[str, Dict[int, float]]:
     loop = asyncio.get_running_loop()
-    if PRIORS_PATH.exists():
-        return await loop.run_in_executor(_IO_POOL, _read_priors_file)
-    return await loop.run_in_executor(None, _build_default_prior)
+    return await loop.run_in_executor(_IO_POOL, _load_priors_files)
 
 
-def find_closest_prior_key(
-    shape: Tuple[int, int], candidates: Dict[Tuple[int, int], Any]
-) -> Tuple[int, int]:
+def find_closest_prior_key(shape: Tuple[int, int], candidates: Dict[str, Any]) -> str:
     rows, cols = shape
 
-    def score(k: Tuple[int, int]) -> Tuple[int, float]:
-        kr, kc = k
+    def score(key: str) -> Tuple[int, float]:
+        m = _DIM_RE.match(key)
+        if not m:
+            return (float("inf"), float("inf"))
+        kr, kc = int(m.group(1)), int(m.group(2))
         cells_diff = abs((kr * kc) - (rows * cols))
         aspect_diff = abs((kr / kc) - (rows / cols))
         return (cells_diff, aspect_diff)
@@ -115,6 +96,7 @@ async def warm_up() -> None:
     brain.priors_map.clear()
     brain.priors_map.update(priors)
     logging.info(f"[warm-up] Loaded {len(priors)} shapes")
+    logger.debug("Loaded priors sizes: %s", list(brain.priors_map.keys()))
     await _load_samples_background()
 
 
@@ -305,7 +287,8 @@ async def ping() -> Dict[str, str]:
 )
 async def predict(req: GridRequest):
     try:
-        # 格式校验
+        logger.debug("Loaded priors sizes: %s", list(brain.priors_map.keys()))
+        # 格式校驗
         if not req.grid or not all(isinstance(row, list) for row in req.grid):
             raise ValueError("Invalid grid format: expected List[List[int]].")
         rows, cols = len(req.grid), len(req.grid[0])
@@ -317,11 +300,16 @@ async def predict(req: GridRequest):
             raise ValueError("Grid contains duplicate numbers")
         if any(v < 1 or v > max_val for v in known):
             raise ValueError(f"Numbers must be between 1 and {max_val}")
+        if req.target_num is not None and not (1 <= req.target_num <= max_val):
+            raise HTTPException(
+                status_code=400,
+                detail=f"target_num must be between 1 and {max_val}",
+            )
 
-        key = (rows, cols)
-        priors = get_prior_for_shape(rows, cols)
-        if not priors:
-            logging.info(f"[predict] Computing priors for {rows}×{cols}…")
+        key = f"{rows}x{cols}"
+        priors = brain.priors_map.get(key)
+        if priors is None:
+            logger.warning("No priors for %s, computing on-the-fly", key)
             priors = compute_position_probabilities("samples", rows, cols)
             brain.priors_map[key] = priors
 
@@ -379,6 +367,8 @@ async def predict(req: GridRequest):
         logger.info("✅ Response ready")
         return JSONResponse(content=safe_payload, status_code=200)
 
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error("Prediction failed", exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
@@ -408,9 +398,10 @@ async def heatmap(req: HeatmapRequest):
         )
 
         rows, cols = len(req.grid), len(req.grid[0])
-        key = (rows, cols)
-        priors = get_prior_for_shape(rows, cols)
-        if not priors:
+        key = f"{rows}x{cols}"
+        priors = brain.priors_map.get(key)
+        if priors is None:
+            logger.warning("No priors for %s, computing on-the-fly", key)
             priors = compute_position_probabilities("samples", rows, cols)
             brain.priors_map[key] = priors
 
@@ -467,6 +458,8 @@ async def heatmap(req: HeatmapRequest):
             }
 
         return JSONResponse(content=sanitize_floats(resp), status_code=200)
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error("Heatmap failed", exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -58,3 +58,10 @@ def test_invalid_small_grid():
     res = client.post("/predict", json=payload)
     assert res.status_code == 500
     assert "at least 2x2" in res.json()["detail"].lower()
+
+
+def test_target_num_out_of_range():
+    grid = [[1, -1], [3, 4]]
+    payload = {"grid": grid, "target_num": 5}
+    res = client.post("/predict", json=payload)
+    assert res.status_code == 400

--- a/tests/test_startup_priors.py
+++ b/tests/test_startup_priors.py
@@ -7,23 +7,23 @@ import brain
 
 
 def test_find_closest_prior_key():
-    brain.priors_map = {(2, 2): {"a": 1}, (4, 4): {"b": 1}}
+    brain.priors_map = {"2x2": {"a": 1}, "4x4": {"b": 1}}
     key = app.find_closest_prior_key((3, 3), brain.priors_map)
-    assert key == (2, 2)
+    assert key == "2x2"
     prior = app.get_prior_for_shape(3, 3)
-    assert prior == brain.priors_map[(2, 2)]
+    assert prior == brain.priors_map["2x2"]
 
 
 def test_load_priors_async_file(tmp_path, monkeypatch):
-    path = tmp_path / "p.json"
-    path.write_text(json.dumps({"2x2": {}}))
-    monkeypatch.setattr(app, "PRIORS_PATH", path)
+    p = tmp_path / "priors_2x2.json"
+    p.write_text(json.dumps({"1": 1.0}))
+    monkeypatch.setattr(app, "PRIORS_DIR", tmp_path)
     priors = asyncio.run(app.load_priors_async())
-    assert (2, 2) in priors
+    assert "2x2" in priors
 
 
 def test_load_priors_async_fallback(monkeypatch):
-    monkeypatch.setattr(app, "PRIORS_PATH", Path("nope.json"))
-    monkeypatch.setattr(app, "_build_default_prior", lambda: {(5, 5): {"x": 1}})
+    monkeypatch.setattr(app, "PRIORS_DIR", Path("nope"))
+    monkeypatch.setattr(app, "_load_priors_files", lambda: {"5x5": {"x": 1}})
     priors = asyncio.run(app.load_priors_async())
-    assert priors == {(5, 5): {"x": 1}}
+    assert priors == {"5x5": {"x": 1}}


### PR DESCRIPTION
## Summary
- load all `priors_*.json` files at startup
- store priors keyed by `rowsxcols` string
- compute priors on demand when missing
- validate `target_num` range and return 400
- update tests for new priors behaviour

## Testing
- `black --check app.py tests/test_predict.py tests/test_startup_priors.py`
- `isort --check-only app.py tests/test_predict.py tests/test_startup_priors.py`
- `flake8 app.py tests/test_predict.py tests/test_startup_priors.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_startup_priors.py tests/test_predict.py`


------
https://chatgpt.com/codex/tasks/task_e_6867d887f56c8324b5ed80b1f2733e72