### PR TITLE
Add fusion endpoint combining predictions and heatmap

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -811,6 +811,31 @@ def fuse_predictions_with_heatmap(
     return recs[:top_k]
 
 
+def fuse_score_matrices(
+    predict_scores: np.ndarray,
+    heatmap_prob_map: np.ndarray,
+    *,
+    fusion_alpha: float = 0.5,
+    top_k: int = 5,
+) -> List[Dict[str, Any]]:
+    """Fuse two full-size score matrices and return top ranked cells."""
+
+    if predict_scores.shape != heatmap_prob_map.shape:
+        raise ValueError("score map and heatmap must have the same shape")
+
+    rows, cols = predict_scores.shape
+    recs: List[Dict[str, Any]] = []
+    for r in range(rows):
+        for c in range(cols):
+            pred = float(predict_scores[r, c])
+            prob = float(heatmap_prob_map[r, c])
+            score = fusion_alpha * pred + (1.0 - fusion_alpha) * prob
+            recs.append({"row": r, "col": c, "final_score": score})
+
+    recs.sort(key=lambda x: x["final_score"], reverse=True)
+    return recs[:top_k]
+
+
 def rank_cells_by_prior_and_modules(
     grid: np.ndarray,
     prior_cube: np.ndarray,

--- a/app.py
+++ b/app.py
@@ -23,9 +23,9 @@ from pydantic import BaseModel
 import analyzer
 import brain
 from analyzer import (compute_position_probabilities,
-                      fuse_predictions_with_heatmap, iter_sample_jsons,
-                      predict_scratch_card, probability_heatmap,
-                      render_heatmap)
+                      fuse_predictions_with_heatmap, fuse_score_matrices,
+                      iter_sample_jsons, predict_scratch_card,
+                      probability_heatmap, render_heatmap)
 
 # fmt: on
 brain.priors_map: Dict[str, Dict[int, float]] = {}
@@ -199,6 +199,20 @@ class HeatmapResponse(BaseModel):
     top_predictions: Optional[List[Prediction]] = None
     full_probabilities: Optional[Dict[str, Dict[str, float]]] = None
     final_recommendations: Optional[List[Dict[str, Any]]] = None
+
+
+class FusionRequest(BaseModel):
+    predict_scores: List[List[float]]
+    heatmap_prob_map: List[List[float]]
+    alpha: Optional[float] = 0.5
+    top_n: int = 5
+    target_num: Optional[int] = None
+
+
+class FusionResult(BaseModel):
+    row: int
+    col: int
+    final_score: float
 
 
 # ==== Startup & ENV parsing =================================================
@@ -504,6 +518,37 @@ async def heatmap(req: HeatmapRequest):
         raise
     except Exception as exc:
         logger.error("Heatmap failed", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post(
+    "/fuse",
+    response_model=List[FusionResult],
+    response_class=JSONResponse,
+    status_code=200,
+)
+async def fuse(req: FusionRequest):
+    try:
+        pred_arr = np.asarray(req.predict_scores, dtype=float)
+        heat_arr = np.asarray(req.heatmap_prob_map, dtype=float)
+        if pred_arr.shape != heat_arr.shape:
+            raise HTTPException(
+                status_code=400,
+                detail="predict_scores and heatmap_prob_map must have the same shape",
+            )
+        alpha = req.alpha if req.alpha is not None else 0.5
+        fused = fuse_score_matrices(
+            pred_arr,
+            heat_arr,
+            fusion_alpha=alpha,
+            top_k=req.top_n,
+        )
+        recs = _to_1_based(fused)
+        return JSONResponse(content=sanitize_floats(recs), status_code=200)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Fusion failed", exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,8 @@ Ultra-minimal smoke-tests for Scratch-Card Prediction API
 
 from typing import Any, Dict, List
 
+import pytest
+
 import analyzer
 from modules import generate_excel_style_card
 
@@ -150,3 +152,23 @@ def test_blank_types_predict_and_heatmap(client):
         json={"grid": grid, "target_num": 1, "iterations": 4, "output_format": "json"},
     )
     assert resp_h.status_code == 200
+
+
+def test_fuse_basic(client):
+    pred = [[0.9, 0.1], [0.2, 0.4]]
+    heat = [[0.5, 0.8], [0.3, 0.6]]
+    payload = {
+        "predict_scores": pred,
+        "heatmap_prob_map": heat,
+        "alpha": 0.5,
+        "top_n": 2,
+    }
+    resp = client.post("/fuse", json=payload)
+    body = resp.json()
+
+    assert resp.status_code == 200
+    assert isinstance(body, list)
+    assert len(body) == 2
+    assert body[0]["row"] == 1
+    assert body[0]["col"] == 1
+    assert body[0]["final_score"] == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- implement `fuse_score_matrices` helper in analyzer
- add `/fuse` FastAPI route with accompanying models
- update smoke tests to cover new endpoint

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a0d07329c8324837820530cb435e3