### PR TITLE
Fix JSON list support

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -134,6 +134,33 @@ def _iter_json_from_zip(zip_path: Path) -> Iterator[Dict[str, Any]]:
                 yield item
                 continue
 
+            # 新增：裸 list 也要拆成單張 board
+            if isinstance(data, list):
+                if not data:
+                    continue
+                first = data[0]
+                if not (
+                    isinstance(first, list) and all(isinstance(r, list) for r in first)
+                ):
+                    logger.warning(
+                        "Top-level list not boards in %s:%s", zip_path.name, name
+                    )
+                    continue
+                rows, cols = len(first), len(first[0])
+                for board in data:
+                    if (
+                        isinstance(board, list)
+                        and len(board) == rows
+                        and all(isinstance(r, list) and len(r) == cols for r in board)
+                    ):
+                        count += 1
+                        yield {"rows": rows, "cols": cols, "grid": board}
+                    else:
+                        logger.warning(
+                            "Invalid board in list %s:%s", zip_path.name, name
+                        )
+                continue
+
             for key, boards_list in data.items():
                 match = re.match(r"^(\d+)x(\d+)$", key)
                 if not match:

--- a/tests/test_multi_size_loader.py
+++ b/tests/test_multi_size_loader.py
@@ -20,3 +20,17 @@ def test_iter_sample_jsons_multi_size(tmp_path, caplog):
         items = list(analyzer.iter_sample_jsons(str(samples)))
     assert len(items) == 3
     assert any("invalid" in r.message for r in caplog.records)
+
+
+def test_iter_sample_jsons_list_only(tmp_path, caplog):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    data = [[[1, 2], [3, 4]], [[4, 3], [2, 1]]]
+    with zipfile.ZipFile(samples / "list.zip", "w") as zf:
+        zf.writestr("boards.json", json.dumps(data))
+
+    with caplog.at_level(logging.WARNING):
+        items = list(analyzer.iter_sample_jsons(str(samples)))
+
+    assert len(items) == 2
+    assert all(i["rows"] == 2 and i["cols"] == 2 for i in items)


### PR DESCRIPTION
## Summary
- handle top-level list objects in `_iter_json_from_zip`
- add regression test for list-only JSON archives

## Testing
- `black --check analyzer.py tests/test_multi_size_loader.py`
- `isort --check analyzer.py tests/test_multi_size_loader.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5ac7be84832495063b46ea88db15