### PR TITLE
Update sample loader to read NPZ boards

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -151,23 +151,31 @@ def _native_dict(d):
 
 
 def _load_samples_for_shape(
-    samples_dir: str, rows: int, cols: int
+    out_npz_dir: str, rows: int, cols: int
 ) -> List[Tuple[np.ndarray, str]]:
-    """Load all sample boards for the given shape along with file names."""
-    key = (rows, cols, samples_dir)
+    """Load sample boards for ``rows``×``cols`` from ``out_npz`` only."""
+
+    key = (rows, cols, out_npz_dir)
     if key in _SAMPLE_CACHE:
         return _SAMPLE_CACHE[key]
 
     boards: List[Tuple[np.ndarray, str]] = []
-    path = Path(samples_dir)
-    for zip_path in sorted(path.glob("*.zip")):
-        for item in _iter_json_from_zip(zip_path):
-            if item["rows"] == rows and item["cols"] == cols:
-                boards.append((np.asarray(item["grid"], dtype=int), zip_path.name))
+    p = Path(out_npz_dir)
+    for npz_path in sorted(p.glob("*.npz")):
+        try:
+            data = np.load(npz_path)
+        except Exception as exc:  # pragma: no cover - corrupted file
+            logger.error("failed to load %s: %s", npz_path, exc)
+            continue
+        if "boards" not in data:
+            continue
+        arr = data["boards"]
+        if arr.ndim == 3 and arr.shape[1:] == (rows, cols):
+            for i, grid in enumerate(arr):
+                boards.append((grid.astype(int), f"{npz_path.name}[{i}]"))
+
     _SAMPLE_CACHE[key] = boards
-    logger.info(
-        "Loaded %d sample boards for %dx%d", len(boards), rows, cols
-    )  # 中文：載入指定尺寸樣本數量
+    logger.info("Loaded %d sample boards for %dx%d", len(boards), rows, cols)
     return boards
 
 

--- a/tests/test_history_freq.py
+++ b/tests/test_history_freq.py
@@ -37,10 +37,17 @@ def test_compute_history_frequency_precomputed(tmp_path, monkeypatch):
 def test_predict_with_history(tmp_path):
     samples = tmp_path / "samples"
     samples.mkdir()
-    data = {"rows": 2, "cols": 2, "grid": [[2, 1], [3, 2]]}
-    zpath = samples / "s.zip"
-    with zipfile.ZipFile(zpath, "w") as zf:
-        zf.writestr("c.json", json.dumps(data))
+    arr = np.array([[[2, 1], [3, 2]]])
+    np.savez(samples / "s.npz", boards=arr)
+    counts = np.zeros((2, 2, 5), dtype=float)
+    for board in arr:
+        for r in range(2):
+            for c in range(2):
+                counts[r, c, board[r, c]] += 1
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts / totals
+    np.savez(samples / "pos_freq.npz", freq=freq)
 
     grid = [[-1, -1], [-1, -1]]
     result = analyzer.predict_scratch_card(

--- a/tests/test_prior_normalization.py
+++ b/tests/test_prior_normalization.py
@@ -1,7 +1,7 @@
-import json
 import logging
 import os
-import zipfile
+
+import numpy as np
 
 import analyzer
 
@@ -9,10 +9,17 @@ import analyzer
 def test_prior_mix_is_normalized(tmp_path):
     samples = tmp_path / "samples"
     samples.mkdir()
-    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
-    zpath = samples / "s.zip"
-    with zipfile.ZipFile(zpath, "w") as zf:
-        zf.writestr("a.json", json.dumps(data))
+    arr = np.array([[[1, 2], [3, 4]]])
+    np.savez(samples / "s.npz", boards=arr)
+    counts = np.zeros((2, 2, 5), dtype=float)
+    for board in arr:
+        for r in range(2):
+            for c in range(2):
+                counts[r, c, board[r, c]] += 1
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts / totals
+    np.savez(samples / "pos_freq.npz", freq=freq)
 
     logging.disable(logging.CRITICAL)
     os.environ["FAST_TEST"] = "1"

--- a/tests/test_pure_sample.py
+++ b/tests/test_pure_sample.py
@@ -1,5 +1,4 @@
-import json
-import zipfile
+import numpy as np
 
 import analyzer
 
@@ -8,11 +7,22 @@ def test_pure_sample_branch(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    b1 = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
-    b2 = {"rows": 2, "cols": 2, "grid": [[1, 3], [2, 4]]}
-    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
-        zf.writestr("a.json", json.dumps(b1))
-        zf.writestr("b.json", json.dumps(b2))
+    arr = np.array(
+        [
+            [[1, 2], [3, 4]],
+            [[1, 3], [2, 4]],
+        ]
+    )
+    np.savez(samples / "s.npz", boards=arr)
+    counts = np.zeros((2, 2, 5), dtype=float)
+    for board in arr:
+        for r in range(2):
+            for c in range(2):
+                counts[r, c, board[r, c]] += 1
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts / totals
+    np.savez(samples / "pos_freq.npz", freq=freq)
 
     grid = [[1, 2], [3, -1]]
     res = analyzer.predict_scratch_card(grid, target_num=4, history_dir=str(samples))
@@ -27,9 +37,17 @@ def test_pure_sample_neighbor_ranking(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    board = {"rows": 3, "cols": 3, "grid": [[1, 2, 2], [3, 4, 4], [5, 6, 7]]}
-    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
-        zf.writestr("b.json", json.dumps(board))
+    arr = np.array([[[1, 2, 2], [3, 4, 4], [5, 6, 7]]])
+    np.savez(samples / "s.npz", boards=arr)
+    counts = np.zeros((3, 3, 10), dtype=float)
+    for board in arr:
+        for r in range(3):
+            for c in range(3):
+                counts[r, c, board[r, c]] += 1
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts / totals
+    np.savez(samples / "pos_freq.npz", freq=freq)
 
     grid = [[1, -1, -1], [3, 4, -1], [5, 6, 7]]
     res = analyzer.predict_scratch_card(
@@ -44,9 +62,17 @@ def test_pure_sample_final_score_weighting(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    board = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
-    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
-        zf.writestr("b.json", json.dumps(board))
+    arr = np.array([[[1, 2], [3, 4]]])
+    np.savez(samples / "s.npz", boards=arr)
+    counts = np.zeros((2, 2, 5), dtype=float)
+    for board in arr:
+        for r in range(2):
+            for c in range(2):
+                counts[r, c, board[r, c]] += 1
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts / totals
+    np.savez(samples / "pos_freq.npz", freq=freq)
 
     grid = [[1, -1], [3, -1]]
     res = analyzer.predict_scratch_card(
@@ -63,9 +89,17 @@ def test_neighbor_relaxed_matching(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    board = {"rows": 3, "cols": 3, "grid": [[9, 2, 3], [4, 5, 6], [7, 8, 1]]}
-    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
-        zf.writestr("b.json", json.dumps(board))
+    arr = np.array([[[9, 2, 3], [4, 5, 6], [7, 8, 1]]])
+    np.savez(samples / "s.npz", boards=arr)
+    counts = np.zeros((3, 3, 10), dtype=float)
+    for board in arr:
+        for r in range(3):
+            for c in range(3):
+                counts[r, c, board[r, c]] += 1
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts / totals
+    np.savez(samples / "pos_freq.npz", freq=freq)
 
     grid = [[1, 2, -1], [4, 5, -1], [7, 8, -1]]
     res = analyzer.predict_scratch_card(grid, target_num=3, history_dir=str(samples))

--- a/tests/test_sample_prior.py
+++ b/tests/test_sample_prior.py
@@ -1,6 +1,8 @@
 import json
 import zipfile
 
+import numpy as np
+
 import analyzer
 
 
@@ -24,10 +26,17 @@ def test_compute_position_probabilities(tmp_path):
 def test_predict_with_sample_prior(tmp_path):
     samples = tmp_path / "samples"
     samples.mkdir()
-    data = {"rows": 2, "cols": 2, "grid": [[1, 2], [3, 4]]}
-    zpath = samples / "s.zip"
-    with zipfile.ZipFile(zpath, "w") as zf:
-        zf.writestr("c.json", json.dumps(data))
+    arr = np.array([[[1, 2], [3, 4]]])
+    np.savez(samples / "s.npz", boards=arr)
+    counts = np.zeros((2, 2, 5), dtype=float)
+    for board in arr:
+        for r in range(2):
+            for c in range(2):
+                counts[r, c, board[r, c]] += 1
+    totals = counts.sum(axis=2, keepdims=True)
+    totals[totals == 0] = 1
+    freq = counts / totals
+    np.savez(samples / "pos_freq.npz", freq=freq)
 
     grid = [[-1, 2], [3, 4]]
     res = analyzer.predict_scratch_card(


### PR DESCRIPTION
## Summary
- simplify `_load_samples_for_shape` to only load `boards` from `.npz`
- adjust unit tests to supply NPZ sample data with frequency tensors

## Testing
- `black --check analyzer.py tests/test_history_freq.py tests/test_prior_normalization.py tests/test_pure_sample.py tests/test_sample_prior.py`
- `isort --check-only analyzer.py tests/test_history_freq.py tests/test_prior_normalization.py tests/test_pure_sample.py tests/test_sample_prior.py`
- `flake8 analyzer.py tests/test_history_freq.py tests/test_prior_normalization.py tests/test_pure_sample.py tests/test_sample_prior.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cafdd088c8324b888a67b9fd11d5a