### PR TITLE
Add gdiff to legacy modules

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1007,12 +1007,16 @@ def predict_scratch_card(
         }
 
     modules = [
+        ("gdiff", "Global arithmetic difference"),  # 新增：全盤等差
         ("focus", "3x3 known density"),
         ("skip", "Skip pattern detection"),
         ("diff", "Difference trend"),
         ("mirror", "Mirror sequence detection"),
         ("conn", "Connectivity heatmap"),
         ("tail", "Tail analyzer"),
+        ("row_col_frequency_score", "Row/Col frequency"),
+        ("entropy_spread_score", "Entropy spread"),
+        ("diag", "Diagonal consistency"),
     ]
 
     mod_names = [m for m, _ in modules]

--- a/modules.py
+++ b/modules.py
@@ -625,7 +625,7 @@ except Exception:  # pragma: no cover - optional dependency
 # ------------------------------------------------------------------
 # 新模組：全域 1~N 等差分析 (full_range_arith_score)
 # ------------------------------------------------------------------
-from math import sqrt
+from math import sqrt  # noqa: E402
 
 
 def _divisors(n: int) -> list[int]:

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -43,3 +43,16 @@ def test_select_modules_include_all(make_grid):
 
 def test_gdiff_weight_positive():
     assert brain.AGG_WEIGHTS["gdiff"] > 0
+
+
+def test_gdiff_in_legacy_scores():
+    grid = [[1, 2, 3], [4, -1, 6], [7, 8, 9]]
+    result = analyzer.predict_scratch_card(
+        grid,
+        iterations=0,
+        global_iter=1,
+        focus_iter=0,
+        unique=False,
+    )
+    first = result["predictions"][0]
+    assert "gdiff" in first["module_scores"]

--- a/tests/test_q13_spectrum.py
+++ b/tests/test_q13_spectrum.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-import analyzer
 import brain
 import modules
 


### PR DESCRIPTION
## Summary
- include `gdiff` in legacy `predict_scratch_card` module list
- activate extra registered modules (row/col frequency, entropy spread, diag)
- silence flake8 E402 warning in `modules.py`
- ensure unused import removal in spectrum test
- test that legacy output includes `gdiff`

## Testing
- `black --check analyzer.py tests/test_new_modules.py tests/test_q13_spectrum.py modules.py`
- `isort --check analyzer.py tests/test_new_modules.py tests/test_q13_spectrum.py modules.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `FAST_TEST=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686866d189e083248e70187b15b8ee7c