### PR TITLE
Enable override of heatmap-only fallback

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1185,6 +1185,7 @@ def predict_scratch_card(
     pseudo_count: float = 0.0,
     exclude_filled: bool = True,
     strategy: str = "legacy",
+    disable_fallback: bool = False,
 ) -> Dict[str, Any]:
 
     BLANK_VAL = -1
@@ -1197,41 +1198,46 @@ def predict_scratch_card(
 
     known_coords = [tuple(b) for b in np.argwhere(grid_np > 0)]
     use_heatmap_only = False
-    if len(known_coords) <= 3:
-        has_adj = False
-        for r, c in known_coords:
-            for dr in (-1, 0, 1):
-                for dc in (-1, 0, 1):
-                    if dr == 0 and dc == 0:
-                        continue
-                    nr, nc = r + dr, c + dc
-                    if 0 <= nr < rows and 0 <= nc < cols and grid_np[nr, nc] > 0:
-                        has_adj = True
-                        break
-                if has_adj:
-                    break
-        if not has_adj:
-            use_heatmap_only = True
-
-    if not use_heatmap_only and target_num is not None:
-        target_cells = [pos for pos in known_coords if grid_np[pos] == target_num]
-        if not target_cells:
-            use_heatmap_only = True
-        else:
-            has_target_neighbor = False
-            for r, c in target_cells:
+    if not disable_fallback:
+        if len(known_coords) <= 3:
+            has_adj = False
+            for r, c in known_coords:
                 for dr in (-1, 0, 1):
                     for dc in (-1, 0, 1):
                         if dr == 0 and dc == 0:
                             continue
                         nr, nc = r + dr, c + dc
                         if 0 <= nr < rows and 0 <= nc < cols and grid_np[nr, nc] > 0:
-                            has_target_neighbor = True
+                            has_adj = True
                             break
-                    if has_target_neighbor:
+                    if has_adj:
                         break
-            if not has_target_neighbor:
+            if not has_adj:
                 use_heatmap_only = True
+
+        if not use_heatmap_only and target_num is not None:
+            target_cells = [pos for pos in known_coords if grid_np[pos] == target_num]
+            if not target_cells:
+                use_heatmap_only = True
+            else:
+                has_target_neighbor = False
+                for r, c in target_cells:
+                    for dr in (-1, 0, 1):
+                        for dc in (-1, 0, 1):
+                            if dr == 0 and dc == 0:
+                                continue
+                            nr, nc = r + dr, c + dc
+                            if (
+                                0 <= nr < rows
+                                and 0 <= nc < cols
+                                and grid_np[nr, nc] > 0
+                            ):
+                                has_target_neighbor = True
+                                break
+                        if has_target_neighbor:
+                            break
+                if not has_target_neighbor:
+                    use_heatmap_only = True
 
     if not blanks:
         return {

--- a/app.py
+++ b/app.py
@@ -163,6 +163,7 @@ class GridRequest(BaseModel):
     pseudo_count: Optional[float] = None
     exclude_filled: bool = True
     strategy: Literal["legacy", "modern"] = "legacy"
+    disable_fallback: Optional[bool] = False
 
 
 class Prediction(BaseModel):
@@ -191,6 +192,7 @@ class HeatmapRequest(BaseModel):
     output_format: Literal["base64", "raw", "json"] = "base64"
     sample_gamma: Optional[float] = None
     fusion_alpha: Optional[float] = None
+    disable_fallback: Optional[bool] = False
 
 
 class HeatmapResponse(BaseModel):
@@ -375,6 +377,7 @@ async def predict(req: GridRequest):
             fusion_alpha=req.fusion_alpha or 0.5,
             pseudo_count=req.pseudo_count or 0.0,
             strategy=req.strategy,
+            disable_fallback=req.disable_fallback or False,
         )
 
         if req.target_num is not None:
@@ -468,6 +471,7 @@ async def heatmap(req: HeatmapRequest):
             result_top_k=3,
             priors=priors,
             sample_gamma=req.sample_gamma or 0.0,
+            disable_fallback=req.disable_fallback or False,
         )
 
         fusion_alpha = req.fusion_alpha or 0.7

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,6 @@ Ultra-minimal smoke-tests for Scratch-Card Prediction API
 from typing import Any, Dict, List
 
 import numpy as np
-
 import pytest
 
 import analyzer
@@ -139,6 +138,18 @@ def test_predict_strategy_modern(client):
     resp = client.post("/predict", json=payload)
     assert resp.status_code == 200
     assert "final_recommendations" in resp.json()
+
+
+def test_predict_disable_fallback(client):
+    grid = [
+        [5, -1, 1],
+        [-1, -1, 2],
+        [3, -1, 4],
+    ]
+    payload = {"grid": grid, "target_num": 5, "disable_fallback": True}
+    resp = client.post("/predict", json=payload)
+    assert resp.status_code == 200
+    assert resp.json().get("strategy") != "heatmap_only"
 
 
 def test_no_open_cells_in_top3(client):

--- a/tests/test_simulation_fallback.py
+++ b/tests/test_simulation_fallback.py
@@ -60,3 +60,25 @@ def test_target_with_diagonal_neighbor_not_heatmap_only(monkeypatch):
     assert result.get("strategy") != "heatmap_only"
     if called["n"]:
         assert called.get("iter") != 10000
+
+
+def test_disable_fallback_overrides(monkeypatch):
+    grid = [
+        [5, -1, 1],
+        [-1, -1, 2],
+        [3, -1, 4],
+    ]
+    called = {"n": 0}
+
+    def fake_heatmap(g, k, n_iter=500, **_):
+        called["n"] += 1
+        called["iter"] = n_iter
+        return np.zeros_like(g, dtype=float)
+
+    monkeypatch.setattr(analyzer, "probability_heatmap", fake_heatmap)
+    result = analyzer.predict_scratch_card(
+        grid, target_num=5, iterations=4, disable_fallback=True
+    )
+    assert result.get("strategy") != "heatmap_only"
+    if called["n"]:
+        assert called.get("iter") != 10000


### PR DESCRIPTION
## Summary
- add `disable_fallback` option to `predict_scratch_card`
- expose option on `/predict` and `/heatmap` endpoints
- test API and analyzer override behavior

## Testing
- `black --check analyzer.py app.py tests/test_simulation_fallback.py tests/test_api.py`
- `isort --check-only analyzer.py app.py tests/test_simulation_fallback.py tests/test_api.py`
- `flake8 analyzer.py app.py tests/test_simulation_fallback.py tests/test_api.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9240ab348324809747cee01ae2c6