### PR TITLE
Implement utility to fill blanks with unique numbers

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -44,6 +44,43 @@ class BoardAnalyzerUtils:
         used = set(int(v) for v in grid.flatten() if v != -1 and v > 0)
         return all_vals - used
 
+    def fill_blanks_with_remaining_numbers(
+        self,
+        grid: np.ndarray,
+        *,
+        rng: Optional[np.random.Generator] = None,
+    ) -> np.ndarray:
+        """Fill ``-1`` cells with unused numbers from ``1`` to ``N``.
+
+        Parameters
+        ----------
+        grid : np.ndarray
+            Board matrix with ``-1`` marking unknown cells.
+        rng : np.random.Generator, optional
+            RNG used for shuffling remaining numbers.
+
+        Returns
+        -------
+        np.ndarray
+            New grid with blanks replaced by unique numbers.
+        """
+
+        arr = np.asarray(grid, dtype=int).copy()
+        blanks = np.argwhere(arr == -1)
+        if blanks.size == 0:
+            return arr
+
+        if rng is None:
+            rng = np.random.default_rng()
+
+        legal = list(self.get_legal_values_for_placement(arr))
+        if len(legal) < blanks.shape[0]:
+            raise ValueError("Not enough numbers to fill blanks")
+
+        rng.shuffle(legal)
+        arr[blanks[:, 0], blanks[:, 1]] = legal[: blanks.shape[0]]
+        return arr
+
 
 DTYPE_DEFAULT = np.int32
 ITEMSIZE = np.dtype(DTYPE_DEFAULT).itemsize

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -2,6 +2,7 @@
 import numpy as np
 import pytest
 
+import brain
 from modules import generate_unique_grid
 
 
@@ -29,3 +30,12 @@ def test_generate_unique_grid_multi_hidden():
     assert grid[0, 0] == -1 and grid[1, 1] == -1
     values = [v for v in grid.ravel() if v != -1]
     assert len(values) == len(set(values))
+
+
+def test_fill_blanks_with_remaining_numbers():
+    util = brain.BoardAnalyzerUtils()
+    grid = np.array([[1, -1], [3, -1]])
+    filled = util.fill_blanks_with_remaining_numbers(grid, rng=np.random.default_rng(0))
+    assert -1 not in filled
+    assert len(np.unique(filled)) == 4
+    assert set(filled.ravel()) == {1, 2, 3, 4}


### PR DESCRIPTION
## Summary
- support filling blanks with remaining numbers via `BoardAnalyzerUtils.fill_blanks_with_remaining_numbers`
- test blank-filling helper logic

## Testing
- `black --check brain.py tests/test_board.py`
- `isort --check brain.py tests/test_board.py`
- `flake8 brain.py tests/test_board.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e0bb22f083248c919f3c71ffd3bb