### PR TITLE
Add heuristic CSP solver and integrate with prediction

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1027,8 +1027,8 @@ def predict_scratch_card(
 
     scores_uniform = False
     if blanks:
-scores = np.array([nbr_score[pos] for pos in blanks], dtype=float)
-scores_uniform = (scores.ptp() < epsilon)
+        scores = np.array([nbr_score[pos] for pos in blanks], dtype=float)
+        scores_uniform = (scores.ptp() < epsilon)
     final_score_map = np.zeros_like(grid_np, dtype=float)
     if scores_uniform:
         for (r, c), p in csp_probs.items():

--- a/analyzer.py
+++ b/analyzer.py
@@ -1028,7 +1028,7 @@ def predict_scratch_card(
     scores_uniform = False
     if blanks:
         scores = np.array([nbr_score[pos] for pos in blanks], dtype=float)
-        scores_uniform = (scores.ptp() < epsilon)
+        scores_uniform = (np.ptp(scores) < epsilon)
     final_score_map = np.zeros_like(grid_np, dtype=float)
     if scores_uniform:
         for (r, c), p in csp_probs.items():

--- a/analyzer.py
+++ b/analyzer.py
@@ -30,6 +30,8 @@ from brain import (
 # isort: on
 from modules import FORMULA_REGISTRY, generate_unique_grid
 from weights import AGG_WEIGHTS
+from neighbor_stats import compute_neighbor_distribution, neighbor_compatibility_score
+from csp_solver import heuristic_csp_sampling
 
 # Logger configuration
 logging.basicConfig(
@@ -1011,13 +1013,33 @@ def predict_scratch_card(
             "final_recommendations": [],
         }
 
-    from neighbor_stats import (
-        compute_neighbor_distribution,
-        neighbor_compatibility_score,
+    dist = compute_neighbor_distribution(rows, cols, target_num, n_sims=10000)
+    nbr_score = neighbor_compatibility_score(grid_np, dist)
+
+    nbr_probs = {(int(r), int(c)): float(nbr_score[r, c]) for r, c in blanks}
+    csp_probs = heuristic_csp_sampling(
+        grid_np.tolist(),
+        target_num,
+        nbr_probs,
+        samples=iterations or 2000,
+        enforce_rowcol=True,
     )
 
-    dist = compute_neighbor_distribution(rows, cols, target_num, n_sims=10000)
-    final_score_map = neighbor_compatibility_score(grid_np, dist)
+    scores_uniform = False
+    if blanks:
+        first = nbr_score[blanks[0]]
+        scores_uniform = np.allclose([nbr_score[pos] for pos in blanks], first)
+
+    final_score_map = np.zeros_like(grid_np, dtype=float)
+    if scores_uniform:
+        for (r, c), p in csp_probs.items():
+            final_score_map[r, c] = p
+    else:
+        alpha = 0.7
+        for r, c in blanks:
+            final_score_map[r, c] += alpha * nbr_probs.get((r, c), 0.0)
+        for (r, c), p in csp_probs.items():
+            final_score_map[r, c] += (1 - alpha) * p
 
     top_k = result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
     rings = BoardAnalyzerUtils.ring_index(*grid_np.shape)

--- a/analyzer.py
+++ b/analyzer.py
@@ -1027,9 +1027,8 @@ def predict_scratch_card(
 
     scores_uniform = False
     if blanks:
-        first = nbr_score[blanks[0]]
-        scores_uniform = np.allclose([nbr_score[pos] for pos in blanks], first)
-
+scores = np.array([nbr_score[pos] for pos in blanks], dtype=float)
+scores_uniform = (scores.ptp() < epsilon)
     final_score_map = np.zeros_like(grid_np, dtype=float)
     if scores_uniform:
         for (r, c), p in csp_probs.items():

--- a/csp_solver.py
+++ b/csp_solver.py
@@ -1,0 +1,59 @@
+import random
+from typing import Dict, List, Tuple
+
+BLANK = -1
+
+
+def heuristic_csp_sampling(
+    grid: List[List[int]],
+    target: int,
+    nbr_probs: Dict[Tuple[int, int], float],
+    samples: int = 2000,
+    enforce_rowcol: bool = False,
+) -> Dict[Tuple[int, int], float]:
+    """Estimate P(target at cell) using heuristic CSP sampling."""
+    rows = len(grid)
+    cols = len(grid[0]) if rows else 0
+    blanks = [(r, c) for r in range(rows) for c in range(cols) if grid[r][c] == BLANK]
+    used = {grid[r][c] for r in range(rows) for c in range(cols) if grid[r][c] != BLANK}
+    domain = [v for v in range(1, rows * cols + 1) if v not in used]
+
+    counts = {pos: 0 for pos in blanks}
+
+    for _ in range(samples):
+        assignment: Dict[Tuple[int, int], int] = {}
+        avail = domain.copy()
+        order = sorted(blanks, key=lambda pos: -nbr_probs.get(pos, 0.0))
+        ok = True
+        for pos in order:
+            r, c = pos
+            if target in avail and random.random() < nbr_probs.get(pos, 0.0):
+                val = target
+            else:
+                choices = avail.copy()
+                if target in choices:
+                    choices.remove(target)
+                val = random.choice(choices) if choices else avail[0]
+
+            if val not in avail:
+                ok = False
+                break
+            if enforce_rowcol:
+                for (rr, cc), vv in assignment.items():
+                    if vv == val and (rr == r or cc == c):
+                        ok = False
+                        break
+                if not ok:
+                    break
+
+            assignment[pos] = val
+            avail.remove(val)
+
+        if not ok or len(assignment) != len(blanks):
+            continue
+
+        for pos, val in assignment.items():
+            if val == target:
+                counts[pos] += 1
+
+    return {pos: counts[pos] / samples for pos in blanks}

--- a/tests/test_csp_solver.py
+++ b/tests/test_csp_solver.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from csp_solver import heuristic_csp_sampling
+
+
+def test_uniform_distribution():
+    grid = [[-1, -1, -1], [-1, -1, -1], [-1, -1, -1]]
+    nbr = {(r, c): 1 / 9 for r in range(3) for c in range(3)}
+    probs = heuristic_csp_sampling(grid, 1, nbr, samples=1000)
+    vals = list(probs.values())
+    assert all(0.0 <= p <= 1.0 for p in vals)
+    assert np.allclose(sum(vals), 1.0, atol=0.1)
+
+
+def test_single_blank():
+    grid = [[1, 2, 3], [4, 5, 6], [7, 8, -1]]
+    nbr = {(2, 2): 1.0}
+    probs = heuristic_csp_sampling(grid, 9, nbr, samples=100)
+    assert probs[(2, 2)] == 1.0
+
+
+def test_two_blanks_nonzero():
+    grid = [[1, 2, -1, 4], [5, 6, -1, 8], [9, 10, 11, 12], [13, 14, 15, 16]]
+    nbr = {(0, 2): 0.5, (1, 2): 0.5}
+    probs = heuristic_csp_sampling(grid, 5, nbr, samples=200)
+    assert probs[(0, 2)] >= 0.0 and probs[(1, 2)] >= 0.0
+
+
+def test_enforce_rowcol():
+    grid = [[-1, -1], [-1, -1]]
+    nbr = {(r, c): 0.5 for r in range(2) for c in range(2)}
+    probs = heuristic_csp_sampling(grid, 1, nbr, samples=200, enforce_rowcol=True)
+    assert all(0.0 <= p <= 1.0 for p in probs.values())


### PR DESCRIPTION
## Summary
- implement `heuristic_csp_sampling` in new module `csp_solver.py`
- integrate heuristic CSP sampling with neighbor scores in `predict_scratch_card`
- add unit tests for new CSP solver

## Testing
- `black --check .`
- `isort --check csp_solver.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693f0c9a8c83249aded6521a4b0f91