### PR TITLE
Implement Strategy enum for API

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 import numpy as np
 from joblib import Parallel, delayed
 from numba import njit
+from strategy_types import Strategy
 
 import brain
 
@@ -1494,7 +1495,7 @@ def predict_scratch_card(
     pseudo_count: float = 0.0,
     force_legacy: bool = False,
     exclude_filled: bool = True,
-    strategy: str = "legacy",
+    strategy: Union[str, Strategy] = Strategy.LEGACY,
     use_neighbor_lock: bool = False,
     neighbor_threshold: float = 0.0,
 ) -> Dict[str, Any]:
@@ -1504,6 +1505,7 @@ def predict_scratch_card(
     grid_np = np.asarray(grid, dtype=object)
     grid_np = np.where(grid_np == BLANK_VAL, BLANK_VAL, grid_np).astype(np.int64)
     rows, cols = grid_np.shape
+    strat_name = strategy.value if isinstance(strategy, Strategy) else str(strategy)
 
     try:
         _ = probability_heatmap(
@@ -1661,7 +1663,7 @@ def predict_scratch_card(
     if not blanks:
         return {
             "mode": "no_blanks",
-            "strategy": "predict_structured",
+            "strategy": strat_name,
             "predictions": [],
             "top_predictions": [],
             "full_probabilities": {},
@@ -1758,7 +1760,7 @@ def predict_scratch_card(
 
     return {
         "mode": "neighbor",
-        "strategy": "predict_structured",
+        "strategy": strat_name,
         "predictions": preds,
         "top_predictions": preds,
         "full_probabilities": {},

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from analyzer import (compute_position_probabilities,
                       fuse_predictions_with_heatmap, fuse_score_matrices,
                       iter_sample_jsons, predict_scratch_card,
                       probability_heatmap, render_heatmap)
+from strategy_types import Strategy
 
 # fmt: on
 brain.priors_map: Dict[str, Dict[int, float]] = {}
@@ -180,7 +181,7 @@ class GridRequest(BaseModel):
     fusion_alpha: Optional[float] = None
     pseudo_count: Optional[float] = None
     exclude_filled: bool = True
-    strategy: Literal["legacy", "modern"] = "legacy"
+    strategy: Strategy = Strategy.LEGACY
 
 
 class Prediction(BaseModel):
@@ -381,7 +382,7 @@ async def predict(req: GridRequest):
         is_blank = (grid_np == -1) | (grid_np == 0) | (grid_np == "")
         grid_norm = np.where(is_blank, -1, grid_np).astype(int).tolist()
         force_legacy = False
-        if "strategy" in req.model_fields_set and req.strategy == "legacy":
+        if "strategy" in req.model_fields_set and req.strategy == Strategy.LEGACY:
             force_legacy = True
         if (
             "fusion_alpha" in req.model_fields_set

--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ from typing import Dict, List
 import numpy as np
 import ray
 
+from strategy_types import Strategy
+
 # fmt: off
 # isort: off
 import analyzer
@@ -104,8 +106,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--strategy",
         type=str,
-        choices=["legacy", "modern"],
-        default="legacy",
+        choices=[s.value for s in Strategy],
+        default=Strategy.LEGACY.value,
         help="Prediction ranking strategy",
     )
     return parser.parse_args()
@@ -131,6 +133,7 @@ def parse_grid(grid_str: str) -> List[List[int]]:
 def main():
     """Main function to run scratch card prediction."""
     args = parse_args()
+    args.strategy = Strategy(args.strategy)
     try:
         p = Path("output/cleaned_data.json")
         global priors

--- a/strategy_types.py
+++ b/strategy_types.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class Strategy(Enum):
+    """Available prediction strategies."""
+
+    LEGACY = "legacy"
+    MODERN = "modern"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import analyzer
 from analyzer import simulate_full_board
+from strategy_types import Strategy
 
 
 def test_simulate_dimensions(make_grid):
@@ -137,3 +138,10 @@ def test_apply_uniqueness_penalty():
     assert out[(0, 0)][1] < pm[(0, 0)][1]
     assert out[(0, 0)][2] < pm[(0, 0)][2]
     assert out[(0, 1)][1] == pm[(0, 1)][1]
+
+
+def test_predict_accepts_enum_strategy():
+    grid = [[-1, -1], [-1, -1]]
+    res_enum = analyzer.predict_scratch_card(grid, strategy=Strategy.MODERN)
+    res_str = analyzer.predict_scratch_card(grid, strategy="modern")
+    assert res_enum["strategy"] == res_str["strategy"]


### PR DESCRIPTION
## Summary
- support `Strategy` enum for /predict requests
- adjust analyzers to accept enum values
- test enum handling

## Testing
- `black --check main.py app.py analyzer.py brain.py modules.py strategy_types.py tests/test_analyzer.py`
- `isort --check main.py app.py analyzer.py brain.py modules.py strategy_types.py tests/test_analyzer.py`
- `flake8 main.py app.py analyzer.py brain.py modules.py strategy_types.py tests/test_analyzer.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd1c11fa88324bf536990ba646325