### PR TITLE
Fix heatmap fallback and fusion scoring

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -907,17 +907,23 @@ def fuse_predictions_with_heatmap(
     """
 
     rows, cols = heatmap.shape
-    score_map = {
-        (int(p.get("row")), int(p.get("col"))): float(p.get("score", 0.0))
-        for p in predictions
-    }
+    pred_mat = np.zeros((rows, cols), dtype=float)
+    for p in predictions:
+        r = int(p.get("row"))
+        c = int(p.get("col"))
+        pred_mat[r, c] = float(p.get("score", 0.0))
+
+    def _softmax(arr: np.ndarray) -> np.ndarray:
+        ex = np.exp(arr - np.max(arr))
+        return ex / np.sum(ex)
+
+    pred_norm = _softmax(pred_mat)
+    heat_norm = _softmax(heatmap)
+    final = fusion_alpha * pred_norm + (1.0 - fusion_alpha) * heat_norm
     recs: List[Dict[str, Any]] = []
     for r in range(rows):
         for c in range(cols):
-            pred_score = score_map.get((r, c), 0.0)
-            prob = float(heatmap[r, c])
-            final = fusion_alpha * pred_score + (1.0 - fusion_alpha) * prob
-            recs.append({"row": r, "col": c, "final_score": final})
+            recs.append({"row": r, "col": c, "final_score": float(final[r, c])})
     recs.sort(key=lambda x: x["final_score"], reverse=True)
     return recs[:top_k]
 
@@ -935,13 +941,19 @@ def fuse_score_matrices(
         raise ValueError("score map and heatmap must have the same shape")
 
     rows, cols = predict_scores.shape
+
+    def _softmax(arr: np.ndarray) -> np.ndarray:
+        ex = np.exp(arr - np.max(arr))
+        return ex / np.sum(ex)
+
+    pred_norm = _softmax(predict_scores)
+    heat_norm = _softmax(heatmap_prob_map)
+    final = fusion_alpha * pred_norm + (1.0 - fusion_alpha) * heat_norm
+
     recs: List[Dict[str, Any]] = []
     for r in range(rows):
         for c in range(cols):
-            pred = float(predict_scores[r, c])
-            prob = float(heatmap_prob_map[r, c])
-            score = fusion_alpha * pred + (1.0 - fusion_alpha) * prob
-            recs.append({"row": r, "col": c, "final_score": score})
+            recs.append({"row": r, "col": c, "final_score": float(final[r, c])})
 
     recs.sort(key=lambda x: x["final_score"], reverse=True)
     return recs[:top_k]
@@ -1208,18 +1220,16 @@ def predict_scratch_card(
         else:
             has_target_neighbor = False
             for r, c in target_cells:
-                for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
-                    nr, nc = r + dr, c + dc
-                    if (
-                        0 <= nr < rows
-                        and 0 <= nc < cols
-                        and grid_np[nr, nc] > 0
-                        and (nr, nc) not in target_cells
-                    ):
-                        has_target_neighbor = True
+                for dr in (-1, 0, 1):
+                    for dc in (-1, 0, 1):
+                        if dr == 0 and dc == 0:
+                            continue
+                        nr, nc = r + dr, c + dc
+                        if 0 <= nr < rows and 0 <= nc < cols and grid_np[nr, nc] > 0:
+                            has_target_neighbor = True
+                            break
+                    if has_target_neighbor:
                         break
-                if has_target_neighbor:
-                    break
             if not has_target_neighbor:
                 use_heatmap_only = True
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,8 @@ Ultra-minimal smoke-tests for Scratch-Card Prediction API
 
 from typing import Any, Dict, List
 
+import numpy as np
+
 import pytest
 
 import analyzer
@@ -173,6 +175,22 @@ def test_fuse_basic(client):
     assert resp.status_code == 200
     assert isinstance(body, list)
     assert len(body) == 2
-    assert body[0]["row"] == 1
-    assert body[0]["col"] == 1
-    assert body[0]["final_score"] == pytest.approx(0.7)
+
+    def softmax(arr):
+        ex = np.exp(arr - np.max(arr))
+        return ex / ex.sum()
+
+    pred_s = softmax(np.array(pred))
+    heat_s = softmax(np.array(heat))
+    final = 0.5 * pred_s + 0.5 * heat_s
+    top_flat = final.ravel().argsort()[::-1][:2]
+    rows, cols = np.unravel_index(top_flat, final.shape)
+    expected = [
+        {"row": int(r) + 1, "col": int(c) + 1, "final_score": float(final[r, c])}
+        for r, c in zip(rows, cols)
+    ]
+
+    for res, exp in zip(body, expected):
+        assert res["row"] == exp["row"]
+        assert res["col"] == exp["col"]
+        assert res["final_score"] == pytest.approx(exp["final_score"])

--- a/tests/test_simulation_fallback.py
+++ b/tests/test_simulation_fallback.py
@@ -40,3 +40,23 @@ def test_heatmap_only_when_target_isolated(monkeypatch):
     assert called["n"] == 1
     assert called.get("iter") == 10000
     assert result.get("strategy") == "heatmap_only"
+
+
+def test_target_with_diagonal_neighbor_not_heatmap_only(monkeypatch):
+    grid = [
+        [8, -1, -1],
+        [-1, 5, -1],
+        [-1, -1, -1],
+    ]
+    called = {"n": 0}
+
+    def fake_heatmap(g, k, n_iter=500, **_):
+        called["n"] += 1
+        called["iter"] = n_iter
+        return np.zeros_like(g, dtype=float)
+
+    monkeypatch.setattr(analyzer, "probability_heatmap", fake_heatmap)
+    result = analyzer.predict_scratch_card(grid, target_num=5, iterations=4)
+    assert result.get("strategy") != "heatmap_only"
+    if called["n"]:
+        assert called.get("iter") != 10000


### PR DESCRIPTION
## Summary
- improve eight-direction neighbor check in `predict_scratch_card`
- normalize fusion calculations with softmax
- add regression test for diagonal neighbor case
- update `/fuse` endpoint tests for new fusion logic

## Testing
- `black --check analyzer.py tests/test_simulation_fallback.py tests/test_api.py`
- `isort --check-only analyzer.py tests/test_simulation_fallback.py tests/test_api.py`
- `flake8 analyzer.py tests/test_simulation_fallback.py tests/test_api.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a82bd5a808324bad9821ec61b2179