### PR TITLE
fix/blank-cell-detection

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -994,9 +994,13 @@ def predict_scratch_card(
     strategy: str = "legacy",
 ) -> Dict[str, Any]:
 
-    grid_np = np.array(grid, dtype=np.int64)
+    BLANK_VAL = -1
+    # Keep object dtype first to avoid coercing values like "0" or "" to 0
+    grid_np = np.asarray(grid, dtype=object)
+    grid_np = np.where(grid_np == BLANK_VAL, BLANK_VAL, grid_np).astype(np.int64)
     rows, cols = grid_np.shape
-    blanks = [tuple(map(int, b)) for b in np.argwhere(grid_np == -1)]
+
+    blanks = [tuple(b) for b in np.argwhere(grid_np == BLANK_VAL)]
 
     if not blanks:
         return {
@@ -1010,13 +1014,14 @@ def predict_scratch_card(
     from neighbor_stats import (
         compute_neighbor_distribution,
         neighbor_compatibility_score,
+        rank_candidates_by_neighbor,
     )
 
     dist = compute_neighbor_distribution(rows, cols, target_num, n_sims=10000)
     final_score_map = neighbor_compatibility_score(grid_np, dist)
 
     top_k = result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
-    ranked = sorted(blanks, key=lambda pos: final_score_map[pos], reverse=True)[:top_k]
+    ranked = rank_candidates_by_neighbor(grid_np, dist, blanks)[:top_k]
 
     preds = [
         {"row": r, "col": c, "score": float(final_score_map[r, c])} for r, c in ranked

--- a/neighbor_stats.py
+++ b/neighbor_stats.py
@@ -4,7 +4,11 @@ from typing import Dict
 
 import numpy as np
 
-__all__ = ["compute_neighbor_distribution", "neighbor_compatibility_score"]
+__all__ = [
+    "compute_neighbor_distribution",
+    "neighbor_compatibility_score",
+    "rank_candidates_by_neighbor",
+]
 
 
 @functools.lru_cache(maxsize=128)
@@ -89,3 +93,19 @@ def neighbor_compatibility_score(
     score *= levels_inv
     mx = score.max(initial=0.0)
     return score / mx if mx > 0 else score
+
+
+def rank_candidates_by_neighbor(
+    grid: np.ndarray,
+    dist: Dict[int, float],
+    blanks: list[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    """Rank blank cells by :func:`neighbor_compatibility_score`."""
+
+    # blanks 由呼叫端保證只含 BLANK_VAL
+    if not blanks:
+        return []
+
+    score_map = neighbor_compatibility_score(grid, dist)
+    ranked = sorted(blanks, key=lambda pos: score_map[pos], reverse=True)
+    return ranked

--- a/tests/test_predictions_blank_only.py
+++ b/tests/test_predictions_blank_only.py
@@ -1,0 +1,13 @@
+from analyzer import predict_scratch_card
+
+
+def test_predictions_only_blank_cells():
+    grid = [
+        [-1, 2, 3],
+        [4, -1, 6],
+        [7, 8, 9],
+    ]
+    out = predict_scratch_card(grid, target_num=1, result_top_k=3)
+    blanks = {(0, 0), (1, 1)}
+    for p in out["predictions"]:
+        assert (p["row"], p["col"]) in blanks


### PR DESCRIPTION
## Summary
- improve analyzer blank cell detection
- update neighbor candidate ranking helper
- ensure predictions return blanks only
- add regression test for blank-only predictions

## Testing
- `black analyzer.py neighbor_stats.py tests/test_predictions_blank_only.py --check -q`
- `isort analyzer.py neighbor_stats.py tests/test_predictions_blank_only.py --profile black --check`
- `flake8 analyzer.py neighbor_stats.py tests/test_predictions_blank_only.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c61c51308324bf445f43ed1f6f23