### PR TITLE
Implement heatmap/predict fusion

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -768,6 +768,49 @@ def _compute_final_recommendations(
     return recs[:top_k]
 
 
+def fuse_predictions_with_heatmap(
+    heatmap: np.ndarray,
+    predictions: List[Dict[str, Any]],
+    *,
+    fusion_alpha: float = 0.7,
+    top_k: int = 3,
+) -> List[Dict[str, Any]]:
+    """Fuse prediction scores with heatmap probability.
+
+    Parameters
+    ----------
+    heatmap : np.ndarray
+        Probability matrix for the target number.
+    predictions : list of dict
+        Items with ``row``, ``col`` and ``score`` fields (0-based indices).
+    fusion_alpha : float, optional
+        Weight for ``score`` from predictions. ``1 - fusion_alpha`` is applied
+        to ``heatmap`` probability. Defaults to ``0.7``.
+    top_k : int, optional
+        Number of cells to return. Defaults to ``3``.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        Sorted list of recommendations with ``final_score``.
+    """
+
+    rows, cols = heatmap.shape
+    score_map = {
+        (int(p.get("row")), int(p.get("col"))): float(p.get("score", 0.0))
+        for p in predictions
+    }
+    recs: List[Dict[str, Any]] = []
+    for r in range(rows):
+        for c in range(cols):
+            pred_score = score_map.get((r, c), 0.0)
+            prob = float(heatmap[r, c])
+            final = fusion_alpha * pred_score + (1.0 - fusion_alpha) * prob
+            recs.append({"row": r, "col": c, "final_score": final})
+    recs.sort(key=lambda x: x["final_score"], reverse=True)
+    return recs[:top_k]
+
+
 def rank_cells_by_prior_and_modules(
     grid: np.ndarray,
     prior_cube: np.ndarray,

--- a/app.py
+++ b/app.py
@@ -22,7 +22,8 @@ from pydantic import BaseModel
 # fmt: off
 import analyzer
 import brain
-from analyzer import (compute_position_probabilities, iter_sample_jsons,
+from analyzer import (compute_position_probabilities,
+                      fuse_predictions_with_heatmap, iter_sample_jsons,
                       predict_scratch_card, probability_heatmap,
                       render_heatmap)
 
@@ -188,6 +189,7 @@ class HeatmapRequest(BaseModel):
     seed: int = 0
     output_format: Literal["base64", "raw", "json"] = "base64"
     sample_gamma: Optional[float] = None
+    fusion_alpha: Optional[float] = None
 
 
 class HeatmapResponse(BaseModel):
@@ -359,6 +361,23 @@ async def predict(req: GridRequest):
             strategy=req.strategy,
         )
 
+        if req.target_num is not None:
+            hm_iter = phase1 if os.getenv("FAST_TEST") != "1" else min(phase1, 100)
+            heat = probability_heatmap(
+                grid_norm,
+                req.target_num,
+                hm_iter,
+                sample_gamma=req.sample_gamma or 0.0,
+                history_dir="samples",
+            )
+            fusion_alpha = req.fusion_alpha or 0.7
+            result["final_recommendations"] = fuse_predictions_with_heatmap(
+                heat,
+                result.get("top_predictions", []),
+                fusion_alpha=fusion_alpha,
+                top_k=top_k,
+            )
+
         full_probs = result.get("full_probabilities", {})
         clean_probs = _full_probs_to_1_based(full_probs)
 
@@ -431,6 +450,15 @@ async def heatmap(req: HeatmapRequest):
             priors=priors,
             sample_gamma=req.sample_gamma or 0.0,
         )
+
+        fusion_alpha = req.fusion_alpha or 0.7
+        if isinstance(prob, np.ndarray) and req.target_num is not None:
+            pred_result["final_recommendations"] = fuse_predictions_with_heatmap(
+                prob,
+                pred_result.get("top_predictions", []),
+                fusion_alpha=fusion_alpha,
+                top_k=3,
+            )
 
         full_probs = pred_result.get("full_probabilities", {})
         clean_probs = _full_probs_to_1_based(full_probs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,8 @@ def test_predict_basic(client):
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
     assert isinstance(body.get("final_recommendations"), list)
+    if body["final_recommendations"]:
+        assert "final_score" in body["final_recommendations"][0]
 
 
 def test_heatmap_basic(client):
@@ -61,6 +63,8 @@ def test_heatmap_basic(client):
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
     assert isinstance(body.get("final_recommendations"), list)
+    if body["final_recommendations"]:
+        assert "final_score" in body["final_recommendations"][0]
 
 
 def test_heatmap_json(client):


### PR DESCRIPTION
## Summary
- add `fuse_predictions_with_heatmap` helper to combine prediction scores with heatmap probability
- use fusion logic in `/predict` and `/heatmap` endpoints
- extend API tests to check new `final_score` field

## Testing
- `black analyzer.py app.py tests/test_api.py --check`
- `isort analyzer.py app.py tests/test_api.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `FAST_TEST=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ef4ef6888324b15aab39b09b3aa3