### PR TITLE
Improve heatmap fallback and normalize score fusion

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -907,15 +907,26 @@ def fuse_predictions_with_heatmap(
     """
 
     rows, cols = heatmap.shape
-    score_map = {
-        (int(p.get("row")), int(p.get("col"))): float(p.get("score", 0.0))
-        for p in predictions
-    }
+    pred_mat = np.zeros_like(heatmap, dtype=float)
+    for item in predictions:
+        r, c = int(item.get("row", -1)), int(item.get("col", -1))
+        if 0 <= r < rows and 0 <= c < cols:
+            pred_mat[r, c] = float(item.get("score", 0.0))
+
+    def _softmax(mat: np.ndarray) -> np.ndarray:
+        flat = mat.ravel().astype(float)
+        exp = np.exp(flat - flat.max())
+        res = exp / (exp.sum() + 1e-12)
+        return res.reshape(mat.shape)
+
+    pred_norm = _softmax(pred_mat)
+    heat_norm = _softmax(heatmap)
+
     recs: List[Dict[str, Any]] = []
     for r in range(rows):
         for c in range(cols):
-            pred_score = score_map.get((r, c), 0.0)
-            prob = float(heatmap[r, c])
+            pred_score = pred_norm[r, c]
+            prob = heat_norm[r, c]
             final = fusion_alpha * pred_score + (1.0 - fusion_alpha) * prob
             recs.append({"row": r, "col": c, "final_score": final})
     recs.sort(key=lambda x: x["final_score"], reverse=True)
@@ -935,11 +946,21 @@ def fuse_score_matrices(
         raise ValueError("score map and heatmap must have the same shape")
 
     rows, cols = predict_scores.shape
+
+    def _softmax(mat: np.ndarray) -> np.ndarray:
+        flat = mat.ravel().astype(float)
+        exp = np.exp(flat - flat.max())
+        res = exp / (exp.sum() + 1e-12)
+        return res.reshape(mat.shape)
+
+    p_norm = _softmax(predict_scores)
+    h_norm = _softmax(heatmap_prob_map)
+
     recs: List[Dict[str, Any]] = []
     for r in range(rows):
         for c in range(cols):
-            pred = float(predict_scores[r, c])
-            prob = float(heatmap_prob_map[r, c])
+            pred = float(p_norm[r, c])
+            prob = float(h_norm[r, c])
             score = fusion_alpha * pred + (1.0 - fusion_alpha) * prob
             recs.append({"row": r, "col": c, "final_score": score})
 
@@ -1208,15 +1229,21 @@ def predict_scratch_card(
         else:
             has_target_neighbor = False
             for r, c in target_cells:
-                for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
-                    nr, nc = r + dr, c + dc
-                    if (
-                        0 <= nr < rows
-                        and 0 <= nc < cols
-                        and grid_np[nr, nc] > 0
-                        and (nr, nc) not in target_cells
-                    ):
-                        has_target_neighbor = True
+                # 八方向檢查：如果目標周圍八格都沒有已知數字，就退回 heatmap_only
+                for dr in (-1, 0, 1):
+                    for dc in (-1, 0, 1):
+                        if dr == 0 and dc == 0:
+                            continue
+                        nr, nc = r + dr, c + dc
+                        if (
+                            0 <= nr < rows
+                            and 0 <= nc < cols
+                            and grid_np[nr, nc] > 0
+                            and (nr, nc) not in target_cells
+                        ):
+                            has_target_neighbor = True
+                            break
+                    if has_target_neighbor:
                         break
                 if has_target_neighbor:
                     break

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,4 +175,6 @@ def test_fuse_basic(client):
     assert len(body) == 2
     assert body[0]["row"] == 1
     assert body[0]["col"] == 1
-    assert body[0]["final_score"] == pytest.approx(0.7)
+    assert body[0]["final_score"] == pytest.approx(0.3128836, rel=1e-6)
+    assert body[1]["row"] == 2
+    assert body[1]["col"] == 2

--- a/tests/test_simulation_fallback.py
+++ b/tests/test_simulation_fallback.py
@@ -40,3 +40,21 @@ def test_heatmap_only_when_target_isolated(monkeypatch):
     assert called["n"] == 1
     assert called.get("iter") == 10000
     assert result.get("strategy") == "heatmap_only"
+
+
+def test_diagonal_neighbor_no_heatmap_only(monkeypatch):
+    grid = [
+        [5, -1],
+        [-1, 1],
+    ]
+    called = {"n": 0}
+
+    def fake_heatmap(g, k, n_iter=500, **_):
+        called["n"] += 1
+        called["iter"] = n_iter
+        return np.zeros_like(g, dtype=float)
+
+    monkeypatch.setattr(analyzer, "probability_heatmap", fake_heatmap)
+    result = analyzer.predict_scratch_card(grid, target_num=5, iterations=4)
+    assert called.get("iter") == 4
+    assert result.get("strategy") != "heatmap_only"


### PR DESCRIPTION
## Summary
- trigger heatmap-only mode only when the target cell has no known neighbors in eight directions
- normalize prediction and heatmap matrices with softmax before fusion
- update tests for new behavior
- add regression test for diagonal neighbor fallback

## Testing
- `isort --check analyzer.py tests/test_api.py tests/test_simulation_fallback.py`
- `black analyzer.py tests/test_api.py tests/test_simulation_fallback.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a82bd5a808324bad9821ec61b2179