### PR TITLE
Add zipped board loader utility

### DIFF
--- a/dataset_utils.py
+++ b/dataset_utils.py
@@ -1,0 +1,37 @@
+# Utilities for loading board datasets from compressed archives
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from typing import List
+
+
+def load_boards_from_zip(
+    zip_path: str | Path, rows: int, cols: int
+) -> List[List[List[int]]]:
+    """Load boards from a ZIP archive.
+
+    Parameters
+    ----------
+    zip_path : str | Path
+        Path to the ZIP archive containing board JSON files.
+    rows : int
+        Number of rows of the desired boards.
+    cols : int
+        Number of columns of the desired boards.
+
+    Returns
+    -------
+    list[list[list[int]]]
+        List of boards.
+    """
+    filename = f"boards_{rows}x{cols}_50000.json"
+    zpath = Path(zip_path)
+    with zipfile.ZipFile(zpath, "r") as zf:
+        if filename not in zf.namelist():
+            raise FileNotFoundError(f"{filename} not found in {zpath}")
+        with zf.open(filename) as f:
+            boards: List[List[List[int]]] = json.load(f)
+    return boards

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,0 +1,16 @@
+import json
+import zipfile
+
+from dataset_utils import load_boards_from_zip
+
+
+def test_load_boards_from_zip(tmp_path):
+    zip_path = tmp_path / "boards.zip"
+    data = [[1, 2], [3, 4]]
+    boards = [data, data]
+    filename = "boards_2x2_50000.json"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr(filename, json.dumps(boards))
+
+    result = load_boards_from_zip(str(zip_path), 2, 2)
+    assert result == boards


### PR DESCRIPTION
## Summary
- implement `load_boards_from_zip` for reading JSON boards from zip archives
- add unit test for the new loader

## Testing
- `black --check . && isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(failed: KeyboardInterrupt after running most tests)*

------
https://chatgpt.com/codex/tasks/task_e_6869fa2783388324bd0a83195eb8c5a2