### PR TITLE
Use precomputed global freq npz

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ To reduce build time when manually deploying to Render:
 
 Render will restore this cache before each build and save it afterwards, avoiding repeated downloads.
 
+## Global Frequency Files
+
+Precomputed position frequencies are stored in the `out_npz/` directory.
+Each file is named `global_pos_freq_{rows}x{cols}.npz` and contains a
+`freq` array with shape `(rows, cols, targets)` where the last axis
+corresponds to the target number. Place the files under `out_npz/` so
+the service can load them on demand and skip heavy archive parsing.
+
+You can inspect which board sizes are currently available via the
+`/debug/global_freqs` API endpoint.
+
 # Scratch-Card Prediction System
 
 This project provides a FastAPI service and CLI tool for predicting hidden numbers on scratch cards. The system uses modular heuristics and Monte-Carlo simulation to estimate probabilities.

--- a/analyzer.py
+++ b/analyzer.py
@@ -59,6 +59,36 @@ _SAMPLE_CACHE: Dict[Tuple[int, int, str], List[Tuple[np.ndarray, str]]] = {}
 # Minimum number of matching samples to activate pure-sample mode
 MIN_MATCHING = 0
 
+# Directory containing precomputed global position frequency files
+DEFAULT_NPZ_DIR = Path("out_npz")
+
+
+@lru_cache(maxsize=16)
+def load_global_pos_freq_npz(
+    shape: tuple[int, int], npz_dir: Path = DEFAULT_NPZ_DIR
+) -> np.ndarray:
+    """Load precomputed global position frequencies from ``npz_dir``.
+
+    Parameters
+    ----------
+    shape : tuple[int, int]
+        Board shape ``(rows, cols)``.
+    npz_dir : Path
+        Directory containing ``global_pos_freq_{rows}x{cols}.npz``.
+
+    Returns
+    -------
+    np.ndarray
+        Loaded frequency cube with shape ``(rows, cols, targets)``.
+    """
+    rows, cols = shape
+    path = npz_dir / f"global_pos_freq_{rows}x{cols}.npz"
+    try:
+        return np.load(path)["freq"]
+    except Exception as exc:
+        logger.error("failed to load %s: %s", path, exc)
+        raise FileNotFoundError(path) from exc
+
 
 def load_global_pos_freq(samples_dir: str) -> None:
     """Load global position frequency tensor from samples_dir if available."""
@@ -579,7 +609,11 @@ def compute_position_probabilities(
 
 @lru_cache(maxsize=8)
 def compute_global_distribution(samples_dir: str, rows: int, cols: int) -> np.ndarray:
-    """按現有邏輯計算 global pos heatmap"""
+    """Compute global position heatmap from raw sample ZIP files.
+
+    This heavy-weight routine is kept for offline generation of priors.
+    Runtime code should prefer :func:`load_global_pos_freq_npz`.
+    """
     cached = Path(samples_dir) / "prior.npy"
     if cached.exists():
         cube = np.load(cached, mmap_mode="r")
@@ -1356,9 +1390,7 @@ def predict_scratch_card(
 
     try:
         _ = probability_heatmap(
-            grid_np,
-            sample_gamma=sample_gamma,
-            history_dir=history_dir
+            grid_np, sample_gamma=sample_gamma, history_dir=history_dir
         )
     except Exception:
         pass
@@ -1368,7 +1400,11 @@ def predict_scratch_card(
         # 1) 全局盤面大小分布熱力
         global_heat = _get_global_pos_freq(history_dir)
         if global_heat is None:
-            global_heat = compute_global_distribution(history_dir, rows, cols)
+            try:
+                global_heat = load_global_pos_freq_npz((rows, cols))
+            except FileNotFoundError:
+                # fallback to on-the-fly computation for missing npz
+                global_heat = compute_global_distribution(history_dir, rows, cols)
         # 2) 樣本篩選
         samples = _load_samples_for_shape(history_dir, rows, cols)
         matching = filter_matching_samples(grid_np, samples)

--- a/app.py
+++ b/app.py
@@ -135,6 +135,17 @@ async def debug_number_distribution(
     return result
 
 
+@app.get("/debug/global_freqs", response_class=JSONResponse)
+async def debug_global_freqs() -> List[str]:
+    """Return board sizes with available global frequency files."""
+    shapes: set[str] = set()
+    for p in analyzer.DEFAULT_NPZ_DIR.glob("global_pos_freq_*x*.npz"):
+        m = re.search(r"_(\d+x\d+)\.npz$", p.name)
+        if m:
+            shapes.add(m.group(1))
+    return sorted(shapes)
+
+
 async def _load_samples_background():
     # 這裡會觸發 analyzer 裡的 logger.info("Total loaded: …")
     for _ in iter_sample_jsons("samples"):
@@ -144,7 +155,6 @@ async def _load_samples_background():
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    analyzer.load_global_pos_freq("samples")
     asyncio.create_task(warm_up())
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,6 +103,17 @@ def test_debug_number_distribution(client, monkeypatch):
     assert body["1"]["1,1"] == 2
 
 
+def test_debug_global_freqs(client, tmp_path, monkeypatch):
+    d = tmp_path / "npz"
+    d.mkdir()
+    arr = np.ones((2, 2, 5))
+    np.savez(d / "global_pos_freq_2x2.npz", freq=arr)
+    monkeypatch.setattr(analyzer, "DEFAULT_NPZ_DIR", d)
+    resp = client.get("/debug/global_freqs")
+    assert resp.status_code == 200
+    assert resp.json() == ["2x2"]
+
+
 def test_predict_1_based_top_left(client):
     grid = [[-1, 2], [3, 4]]
     payload = {"grid": grid, "target_num": 1, "iterations": 2}

--- a/tests/test_npz_fallback.py
+++ b/tests/test_npz_fallback.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+import analyzer
+
+
+def test_predict_fallback_to_compute(monkeypatch):
+    called = {"n": 0}
+
+    def fake_load(shape, npz_dir=analyzer.DEFAULT_NPZ_DIR):
+        raise FileNotFoundError
+
+    def fake_compute(samples_dir, rows, cols):
+        called["n"] += 1
+        return np.zeros((rows, cols, rows * cols + 1))
+
+    monkeypatch.setattr(analyzer, "load_global_pos_freq_npz", fake_load)
+    monkeypatch.setattr(analyzer, "compute_global_distribution", fake_compute)
+    monkeypatch.setattr(analyzer, "_load_samples_for_shape", lambda *_: [])
+
+    grid = [[-1, -1], [-1, -1]]
+    analyzer.predict_scratch_card(grid, target_num=1, use_neighbor_lock=False)
+    assert called["n"] == 1

--- a/tests/test_npz_loader.py
+++ b/tests/test_npz_loader.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+import analyzer
+
+
+def test_load_global_pos_freq_npz(tmp_path):
+    d = tmp_path / "out"
+    d.mkdir()
+    arr = np.ones((4, 5, 21))
+    np.savez(d / "global_pos_freq_4x5.npz", freq=arr)
+    loaded = analyzer.load_global_pos_freq_npz((4, 5), d)
+    assert np.array_equal(loaded, arr)
+
+
+def test_load_global_pos_freq_npz_missing(tmp_path):
+    d = tmp_path / "out"
+    d.mkdir()
+    with pytest.raises(FileNotFoundError):
+        analyzer.load_global_pos_freq_npz((2, 2), d)


### PR DESCRIPTION
## Summary
- load board heatmap from `out_npz` via new `load_global_pos_freq_npz`
- fallback to on-the-fly calculation if file missing
- drop unused loader call at startup
- document new `.npz` files
- test loader behaviour
- add `/debug/global_freqs` endpoint and related docs
- test fallback logic when npz missing

## Testing
- `black app.py tests/test_api.py tests/test_npz_fallback.py --check`
- `isort app.py tests/test_api.py tests/test_npz_fallback.py --check`
- `flake8 app.py tests/test_api.py tests/test_npz_fallback.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c40d22ac48324b1d1579131e8b547