### PR TITLE
Fix strategy override for predict

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1181,8 +1181,9 @@ def predict_scratch_card(
     history_dir: str = "samples",
     gamma_history: float = 0.0,
     sample_gamma: float = 0.0,
-    fusion_alpha: float = 0.5,
+    fusion_alpha: Optional[float] = None,
     pseudo_count: float = 0.0,
+    force_legacy: bool = False,
     exclude_filled: bool = True,
     strategy: str = "legacy",
 ) -> Dict[str, Any]:
@@ -1232,6 +1233,9 @@ def predict_scratch_card(
                         break
             if not has_target_neighbor:
                 use_heatmap_only = True
+
+    if force_legacy:
+        use_heatmap_only = False
 
     if not blanks:
         return {
@@ -1607,6 +1611,8 @@ def evaluate_prediction_accuracy(num_trials: int = 50, seed: int = 0) -> float:
             focus_iter=5,
             top_n=5,
             epsilon=0.1,
+            fusion_alpha=None,
+            force_legacy=False,
         )
         preds = res.get("predictions", [])
         trials += 1

--- a/app.py
+++ b/app.py
@@ -361,6 +361,16 @@ async def predict(req: GridRequest):
         # 正規化空格：0 / "" 皆視為 -1
         is_blank = (grid_np == -1) | (grid_np == 0) | (grid_np == "")
         grid_norm = np.where(is_blank, -1, grid_np).astype(int).tolist()
+        force_legacy = False
+        if "strategy" in req.model_fields_set and req.strategy == "legacy":
+            force_legacy = True
+        if (
+            "fusion_alpha" in req.model_fields_set
+            and req.fusion_alpha is not None
+            and req.fusion_alpha > 0
+        ):
+            force_legacy = True
+
         result = predict_scratch_card(
             grid=grid_norm,
             target_num=req.target_num,
@@ -372,7 +382,8 @@ async def predict(req: GridRequest):
             result_top_k=top_k,
             priors=priors,
             sample_gamma=req.sample_gamma or 0.0,
-            fusion_alpha=req.fusion_alpha or 0.5,
+            fusion_alpha=req.fusion_alpha,
+            force_legacy=force_legacy,
             pseudo_count=req.pseudo_count or 0.0,
             strategy=req.strategy,
         )
@@ -386,7 +397,7 @@ async def predict(req: GridRequest):
                 sample_gamma=req.sample_gamma or 0.0,
                 history_dir="samples",
             )
-            fusion_alpha = req.fusion_alpha or 0.7
+            fusion_alpha = req.fusion_alpha if req.fusion_alpha is not None else 0.7
             result["final_recommendations"] = fuse_predictions_with_heatmap(
                 heat,
                 result.get("top_predictions", []),

--- a/main.py
+++ b/main.py
@@ -158,6 +158,8 @@ def main():
             result_top_k=args.top_k,
             priors=priors,
             sample_gamma=args.sample_gamma,
+            fusion_alpha=None,
+            force_legacy=False,
             strategy=args.strategy,
         )
         ray.shutdown()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,6 @@ Ultra-minimal smoke-tests for Scratch-Card Prediction API
 from typing import Any, Dict, List
 
 import numpy as np
-
 import pytest
 
 import analyzer
@@ -139,6 +138,20 @@ def test_predict_strategy_modern(client):
     resp = client.post("/predict", json=payload)
     assert resp.status_code == 200
     assert "final_recommendations" in resp.json()
+
+
+def test_predict_legacy_override_heatmap(client):
+    grid = [[-1, -1], [-1, 2]]
+    payload = {
+        "grid": grid,
+        "target_num": 1,
+        "strategy": "legacy",
+        "fusion_alpha": 0.5,
+        "iterations": 4,
+    }
+    resp = client.post("/predict", json=payload)
+    assert resp.status_code == 200
+    assert resp.json().get("strategy") != "heatmap_only"
 
 
 def test_no_open_cells_in_top3(client):

--- a/tests/test_simulation_fallback.py
+++ b/tests/test_simulation_fallback.py
@@ -60,3 +60,22 @@ def test_target_with_diagonal_neighbor_not_heatmap_only(monkeypatch):
     assert result.get("strategy") != "heatmap_only"
     if called["n"]:
         assert called.get("iter") != 10000
+
+
+def test_force_legacy_overrides_heatmap(monkeypatch):
+    grid = [
+        [-1, -1],
+        [-1, 4],
+    ]
+    monkeypatch.setattr(
+        analyzer,
+        "probability_heatmap",
+        lambda *a, **k: np.zeros((2, 2), dtype=float),
+    )
+    result = analyzer.predict_scratch_card(
+        grid,
+        target_num=1,
+        iterations=4,
+        force_legacy=True,
+    )
+    assert result.get("strategy") != "heatmap_only"


### PR DESCRIPTION
## Summary
- add `force_legacy` flag to `predict_scratch_card`
- respect client-provided strategy/fusion_alpha in `/predict`
- update CLI and internal calls
- test that legacy strategy can override heatmap-only fallback

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a9240ab348324809747cee01ae2c6