### PR TITLE
Implement heatmap-only fallback

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1201,6 +1201,28 @@ def predict_scratch_card(
         if not has_adj:
             use_heatmap_only = True
 
+    if not use_heatmap_only and target_num is not None:
+        target_cells = [pos for pos in known_coords if grid_np[pos] == target_num]
+        if not target_cells:
+            use_heatmap_only = True
+        else:
+            has_target_neighbor = False
+            for r, c in target_cells:
+                for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                    nr, nc = r + dr, c + dc
+                    if (
+                        0 <= nr < rows
+                        and 0 <= nc < cols
+                        and grid_np[nr, nc] > 0
+                        and (nr, nc) not in target_cells
+                    ):
+                        has_target_neighbor = True
+                        break
+                if has_target_neighbor:
+                    break
+            if not has_target_neighbor:
+                use_heatmap_only = True
+
     if not blanks:
         return {
             "mode": "no_blanks",
@@ -1230,6 +1252,7 @@ def predict_scratch_card(
             "target_num": int(target_num),
             "predictions": preds,
             "top_predictions": preds,
+            "top_recommendations": preds,
             "full_probabilities": {},
             "final_recommendations": [],
         }

--- a/app.py
+++ b/app.py
@@ -177,6 +177,7 @@ class Prediction(BaseModel):
 class PredictResponse(BaseModel):
     predictions: List[Prediction]
     top_predictions: List[Prediction]
+    top_recommendations: Optional[List[Prediction]] = None
     full_probabilities: Dict[str, Dict[str, float]]
     final_recommendations: List[Dict[str, Any]]
 
@@ -197,6 +198,7 @@ class HeatmapResponse(BaseModel):
     heatmap: Optional[str] = None
     predictions: Optional[List[Prediction]] = None
     top_predictions: Optional[List[Prediction]] = None
+    top_recommendations: Optional[List[Prediction]] = None
     full_probabilities: Optional[Dict[str, Dict[str, float]]] = None
     final_recommendations: Optional[List[Dict[str, Any]]] = None
 
@@ -398,6 +400,7 @@ async def predict(req: GridRequest):
         preds = _to_1_based(result.get("predictions"))
         tops = _to_1_based(result.get("top_predictions"))
         recs = _to_1_based(result.get("final_recommendations"))
+        top_recs = _to_1_based(result.get("top_recommendations"))
 
         payload = {
             "predictions": preds,
@@ -405,6 +408,7 @@ async def predict(req: GridRequest):
             "full_probabilities": clean_probs,
             "sample_gamma_used": req.sample_gamma or 0.0,
             "final_recommendations": recs,
+            "top_recommendations": top_recs,
             "strategy": result.get("strategy"),
         }
         safe_payload = sanitize_floats(payload)
@@ -481,6 +485,7 @@ async def heatmap(req: HeatmapRequest):
         preds = _to_1_based(pred_result.get("predictions"))
         tops = _to_1_based(pred_result.get("top_predictions"))
         recs = _to_1_based(pred_result.get("final_recommendations"))
+        top_recs = _to_1_based(pred_result.get("top_recommendations"))
 
         if isinstance(prob, dict):
             pm = {str(int(k)): v.tolist() for k, v in prob.items()}
@@ -491,6 +496,7 @@ async def heatmap(req: HeatmapRequest):
                 "top_predictions": tops,
                 "full_probabilities": clean_probs,
                 "final_recommendations": recs,
+                "top_recommendations": top_recs,
                 "strategy": pred_result.get("strategy"),
             }
         elif req.output_format.lower() in ("raw", "json"):
@@ -501,6 +507,7 @@ async def heatmap(req: HeatmapRequest):
                 "top_predictions": tops,
                 "full_probabilities": clean_probs,
                 "final_recommendations": recs,
+                "top_recommendations": top_recs,
                 "sample_gamma_used": req.sample_gamma or 0.0,
                 "strategy": pred_result.get("strategy"),
             }
@@ -514,6 +521,7 @@ async def heatmap(req: HeatmapRequest):
                 "top_predictions": tops,
                 "full_probabilities": clean_probs,
                 "final_recommendations": recs,
+                "top_recommendations": top_recs,
                 "strategy": pred_result.get("strategy"),
             }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,6 +45,8 @@ def test_predict_basic(client):
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
     assert isinstance(body.get("final_recommendations"), list)
+    assert isinstance(body.get("top_recommendations"), list)
+    assert isinstance(body.get("top_recommendations"), list)
     assert body.get("strategy") == "heatmap_only"
     if body["final_recommendations"]:
         assert "final_score" in body["final_recommendations"][0]
@@ -66,6 +68,7 @@ def test_heatmap_basic(client):
     assert isinstance(body.get("top_predictions"), list)
     assert isinstance(body.get("full_probabilities"), dict)
     assert isinstance(body.get("final_recommendations"), list)
+    assert isinstance(body.get("top_recommendations"), list)
     if body["final_recommendations"]:
         assert "final_score" in body["final_recommendations"][0]
 

--- a/tests/test_simulation_fallback.py
+++ b/tests/test_simulation_fallback.py
@@ -20,3 +20,23 @@ def test_predict_uses_simulation_when_neighbors_sparse(monkeypatch):
     assert called["n"] == 1
     assert called.get("iter") == 10000
     assert result.get("strategy") == "heatmap_only"
+
+
+def test_heatmap_only_when_target_isolated(monkeypatch):
+    grid = [
+        [5, -1, 1],
+        [-1, -1, 2],
+        [3, -1, 4],
+    ]
+    called = {"n": 0}
+
+    def fake_heatmap(g, k, n_iter=500, **_):
+        called["n"] += 1
+        called["iter"] = n_iter
+        return np.zeros_like(g, dtype=float)
+
+    monkeypatch.setattr(analyzer, "probability_heatmap", fake_heatmap)
+    result = analyzer.predict_scratch_card(grid, target_num=5, iterations=4)
+    assert called["n"] == 1
+    assert called.get("iter") == 10000
+    assert result.get("strategy") == "heatmap_only"


### PR DESCRIPTION
## Summary
- enable heatmap-only mode when board sparse or target isolated
- expose `top_recommendations` via API
- add coverage for new logic and adjust API tests

## Testing
- `black analyzer.py app.py tests/test_api.py tests/test_simulation_fallback.py --check`
- `isort . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_api.py tests/test_simulation_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_686a708299048324b54b078c9dc5510c