### PR TITLE
Set fusion_alpha default to 0.1

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1316,7 +1316,7 @@ def predict_scratch_card(
     history_dir: str = "samples",
     gamma_history: float = 0.0,
     sample_gamma: float = 0.0,
-    fusion_alpha: Optional[float] = None,
+    fusion_alpha: float = 0.1,
     pseudo_count: float = 0.0,
     force_legacy: bool = False,
     exclude_filled: bool = True,
@@ -1390,7 +1390,7 @@ def predict_scratch_card(
                 phase1=iterations or 6000,
                 samples_dir=history_dir,
                 sample_gamma=sample_gamma or 0.9,
-                fusion_alpha = 0.1,
+                fusion_alpha=fusion_alpha,
                 threshold=neighbor_threshold,
             )
             return {
@@ -1770,7 +1770,7 @@ def probability_heatmap(
     # 中文 log：顯示融合參數與實際使用的樣本比例
     logger.info(
         "融合中：sample_gamma=%.2f（樣本佔比），fusion_alpha=%.2f（模擬佔比）",
-        sample_gamma,
+        sample_gamma or 0.9,
         fusion_alpha,
     )
 
@@ -1829,7 +1829,7 @@ def evaluate_prediction_accuracy(num_trials: int = 50, seed: int = 0) -> float:
             focus_iter=5,
             top_n=5,
             epsilon=0.1,
-            fusion_alpha=None,
+            fusion_alpha=0.1,
             force_legacy=False,
         )
         preds = res.get("predictions", [])

--- a/app.py
+++ b/app.py
@@ -373,6 +373,7 @@ async def predict(req: GridRequest):
         ):
             force_legacy = True
 
+        fusion_alpha = req.fusion_alpha if req.fusion_alpha is not None else 0.1
         result = predict_scratch_card(
             grid=grid_norm,
             target_num=req.target_num,
@@ -385,7 +386,7 @@ async def predict(req: GridRequest):
             priors=priors,
             sample_gamma=req.sample_gamma or 0.9,
             use_neighbor_lock=req.use_neighbor_lock,
-            fusion_alpha=req.fusion_alpha,
+            fusion_alpha=fusion_alpha,
             force_legacy=force_legacy,
             pseudo_count=req.pseudo_count or 0.0,
             strategy=req.strategy,

--- a/main.py
+++ b/main.py
@@ -165,7 +165,7 @@ def main():
             priors=priors,
             sample_gamma=args.sample_gamma,
             use_neighbor_lock=args.use_neighbor_lock,
-            fusion_alpha=None,
+            fusion_alpha=0.1,
             force_legacy=False,
             strategy=args.strategy,
         )


### PR DESCRIPTION
## Summary
- default `fusion_alpha` to `0.1` in prediction API
- forward new default through app and CLI
- update neighbor lock call and logging

## Testing
- `black --check main.py app.py analyzer.py brain.py modules.py tests`
- `isort --check main.py app.py analyzer.py brain.py modules.py tests`
- `flake8 main.py app.py analyzer.py brain.py modules.py tests`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7145a1ec83248247eed861669317