### PR TITLE
Fix ranking and blank normalization

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1021,7 +1021,12 @@ def predict_scratch_card(
     final_score_map = neighbor_compatibility_score(grid_np, dist)
 
     top_k = result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
-    ranked = rank_candidates_by_neighbor(grid_np, dist, blanks)[:top_k]
+    rings = BoardAnalyzerUtils.ring_index(*grid_np.shape)
+    ranked_all = sorted(
+        blanks,
+        key=lambda pos: (rings[pos], -final_score_map[pos]),
+    )
+    ranked = ranked_all[:top_k]
 
     preds = [
         {"row": r, "col": c, "score": float(final_score_map[r, c])} for r, c in ranked

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
+import numpy as np
 import uvicorn
 from fastapi import FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -333,8 +334,11 @@ async def predict(req: GridRequest):
         )
 
         # 调用核心推理
+        grid_np = np.asarray(req.grid, dtype=object)
+        # 正規化空格：0 / "" 皆視為 -1
+        grid_norm = np.where(grid_np <= 0, -1, grid_np).tolist()
         result = predict_scratch_card(
-            grid=req.grid,
+            grid=grid_norm,
             target_num=req.target_num,
             iterations=phase1,
             global_iter=req.global_iter,
@@ -405,8 +409,10 @@ async def heatmap(req: HeatmapRequest):
             priors = compute_position_probabilities("samples", rows, cols)
             brain.priors_map[key] = priors
 
+        grid_np = np.asarray(req.grid, dtype=object)
+        grid_norm = np.where(grid_np <= 0, -1, grid_np).tolist()
         pred_result = predict_scratch_card(
-            grid=req.grid,
+            grid=grid_norm,
             target_num=req.target_num,
             iterations=PHASE1_ITER,
             global_iter=None,

--- a/brain.py
+++ b/brain.py
@@ -81,6 +81,16 @@ class BoardAnalyzerUtils:
         arr[blanks[:, 0], blanks[:, 1]] = legal[: blanks.shape[0]]
         return arr
 
+    @staticmethod
+    def ring_index(rows: int, cols: int) -> np.ndarray:
+        """Return each cell's distance from the outer frame (0=outermost)."""
+
+        return np.fromfunction(
+            lambda r, c: np.minimum.reduce([r, c, rows - 1 - r, cols - 1 - c]),
+            (rows, cols),
+            dtype=int,
+        )
+
 
 DTYPE_DEFAULT = np.int32
 ITEMSIZE = np.dtype(DTYPE_DEFAULT).itemsize

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ Ultra-minimal smoke-tests for Scratch-Card Prediction API
 from typing import Any, Dict, List
 
 import analyzer
+from modules import generate_excel_style_card
 
 
 # ────────────────────────────── 工具 ──────────────────────────────
@@ -126,3 +127,11 @@ def test_predict_strategy_modern(client):
     resp = client.post("/predict", json=payload)
     assert resp.status_code == 200
     assert "final_recommendations" in resp.json()
+
+
+def test_no_open_cells_in_top3(client):
+    grid = generate_excel_style_card(8, 10).tolist()
+    grid[0][0] = -1
+    body = client.post("/predict", json={"grid": grid, "target_num": 1}).json()
+    top3 = {(p["row"] - 1, p["col"] - 1) for p in body["top_predictions"]}
+    assert all(grid[r][c] == -1 for r, c in top3)


### PR DESCRIPTION
## Summary
- normalize blank inputs before prediction
- rank candidate cells by outer ring then neighbor score
- expose ring_index utility
- ensure API excludes opened cells in top predictions
- test to verify open cells never in top3

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f1eb5a10832497f205896dd09d62