### PR TITLE
Apply new global/sample heatmap blending

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1352,9 +1352,16 @@ def predict_scratch_card(
             # B) 3×3 鄰居相似度
             neighbor_score = compute_neighbor_match_score(grid_np, matching)
 
-            # C) 混合權重
-            β = 0.8
+            # C) 混合權重（全局熱力 20%，樣本熱力 80%）
+            β = 0.2  # 全局熱力權重
             α = sample_gamma  # 從外部傳入，默認0.9
+
+            # 日誌：顯示當前混合權重
+            logger.info(
+                "混合權重：全局熱力 %.0f%%，樣本熱力 %.0f%%",
+                β * 100,
+                (1 - β) * 100,
+            )
 
             mixed_sample = α * probs + (1 - α) * neighbor_score
             global_layer = global_heat[:, :, target_num]

--- a/tests/test_pure_sample.py
+++ b/tests/test_pure_sample.py
@@ -53,7 +53,7 @@ def test_pure_sample_final_score_weighting(tmp_path):
     assert preds[0]["row"] == 1 and preds[0]["col"] == 1
     assert preds[1]["row"] == 0 and preds[1]["col"] == 1
     assert abs(preds[0]["score"] - 1.0) < 1e-6
-    assert abs(preds[1]["score"] - 0.2) < 1e-6
+    assert abs(preds[1]["score"] - 0.8) < 1e-6
 
 
 def test_neighbor_relaxed_matching(tmp_path):


### PR DESCRIPTION
## Summary
- adjust blend weight in analyzer's pure sample mode
- log mixing ratio
- update test for new default score

## Testing
- `black --check analyzer.py tests/test_pure_sample.py`
- `isort --check analyzer.py tests/test_pure_sample.py`
- `flake8 analyzer.py tests/test_pure_sample.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b891113488324b732c6192e14abba