### PR TITLE
Add NPZ usage statistics

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -8,8 +8,9 @@ import os
 import sys
 import re
 import zipfile
-from collections import defaultdict
+from collections import defaultdict, Counter
 from functools import lru_cache
+import atexit
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -66,25 +67,29 @@ MIN_MATCHING = 0
 # Directory containing precomputed global position frequency files
 DEFAULT_NPZ_DIR = Path("out_npz")
 
+# Track how many times each heatmap NPZ is loaded
+_NPZ_USAGE_STATS: Counter = Counter()
+
+
+@atexit.register
+def print_npz_usage_stats() -> None:
+    """Print usage statistics for loaded heatmap NPZ files."""
+
+    if not _NPZ_USAGE_STATS:
+        print("WARNING: no heatmap .npz files loaded")
+        return
+
+    print("\nHeatmap .npz usage stats:")
+    for shape, count in sorted(_NPZ_USAGE_STATS.items()):
+        print(f"  {shape} -> {count}")
+
 
 @lru_cache(maxsize=16)
-def load_global_pos_freq_npz(
+def _load_global_pos_freq_npz_cached(
     shape: tuple[int, int], npz_dir: Path = DEFAULT_NPZ_DIR
 ) -> np.ndarray:
-    """Load precomputed global position frequencies from ``npz_dir``.
+    """Internal cached loader for global position frequencies."""
 
-    Parameters
-    ----------
-    shape : tuple[int, int]
-        Board shape ``(rows, cols)``.
-    npz_dir : Path
-        Directory containing ``global_pos_freq_{rows}x{cols}.npz``.
-
-    Returns
-    -------
-    np.ndarray
-        Loaded frequency cube with shape ``(rows, cols, targets)``.
-    """
     rows, cols = shape
     path = npz_dir / f"global_pos_freq_{rows}x{cols}.npz"
     try:
@@ -92,6 +97,16 @@ def load_global_pos_freq_npz(
     except Exception as exc:
         logger.error("failed to load %s: %s", path, exc)
         raise FileNotFoundError(path) from exc
+
+
+def load_global_pos_freq_npz(
+    shape: tuple[int, int], npz_dir: Path = DEFAULT_NPZ_DIR
+) -> np.ndarray:
+    """Load precomputed global position frequencies and track usage."""
+
+    rows, cols = shape
+    _NPZ_USAGE_STATS[f"{rows}x{cols}"] += 1
+    return _load_global_pos_freq_npz_cached(shape, npz_dir)
 
 
 def load_global_pos_freq(samples_dir: str) -> None:

--- a/tests/test_npz_loader.py
+++ b/tests/test_npz_loader.py
@@ -18,3 +18,22 @@ def test_load_global_pos_freq_npz_missing(tmp_path):
     d.mkdir()
     with pytest.raises(FileNotFoundError):
         analyzer.load_global_pos_freq_npz((2, 2), d)
+
+
+def test_npz_usage_stats(tmp_path):
+    d = tmp_path / "out"
+    d.mkdir()
+    arr_a = np.ones((2, 2, 5))
+    arr_b = np.ones((3, 3, 10))
+    np.savez(d / "global_pos_freq_2x2.npz", freq=arr_a)
+    np.savez(d / "global_pos_freq_3x3.npz", freq=arr_b)
+
+    analyzer._NPZ_USAGE_STATS.clear()
+    analyzer._load_global_pos_freq_npz_cached.cache_clear()
+
+    analyzer.load_global_pos_freq_npz((2, 2), d)
+    analyzer.load_global_pos_freq_npz((3, 3), d)
+    analyzer.load_global_pos_freq_npz((2, 2), d)
+
+    assert analyzer._NPZ_USAGE_STATS["2x2"] == 2
+    assert analyzer._NPZ_USAGE_STATS["3x3"] == 1


### PR DESCRIPTION
## Summary
- track global heatmap `.npz` usage in `analyzer.py`
- print usage stats at exit
- test tracking logic in `tests/test_npz_loader.py`

## Testing
- `black analyzer.py tests/test_npz_loader.py --check`
- `isort --check-only analyzer.py tests/test_npz_loader.py`
- `flake8 analyzer.py tests/test_npz_loader.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd83bc8a083249f208f3161e039eb