### PR TITLE
Implement sample neighbor ranking

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -127,17 +127,62 @@ def compute_target_distribution(
     return freq.astype(float) / float(total)
 
 
+def compute_neighbor_match_score(
+    grid: np.ndarray, matching: List[np.ndarray]
+) -> np.ndarray:
+    """Return per-cell neighbor match counts averaged over ``matching`` boards."""
+
+    rows, cols = grid.shape
+    scores = np.zeros((rows, cols), dtype=float)
+    if not matching:
+        return scores
+
+    deltas = [
+        (-1, -1),
+        (-1, 0),
+        (-1, 1),
+        (0, -1),
+        (0, 1),
+        (1, -1),
+        (1, 0),
+        (1, 1),
+    ]
+
+    blanks = np.argwhere(grid == -1)
+    for r, c in blanks:
+        total = 0
+        for board in matching:
+            cnt = 0
+            for dr, dc in deltas:
+                nr, nc = r + dr, c + dc
+                if 0 <= nr < rows and 0 <= nc < cols and grid[nr, nc] != -1:
+                    if board[nr, nc] == grid[nr, nc]:
+                        cnt += 1
+            total += cnt
+        scores[r, c] = total / float(len(matching))
+    return scores
+
+
 def rank_cells_by_prob(
-    grid: np.ndarray, probs: np.ndarray
+    grid: np.ndarray, probs: np.ndarray, *, neighbor: Optional[np.ndarray] = None
 ) -> List[Tuple[int, int, float]]:
-    """Rank blank cells by probability."""
+    """Rank blank cells by probability and optional neighbor score."""
+
     blanks = [(int(r), int(c)) for r, c in zip(*np.where(grid == -1))]
+    if neighbor is None:
+        ranked = sorted(
+            [(r, c, float(probs[r, c])) for r, c in blanks],
+            key=lambda x: x[2],
+            reverse=True,
+        )
+        return ranked
+
     ranked = sorted(
-        [(r, c, float(probs[r, c])) for r, c in blanks],
-        key=lambda x: x[2],
+        [(r, c, float(probs[r, c]), float(neighbor[r, c])) for r, c in blanks],
+        key=lambda x: (x[2], x[3]),
         reverse=True,
     )
-    return ranked
+    return [(r, c, p) for r, c, p, _ in ranked]
 
 
 def apply_uniqueness_penalty(
@@ -1264,7 +1309,8 @@ def predict_scratch_card(
         matching = filter_matching_samples(grid_np, samples)
         if len(matching) >= MIN_MATCHING:
             probs = compute_target_distribution(matching, target_num, grid_np.shape)
-            ranked = rank_cells_by_prob(grid_np, probs)
+            neighbor_score = compute_neighbor_match_score(grid_np, matching)
+            ranked = rank_cells_by_prob(grid_np, probs, neighbor=neighbor_score)
             preds = [{"row": r, "col": c, "score": p} for r, c, p in ranked[:top_n]]
             return {
                 "mode": "sample_only",

--- a/tests/test_pure_sample.py
+++ b/tests/test_pure_sample.py
@@ -20,3 +20,19 @@ def test_pure_sample_branch(tmp_path):
     assert res["predictions"][0]["row"] == 1
     assert res["predictions"][0]["col"] == 1
     assert abs(res["predictions"][0]["score"] - 1.0) < 1e-6
+
+
+def test_pure_sample_neighbor_ranking(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    board = {"rows": 3, "cols": 3, "grid": [[1, 2, 2], [3, 4, 4], [5, 6, 7]]}
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("b.json", json.dumps(board))
+
+    grid = [[1, -1, -1], [3, 4, -1], [5, 6, 7]]
+    res = analyzer.predict_scratch_card(
+        grid, target_num=2, history_dir=str(samples), top_n=2
+    )
+    preds = res["predictions"]
+    assert preds[0]["row"] == 0 and preds[0]["col"] == 1
+    assert preds[1]["row"] == 0 and preds[1]["col"] == 2


### PR DESCRIPTION
## Summary
- rank sample-only predictions by 3x3 neighborhood matches
- add test for sample neighbor ranking

## Testing
- `black analyzer.py tests/test_pure_sample.py --check`
- `isort --check-only analyzer.py tests/test_pure_sample.py`
- `flake8 analyzer.py tests/test_pure_sample.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b30e4714083248d53c5bb38e8c471