### PR TITLE
Implement uniqueness penalty in predictions

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -76,6 +76,26 @@ def _native_dict(d):
     return {_native_coord(k): v for k, v in d.items()}
 
 
+def apply_uniqueness_penalty(
+    prob_map: Dict[Tuple[int, int], Dict[int, float]],
+    strength: float = 0.5,
+) -> Dict[Tuple[int, int], Dict[int, float]]:
+    """Penalize cells used by multiple numbers to encourage variety."""
+
+    if strength <= 0:
+        return prob_map
+
+    result: Dict[Tuple[int, int], Dict[int, float]] = {}
+    for cell, dist in prob_map.items():
+        count = len(dist)
+        if count > 1:
+            factor = 1.0 / (1.0 + strength * (count - 1))
+            result[cell] = {n: p * factor for n, p in dist.items()}
+        else:
+            result[cell] = dist.copy()
+    return result
+
+
 def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
     """Yield JSON objects from a zip file with basic validation."""
     count = 0
@@ -693,6 +713,8 @@ def simulate_full_board(
 
     # 來自 probmap_key_patch_v2.txt
     prob_map = {(int(r), int(c)): cell for (r, c), cell in final_prob_map.items()}
+
+    prob_map = apply_uniqueness_penalty(prob_map)
 
     # --- 保證所有格都有 entry ------------------------------
     if os.getenv("FORCE_FULL_SCAN", "0") == "1":

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -126,3 +126,14 @@ def test_predict_passes_sample_gamma(monkeypatch):
 
     assert captured["gamma"] == 0.7
     assert captured["history_dir"] == "foo"
+
+
+def test_apply_uniqueness_penalty():
+    pm = {
+        (0, 0): {1: 0.6, 2: 0.4},
+        (0, 1): {1: 0.5},
+    }
+    out = analyzer.apply_uniqueness_penalty(pm, strength=1.0)
+    assert out[(0, 0)][1] < pm[(0, 0)][1]
+    assert out[(0, 0)][2] < pm[(0, 0)][2]
+    assert out[(0, 1)][1] == pm[(0, 1)][1]


### PR DESCRIPTION
## Summary
- discourage repeat recommendations with `apply_uniqueness_penalty`
- use penalty in simulated board prediction
- test the new function

## Testing
- `black analyzer.py tests/test_analyzer.py && isort analyzer.py tests/test_analyzer.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1f6df6a08324982177ceee2f70ae