### PR TITLE
Update heatmap loading logic

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -52,9 +52,6 @@ _PRIOR_CACHE: Dict[tuple[int, int], np.ndarray] = {}
 analyzer_utils = BoardAnalyzerUtils()
 
 # Global position prior cache
-# Cache per-samples_dir frequency maps
-_POS_FREQ_CACHE: Dict[str, np.ndarray] = {}
-
 # Global heatmap cache keyed by (rows, cols)
 _GLOBAL_POS_FREQ_CACHE: Dict[tuple[int, int], np.ndarray] = {}
 
@@ -109,46 +106,23 @@ def load_global_pos_freq_npz(
     return _load_global_pos_freq_npz_cached(shape, npz_dir)
 
 
-def load_global_pos_freq(samples_dir: str) -> None:
-    """若 ``samples_dir`` 內已有計算結果，直接載入全域位置頻率。"""
-    path = Path(samples_dir) / "pos_freq.npz"
-    try:
-        if path.exists():
-            arr = np.load(path)["freq"]
-            _POS_FREQ_CACHE[str(path)] = arr.astype(float)
-            logger.info("Loaded global position freq from %s", path)
-    except Exception as exc:  # pragma: no cover - corrupted file
-        logger.error("failed to load %s: %s", path, exc)
-
-
-def _get_global_pos_freq(samples_dir: str) -> Optional[np.ndarray]:
-    path = Path(samples_dir) / "pos_freq.npz"
-    # 已存在时读取，没有再计算
-    if path.exists() and str(path) not in _POS_FREQ_CACHE:
-        load_global_pos_freq(samples_dir)
-    return _POS_FREQ_CACHE.get(str(path))
-
-
 def load_all_global_pos_freqs(npz_dir: str) -> None:
-    """Scan ``npz_dir`` and cache all ``global_pos_freq_*x*.npz`` files."""
-    pattern = re.compile(r"global_pos_freq.*?_(\d+)x(\d+)\.npz$")
-    p = Path(npz_dir)
-    for npz in p.glob("*.npz"):
-        m = pattern.match(npz.name)
+    """Scan ``npz_dir`` and cache all ``*x*.npz`` heatmap files."""
+    pattern = re.compile(r"(\d+)x(\d+)\.npz$")
+    for npz_file in Path(npz_dir).glob("*.npz"):
+        m = pattern.search(npz_file.name)
         if not m:
-            logger.warning("檔名不符合預期格式，跳過：%s", npz.name)
             continue
         rows, cols = map(int, m.groups())
         try:
-            data = np.load(npz)
+            data = np.load(npz_file)
             freq = data.get("freq")
             if freq is None:
-                logger.error("在 %s 找不到 key 'freq'，跳過", npz.name)
                 continue
             _GLOBAL_POS_FREQ_CACHE[(rows, cols)] = freq.astype(float)
-            logger.info("載入 priors for %dx%d from %s", rows, cols, npz.name)
+            logger.info("loaded %dx%d heatmap from %s", rows, cols, npz_file.name)
         except Exception as e:  # pragma: no cover - corrupted file
-            logger.error("載入 %s 失敗：%s", npz.name, e)
+            logger.warning("Failed to load %s: %s", npz_file.name, e)
 
 
 def get_global_pos_freq(shape: tuple[int, int]) -> Optional[np.ndarray]:
@@ -166,28 +140,25 @@ def _native_dict(d):
 
 
 def _load_samples_for_shape(
-    out_npz_dir: str, rows: int, cols: int
+    samples_dir: str, rows: int, cols: int
 ) -> List[Tuple[np.ndarray, str]]:
-    """Load sample boards for ``rows``×``cols`` from ``out_npz`` only."""
+    """Load sample boards for ``rows``×``cols`` from JSON zip samples."""
 
-    key = (rows, cols, out_npz_dir)
+    key = (rows, cols, samples_dir)
     if key in _SAMPLE_CACHE:
         return _SAMPLE_CACHE[key]
 
     boards: List[Tuple[np.ndarray, str]] = []
-    p = Path(out_npz_dir)
-    for npz_path in sorted(p.glob("*.npz")):
-        try:
-            data = np.load(npz_path)
-        except Exception as exc:  # pragma: no cover - corrupted file
-            logger.error("failed to load %s: %s", npz_path, exc)
-            continue
-        if "boards" not in data:
-            continue
-        arr = data["boards"]
-        if arr.ndim == 3 and arr.shape[1:] == (rows, cols):
-            for i, grid in enumerate(arr):
-                boards.append((grid.astype(int), f"{npz_path.name}[{i}]"))
+    path = Path(samples_dir)
+    for zip_path in sorted(path.glob("*.zip")):
+        idx = 0
+        for item in _iter_json_from_zip(zip_path):
+            if item["rows"] != rows or item["cols"] != cols:
+                idx += 1
+                continue
+            grid = np.asarray(item["grid"], dtype=int)
+            boards.append((grid, f"{zip_path.name}[{idx}]"))
+            idx += 1
 
     _SAMPLE_CACHE[key] = boards
     logger.info("Loaded %d sample boards for %dx%d", len(boards), rows, cols)
@@ -591,7 +562,13 @@ def compute_position_probabilities(
     samples_dir: str, rows: int, cols: int
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
     """Return per-cell number probabilities from history samples."""
-    global_freq = _get_global_pos_freq(samples_dir)
+    global_freq = get_global_pos_freq((rows, cols))
+    if global_freq is None:
+        try:
+            global_freq = load_global_pos_freq_npz((rows, cols))
+        except FileNotFoundError:
+            global_freq = None
+
     if global_freq is not None:
         buckets = global_freq.shape[1]
         prob_map: Dict[Tuple[int, int], Dict[int, float]] = {}
@@ -1452,9 +1429,7 @@ def predict_scratch_card(
     blanks = [tuple(b) for b in np.argwhere(grid_np == BLANK_VAL)]
     if target_num is not None:
         # 1) 全局盤面大小分布熱力
-        global_heat = _get_global_pos_freq(history_dir)
-        if global_heat is None:
-            global_heat = get_global_pos_freq((rows, cols))
+        global_heat = get_global_pos_freq((rows, cols))
         if global_heat is None:
             try:
                 global_heat = load_global_pos_freq_npz((rows, cols))

--- a/tests/test_global_pos_prior.py
+++ b/tests/test_global_pos_prior.py
@@ -12,10 +12,13 @@ def test_global_position_prior(tmp_path):
     with zipfile.ZipFile(samples / "s.zip", "w") as zf:
         zf.writestr("a.json", json.dumps(data))
 
-    out = samples / "pos_freq.npz"
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir()
+    out = out_npz / "global_pos_freq_2x2.npz"
     build_position_prior(str(samples), str(out), buckets=2)
 
-    analyzer.load_global_pos_freq(str(samples))
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
     probs = analyzer.compute_position_probabilities(str(samples), 2, 2)
     assert probs[(0, 0)][1] == 1.0
     assert probs[(0, 1)][2] == 1.0

--- a/tests/test_history_freq.py
+++ b/tests/test_history_freq.py
@@ -37,17 +37,22 @@ def test_compute_history_frequency_precomputed(tmp_path, monkeypatch):
 def test_predict_with_history(tmp_path):
     samples = tmp_path / "samples"
     samples.mkdir()
-    arr = np.array([[[2, 1], [3, 2]]])
-    np.savez(samples / "s.npz", boards=arr)
+    arr = [[[2, 1], [3, 2]]]
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps({"rows": 2, "cols": 2, "grid": arr[0]}))
     counts = np.zeros((2, 2, 5), dtype=float)
     for board in arr:
         for r in range(2):
             for c in range(2):
-                counts[r, c, board[r, c]] += 1
+                counts[r, c, board[r][c]] += 1
     totals = counts.sum(axis=2, keepdims=True)
     totals[totals == 0] = 1
     freq = counts / totals
-    np.savez(samples / "pos_freq.npz", freq=freq)
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir()
+    np.savez(out_npz / "global_pos_freq_2x2.npz", freq=freq)
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
 
     grid = [[-1, -1], [-1, -1]]
     result = analyzer.predict_scratch_card(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,8 @@ import json
 import logging
 import zipfile
 
+import numpy as np
+
 import analyzer
 
 
@@ -17,7 +19,14 @@ def test_iter_sample_jsons_logging(tmp_path, caplog):
     assert any("已載入 a.zip" in r.message for r in caplog.records)
 
 
-def test_top3_logging(caplog):
+def test_top3_logging(tmp_path, caplog):
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir()
+    freq = np.ones((2, 2, 5))
+    np.savez(out_npz / "global_pos_freq_2x2.npz", freq=freq)
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
+
     grid = [[-1, -1], [-1, -1]]
     with caplog.at_level(logging.INFO):
         result = analyzer.predict_scratch_card(

--- a/tests/test_pure_sample.py
+++ b/tests/test_pure_sample.py
@@ -1,3 +1,6 @@
+import json
+import zipfile
+
 import numpy as np
 
 import analyzer
@@ -7,22 +10,26 @@ def test_pure_sample_branch(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    arr = np.array(
-        [
-            [[1, 2], [3, 4]],
-            [[1, 3], [2, 4]],
-        ]
-    )
-    np.savez(samples / "s.npz", boards=arr)
+    boards = [
+        [[1, 2], [3, 4]],
+        [[1, 3], [2, 4]],
+    ]
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        for i, b in enumerate(boards):
+            zf.writestr(f"b{i}.json", json.dumps({"rows": 2, "cols": 2, "grid": b}))
     counts = np.zeros((2, 2, 5), dtype=float)
-    for board in arr:
+    for board in boards:
         for r in range(2):
             for c in range(2):
-                counts[r, c, board[r, c]] += 1
+                counts[r, c, board[r][c]] += 1
     totals = counts.sum(axis=2, keepdims=True)
     totals[totals == 0] = 1
     freq = counts / totals
-    np.savez(samples / "pos_freq.npz", freq=freq)
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir()
+    np.savez(out_npz / "global_pos_freq_2x2.npz", freq=freq)
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
 
     grid = [[1, 2], [3, -1]]
     res = analyzer.predict_scratch_card(grid, target_num=4, history_dir=str(samples))
@@ -37,17 +44,22 @@ def test_pure_sample_neighbor_ranking(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    arr = np.array([[[1, 2, 2], [3, 4, 4], [5, 6, 7]]])
-    np.savez(samples / "s.npz", boards=arr)
+    arr = [[[1, 2, 2], [3, 4, 4], [5, 6, 7]]]
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("b.json", json.dumps({"rows": 3, "cols": 3, "grid": arr[0]}))
     counts = np.zeros((3, 3, 10), dtype=float)
     for board in arr:
         for r in range(3):
             for c in range(3):
-                counts[r, c, board[r, c]] += 1
+                counts[r, c, board[r][c]] += 1
     totals = counts.sum(axis=2, keepdims=True)
     totals[totals == 0] = 1
     freq = counts / totals
-    np.savez(samples / "pos_freq.npz", freq=freq)
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir(exist_ok=True)
+    np.savez(out_npz / "global_pos_freq_3x3.npz", freq=freq)
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
 
     grid = [[1, -1, -1], [3, 4, -1], [5, 6, 7]]
     res = analyzer.predict_scratch_card(
@@ -62,17 +74,22 @@ def test_pure_sample_final_score_weighting(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    arr = np.array([[[1, 2], [3, 4]]])
-    np.savez(samples / "s.npz", boards=arr)
+    arr = [[[1, 2], [3, 4]]]
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("b.json", json.dumps({"rows": 2, "cols": 2, "grid": arr[0]}))
     counts = np.zeros((2, 2, 5), dtype=float)
     for board in arr:
         for r in range(2):
             for c in range(2):
-                counts[r, c, board[r, c]] += 1
+                counts[r, c, board[r][c]] += 1
     totals = counts.sum(axis=2, keepdims=True)
     totals[totals == 0] = 1
     freq = counts / totals
-    np.savez(samples / "pos_freq.npz", freq=freq)
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir(exist_ok=True)
+    np.savez(out_npz / "global_pos_freq_2x2.npz", freq=freq)
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
 
     grid = [[1, -1], [3, -1]]
     res = analyzer.predict_scratch_card(
@@ -89,17 +106,22 @@ def test_neighbor_relaxed_matching(tmp_path):
     analyzer._GLOBAL_POS_FREQ_CACHE.clear()
     samples = tmp_path / "samples"
     samples.mkdir()
-    arr = np.array([[[9, 2, 3], [4, 5, 6], [7, 8, 1]]])
-    np.savez(samples / "s.npz", boards=arr)
+    arr = [[[9, 2, 3], [4, 5, 6], [7, 8, 1]]]
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("b.json", json.dumps({"rows": 3, "cols": 3, "grid": arr[0]}))
     counts = np.zeros((3, 3, 10), dtype=float)
     for board in arr:
         for r in range(3):
             for c in range(3):
-                counts[r, c, board[r, c]] += 1
+                counts[r, c, board[r][c]] += 1
     totals = counts.sum(axis=2, keepdims=True)
     totals[totals == 0] = 1
     freq = counts / totals
-    np.savez(samples / "pos_freq.npz", freq=freq)
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir(exist_ok=True)
+    np.savez(out_npz / "global_pos_freq_3x3.npz", freq=freq)
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
 
     grid = [[1, 2, -1], [4, 5, -1], [7, 8, -1]]
     res = analyzer.predict_scratch_card(grid, target_num=3, history_dir=str(samples))

--- a/tests/test_sample_prior.py
+++ b/tests/test_sample_prior.py
@@ -26,17 +26,22 @@ def test_compute_position_probabilities(tmp_path):
 def test_predict_with_sample_prior(tmp_path):
     samples = tmp_path / "samples"
     samples.mkdir()
-    arr = np.array([[[1, 2], [3, 4]]])
-    np.savez(samples / "s.npz", boards=arr)
+    arr = [[[1, 2], [3, 4]]]
+    with zipfile.ZipFile(samples / "s.zip", "w") as zf:
+        zf.writestr("a.json", json.dumps({"rows": 2, "cols": 2, "grid": arr[0]}))
     counts = np.zeros((2, 2, 5), dtype=float)
     for board in arr:
         for r in range(2):
             for c in range(2):
-                counts[r, c, board[r, c]] += 1
+                counts[r, c, board[r][c]] += 1
     totals = counts.sum(axis=2, keepdims=True)
     totals[totals == 0] = 1
     freq = counts / totals
-    np.savez(samples / "pos_freq.npz", freq=freq)
+    out_npz = tmp_path / "out_npz"
+    out_npz.mkdir()
+    np.savez(out_npz / "global_pos_freq_2x2.npz", freq=freq)
+    analyzer._GLOBAL_POS_FREQ_CACHE.clear()
+    analyzer.load_all_global_pos_freqs(str(out_npz))
 
     grid = [[-1, 2], [3, 4]]
     res = analyzer.predict_scratch_card(


### PR DESCRIPTION
## Summary
- load heatmaps only from `out_npz` directory and cache them on startup
- remove legacy `pos_freq.npz` handling
- support loading sample boards from zipped JSON files
- update associated tests for new behavior

## Testing
- `isort analyzer.py tests/test_global_pos_prior.py tests/test_history_freq.py tests/test_pure_sample.py tests/test_sample_prior.py tests/test_logging.py`
- `black --check analyzer.py tests/test_logging.py tests/test_history_freq.py tests/test_pure_sample.py tests/test_sample_prior.py tests/test_global_pos_prior.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d309047c0832487553a5805ef754a