### PR TITLE
Enable historical sample fusion defaults

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1702,6 +1702,11 @@ def neighbor_lock_or_fuse(
     except Exception as exc:  # pragma: no cover - IO errors
         logger.error("prior load failed: %s", exc)
         prior_map = {}
+    used = len(prior_map)
+    logger.info(
+        "回退融合：從歷史樣本載入 %d 個格子位置的機率分布",
+        used,
+    )
     sim_map = simulate_full_board(grid, target_num, n_iter=phase1)
 
     prior_scores = {pos: prior_map.get(pos, {}).get(target_num, 0.0) for pos in blanks}

--- a/app.py
+++ b/app.py
@@ -158,7 +158,8 @@ class GridRequest(BaseModel):
     top_n: Optional[int] = None
     epsilon: Optional[float] = None
     result_top_k: Optional[int] = None
-    sample_gamma: Optional[float] = None
+    sample_gamma: Optional[float] = 0.9
+    use_neighbor_lock: bool = True
     fusion_alpha: Optional[float] = None
     pseudo_count: Optional[float] = None
     exclude_filled: bool = True
@@ -189,7 +190,8 @@ class HeatmapRequest(BaseModel):
     iterations: int = 1000
     seed: int = 0
     output_format: Literal["base64", "raw", "json"] = "base64"
-    sample_gamma: Optional[float] = None
+    sample_gamma: Optional[float] = 0.9
+    use_neighbor_lock: bool = True
     fusion_alpha: Optional[float] = None
 
 
@@ -381,7 +383,8 @@ async def predict(req: GridRequest):
             epsilon=eps,
             result_top_k=top_k,
             priors=priors,
-            sample_gamma=req.sample_gamma or 0.0,
+            sample_gamma=req.sample_gamma or 0.9,
+            use_neighbor_lock=req.use_neighbor_lock,
             fusion_alpha=req.fusion_alpha,
             force_legacy=force_legacy,
             pseudo_count=req.pseudo_count or 0.0,
@@ -394,7 +397,7 @@ async def predict(req: GridRequest):
                 grid_norm,
                 req.target_num,
                 hm_iter,
-                sample_gamma=req.sample_gamma or 0.0,
+                sample_gamma=req.sample_gamma or 0.9,
                 history_dir="samples",
             )
             fusion_alpha = req.fusion_alpha if req.fusion_alpha is not None else 0.7
@@ -417,7 +420,7 @@ async def predict(req: GridRequest):
             "predictions": preds,
             "top_predictions": tops,
             "full_probabilities": clean_probs,
-            "sample_gamma_used": req.sample_gamma or 0.0,
+            "sample_gamma_used": req.sample_gamma or 0.9,
             "final_recommendations": recs,
             "top_recommendations": top_recs,
             "strategy": result.get("strategy"),
@@ -456,7 +459,7 @@ async def heatmap(req: HeatmapRequest):
             k_eff,
             iters,
             seed=req.seed,
-            sample_gamma=req.sample_gamma or 0.0,
+            sample_gamma=req.sample_gamma or 0.9,
             history_dir="samples",
         )
 
@@ -478,7 +481,8 @@ async def heatmap(req: HeatmapRequest):
             epsilon=PHASE2_EPS,
             result_top_k=3,
             priors=priors,
-            sample_gamma=req.sample_gamma or 0.0,
+            sample_gamma=req.sample_gamma or 0.9,
+            use_neighbor_lock=req.use_neighbor_lock,
         )
 
         fusion_alpha = req.fusion_alpha or 0.7
@@ -519,7 +523,7 @@ async def heatmap(req: HeatmapRequest):
                 "full_probabilities": clean_probs,
                 "final_recommendations": recs,
                 "top_recommendations": top_recs,
-                "sample_gamma_used": req.sample_gamma or 0.0,
+                "sample_gamma_used": req.sample_gamma or 0.9,
                 "strategy": pred_result.get("strategy"),
             }
         else:

--- a/main.py
+++ b/main.py
@@ -92,8 +92,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sample-gamma",
         type=float,
-        default=0.0,
+        default=0.9,
         help="Weight for sample-based frequency prior",
+    )
+    parser.add_argument(
+        "--use-neighbor-lock",
+        action="store_true",
+        default=True,
+        help="Enable neighbor lock strategy",
     )
     parser.add_argument(
         "--strategy",
@@ -158,6 +164,7 @@ def main():
             result_top_k=args.top_k,
             priors=priors,
             sample_gamma=args.sample_gamma,
+            use_neighbor_lock=args.use_neighbor_lock,
             fusion_alpha=None,
             force_legacy=False,
             strategy=args.strategy,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,7 @@ def test_predict_basic(client):
         "grid": grid,
         "target_num": 1,  # 指定一個號碼，避免走唯一分派
         "iterations": 4,
+        "use_neighbor_lock": False,
     }
     resp = client.post("/predict", json=payload)
     body = resp.json()

--- a/tests/test_neighbor_lock.py
+++ b/tests/test_neighbor_lock.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import analyzer
 
 


### PR DESCRIPTION
## Summary
- turn on neighbor lock and sample fusion by default
- expose new defaults in API schema and CLI options
- log sample counts when fusing via history fallback
- update tests for new defaults

## Testing
- `black --check app.py main.py analyzer.py tests/test_api.py tests/test_neighbor_lock.py`
- `isort --check app.py main.py analyzer.py tests/test_api.py tests/test_neighbor_lock.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abfd496188324bf3265601b1f8c19