### PR TITLE
Implement heatmap fallback when info is sparse

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1094,11 +1094,53 @@ def predict_scratch_card(
 
     blanks = [tuple(b) for b in np.argwhere(grid_np == BLANK_VAL)]
 
+    known_coords = [tuple(b) for b in np.argwhere(grid_np > 0)]
+    use_heatmap_only = False
+    if len(known_coords) <= 3:
+        has_adj = False
+        for r, c in known_coords:
+            for dr in (-1, 0, 1):
+                for dc in (-1, 0, 1):
+                    if dr == 0 and dc == 0:
+                        continue
+                    nr, nc = r + dr, c + dc
+                    if 0 <= nr < rows and 0 <= nc < cols and grid_np[nr, nc] > 0:
+                        has_adj = True
+                        break
+                if has_adj:
+                    break
+        if not has_adj:
+            use_heatmap_only = True
+
     if not blanks:
         return {
             "mode": "no_blanks",
+            "strategy": "predict_structured",
             "predictions": [],
             "top_predictions": [],
+            "full_probabilities": {},
+            "final_recommendations": [],
+        }
+
+    if use_heatmap_only and target_num is not None:
+        heat = probability_heatmap(
+            grid_np,
+            target_num,
+            n_iter=iterations or 10000,
+            sample_gamma=sample_gamma,
+            history_dir=history_dir,
+        )
+        top_k = result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
+        ranked = sorted([(float(heat[r, c]), r, c) for r, c in blanks], reverse=True)[
+            :top_k
+        ]
+        preds = [{"row": r, "col": c, "score": prob} for prob, r, c in ranked]
+        return {
+            "mode": "heatmap_only",
+            "strategy": "heatmap_only",
+            "target_num": int(target_num),
+            "predictions": preds,
+            "top_predictions": preds,
             "full_probabilities": {},
             "final_recommendations": [],
         }
@@ -1169,6 +1211,7 @@ def predict_scratch_card(
 
     return {
         "mode": "neighbor",
+        "strategy": "predict_structured",
         "predictions": preds,
         "top_predictions": preds,
         "full_probabilities": {},

--- a/app.py
+++ b/app.py
@@ -405,6 +405,7 @@ async def predict(req: GridRequest):
             "full_probabilities": clean_probs,
             "sample_gamma_used": req.sample_gamma or 0.0,
             "final_recommendations": recs,
+            "strategy": result.get("strategy"),
         }
         safe_payload = sanitize_floats(payload)
         logger.info("✅ Response ready")
@@ -490,6 +491,7 @@ async def heatmap(req: HeatmapRequest):
                 "top_predictions": tops,
                 "full_probabilities": clean_probs,
                 "final_recommendations": recs,
+                "strategy": pred_result.get("strategy"),
             }
         elif req.output_format.lower() in ("raw", "json"):
             resp = {
@@ -500,6 +502,7 @@ async def heatmap(req: HeatmapRequest):
                 "full_probabilities": clean_probs,
                 "final_recommendations": recs,
                 "sample_gamma_used": req.sample_gamma or 0.0,
+                "strategy": pred_result.get("strategy"),
             }
         else:
             img = render_heatmap(prob, req.output_format)
@@ -511,6 +514,7 @@ async def heatmap(req: HeatmapRequest):
                 "top_predictions": tops,
                 "full_probabilities": clean_probs,
                 "final_recommendations": recs,
+                "strategy": pred_result.get("strategy"),
             }
 
         return JSONResponse(content=sanitize_floats(resp), status_code=200)

--- a/main.py
+++ b/main.py
@@ -182,7 +182,7 @@ def main():
                     with open("heatmap.txt", "w") as f:
                         f.write(rendered)
                     logging.info("Heatmap base64 saved to heatmap.txt")
-        logging.info("Prediction results:")
+        logging.info("Prediction results (strategy=%s):", result.get("strategy"))
         for pred in result["predictions"]:
             r = int(pred.get("row", 0)) + 1
             c = int(pred.get("col", 0)) + 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,6 +45,7 @@ def test_predict_basic(client):
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
     assert isinstance(body.get("final_recommendations"), list)
+    assert body.get("strategy") == "heatmap_only"
     if body["final_recommendations"]:
         assert "final_score" in body["final_recommendations"][0]
 

--- a/tests/test_simulation_fallback.py
+++ b/tests/test_simulation_fallback.py
@@ -12,8 +12,11 @@ def test_predict_uses_simulation_when_neighbors_sparse(monkeypatch):
 
     def fake_heatmap(g, k, n_iter=500, **_):
         called["n"] += 1
+        called["iter"] = n_iter
         return np.zeros_like(g, dtype=float)
 
     monkeypatch.setattr(analyzer, "probability_heatmap", fake_heatmap)
-    analyzer.predict_scratch_card(grid, target_num=1, iterations=4)
+    result = analyzer.predict_scratch_card(grid, target_num=1, iterations=4)
     assert called["n"] == 1
+    assert called.get("iter") == 10000
+    assert result.get("strategy") == "heatmap_only"


### PR DESCRIPTION
## Summary
- detect sparse information boards in `predict_scratch_card`
- when detected, run heatmap-only simulation with 10k iterations and mark strategy
- propagate strategy value through API and CLI
- adjust tests for new behaviour

## Testing
- `black .`
- `isort . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a3c3275d48324bd41acc9e2f9efc7