### PR TITLE
Improve sparse neighbor predictions

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1026,13 +1026,32 @@ def predict_scratch_card(
     )
 
     scores_uniform = False
+    neighbor_counts = []
     if blanks:
         scores = np.array([nbr_score[pos] for pos in blanks], dtype=float)
-        scores_uniform = (np.ptp(scores) < epsilon)
+        scores_uniform = np.ptp(scores) < epsilon
+        for r, c in blanks:
+            cnt = 0
+            for dr in (-1, 0, 1):
+                for dc in (-1, 0, 1):
+                    if dr == 0 and dc == 0:
+                        continue
+                    nr, nc = r + dr, c + dc
+                    if (
+                        0 <= nr < rows
+                        and 0 <= nc < cols
+                        and grid_np[nr, nc] != BLANK_VAL
+                    ):
+                        cnt += 1
+            neighbor_counts.append(cnt)
+
     final_score_map = np.zeros_like(grid_np, dtype=float)
-    if scores_uniform:
-        for (r, c), p in csp_probs.items():
-            final_score_map[r, c] = p
+    if target_num is not None and (
+        scores_uniform or (neighbor_counts and max(neighbor_counts) <= 1)
+    ):
+        heat = probability_heatmap(grid_np, target_num, n_iter=iterations or 500)
+        for r, c in blanks:
+            final_score_map[r, c] = float(heat[r, c])
     else:
         alpha = 0.7
         for r, c in blanks:

--- a/tests/test_simulation_fallback.py
+++ b/tests/test_simulation_fallback.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+import analyzer
+
+
+def test_predict_uses_simulation_when_neighbors_sparse(monkeypatch):
+    grid = [
+        [-1, -1],
+        [-1, 4],
+    ]
+    called = {"n": 0}
+
+    def fake_heatmap(g, k, n_iter=500, **_):
+        called["n"] += 1
+        return np.zeros_like(g, dtype=float)
+
+    monkeypatch.setattr(analyzer, "probability_heatmap", fake_heatmap)
+    analyzer.predict_scratch_card(grid, target_num=1, iterations=4)
+    assert called["n"] == 1


### PR DESCRIPTION
## Summary
- trigger heatmap simulation when neighbor info is weak
- add unit test covering simulation fallback logic

## Testing
- `black analyzer.py tests/test_simulation_fallback.py --check`
- `isort --check analyzer.py tests/test_simulation_fallback.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c725305483249ac78af4a1004566