### PR TITLE
Add dataclasses for configs and robust core module selection

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -14,6 +14,8 @@ import atexit
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
+from env_config import EnvConfig
+
 import numpy as np
 from joblib import Parallel, delayed
 from numba import njit
@@ -33,6 +35,8 @@ from brain import (
 # isort: on
 from modules import FORMULA_REGISTRY, generate_unique_grid
 from weights import AGG_WEIGHTS
+
+env = EnvConfig()
 
 # 额外引入全局分布计算
 from neighbor_stats import compute_neighbor_distribution, neighbor_compatibility_score
@@ -1543,7 +1547,7 @@ def predict_scratch_card(
             known_ratio <= KNOWN_RATIO_THRESHOLD
             and len(matching) < SAMPLE_FALLBACK_THRESHOLD
         ):
-            top_k = result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
+            top_k = result_top_k or env.result_top_k
             return heatmap_fallback_prediction(
                 grid_np,
                 int(target_num),
@@ -1678,7 +1682,7 @@ def predict_scratch_card(
             sample_gamma=sample_gamma,
             history_dir=history_dir,
         )
-        top_k = result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
+        top_k = result_top_k or env.result_top_k
         ranked = sorted([(float(heat[r, c]), r, c) for r, c in blanks], reverse=True)[
             :top_k
         ]
@@ -1746,7 +1750,7 @@ def predict_scratch_card(
         for (r, c), p in csp_probs.items():
             final_score_map[r, c] += (1 - alpha) * p
 
-    top_k = result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
+    top_k = result_top_k or env.result_top_k
     rings = BoardAnalyzerUtils.ring_index(*grid_np.shape)
     ranked_all = sorted(
         blanks,

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from analyzer import (compute_position_probabilities,
                       fuse_predictions_with_heatmap, fuse_score_matrices,
                       iter_sample_jsons, predict_scratch_card,
                       probability_heatmap, render_heatmap)
+from env_config import EnvConfig
 from strategy_types import Strategy
 
 # fmt: on
@@ -247,10 +248,7 @@ os.environ.setdefault("PHASE2_TOP_N", "10")
 os.environ.setdefault("PHASE2_EPSILON", "0.05")
 os.environ.setdefault("LOG_LEVEL", "INFO")
 
-PHASE1_ITER = int(os.getenv("PHASE1_ITERATIONS"))
-PHASE2_ITER = int(os.getenv("PHASE2_ITERATIONS"))
-PHASE2_TOP_N = int(os.getenv("PHASE2_TOP_N"))
-PHASE2_EPS = float(os.getenv("PHASE2_EPSILON"))
+env = EnvConfig()
 
 
 # ==== Helpers: sanitize floats ===============================================
@@ -358,11 +356,11 @@ async def predict(req: GridRequest):
             brain.priors_map[key] = priors
 
         # 参数
-        phase1 = req.iterations or PHASE1_ITER
-        phase2 = req.focus_iter or PHASE2_ITER
-        top_n = req.top_n or PHASE2_TOP_N
-        eps = req.epsilon or PHASE2_EPS
-        top_k = req.result_top_k or int(os.getenv("RESULT_TOP_K", "3"))
+        phase1 = req.iterations or env.phase1_iter
+        phase2 = req.focus_iter or env.phase2_iter
+        top_n = req.top_n or env.phase2_top_n
+        eps = req.epsilon or env.phase2_epsilon
+        top_k = req.result_top_k or env.result_top_k
 
         logger.info(
             "Predict | size=%dx%d | target=%s | ph1=%d | ph2=%d | top_k=%d | top_n=%d | eps=%.3f",
@@ -493,11 +491,11 @@ async def heatmap(req: HeatmapRequest):
         pred_result = predict_scratch_card(
             grid=grid_norm,
             target_num=req.target_num,
-            iterations=PHASE1_ITER,
+            iterations=env.phase1_iter,
             global_iter=None,
-            focus_iter=PHASE2_ITER,
-            top_n=PHASE2_TOP_N,
-            epsilon=PHASE2_EPS,
+            focus_iter=env.phase2_iter,
+            top_n=env.phase2_top_n,
+            epsilon=env.phase2_epsilon,
             result_top_k=3,
             priors=priors,
             sample_gamma=req.sample_gamma,

--- a/brain.py
+++ b/brain.py
@@ -154,6 +154,12 @@ AGG_WEIGHTS = _load_weights()
 
 
 def get_core_modules(limit: Optional[int] = None) -> List[str]:
+    """Return top modules sorted by weight.
+
+    The ``limit`` parameter or ``CORE_LIMIT`` environment variable controls how
+    many modules are returned. Invalid values fall back to defaults.
+    """
+
     limit_env_str = os.getenv("CORE_LIMIT", "6")
     try:
         limit_env = int(limit_env_str)
@@ -161,11 +167,22 @@ def get_core_modules(limit: Optional[int] = None) -> List[str]:
         logger.warning("Invalid CORE_LIMIT '%s', using default 6", limit_env_str)
         limit_env = 6
     if limit is None:
-        limit = limit_env
+        limit_final = limit_env
+    else:
+        try:
+            limit_final = int(limit)
+        except (TypeError, ValueError):
+            logger.warning("Invalid limit '%s', using CORE_LIMIT", limit)
+            limit_final = limit_env
+
+    if limit_final < 1:
+        logger.warning("Limit must be >=1, using 1")
+        limit_final = 1
+
     names = list(REGISTERED_MODULES_BRAIN)
-    limit = max(1, min(len(names), limit))
+    limit_final = min(len(names), limit_final)
     sorted_mods = sorted(AGG_WEIGHTS.items(), key=lambda kv: kv[1], reverse=True)
-    return [m for m, _ in sorted_mods[:limit]]
+    return [m for m, _ in sorted_mods[:limit_final]]
 
 
 def get_module_score(

--- a/env_config.py
+++ b/env_config.py
@@ -1,0 +1,24 @@
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class EnvConfig:
+    """Centralized environment configuration."""
+
+    phase1_iter: int = field(
+        default_factory=lambda: int(os.getenv("PHASE1_ITERATIONS", "5000"))
+    )
+    phase2_iter: int = field(
+        default_factory=lambda: int(os.getenv("PHASE2_ITERATIONS", "1000"))
+    )
+    phase2_top_n: int = field(
+        default_factory=lambda: int(os.getenv("PHASE2_TOP_N", "10"))
+    )
+    phase2_epsilon: float = field(
+        default_factory=lambda: float(os.getenv("PHASE2_EPSILON", "0.05"))
+    )
+    result_top_k: int = field(
+        default_factory=lambda: int(os.getenv("RESULT_TOP_K", "3"))
+    )
+    log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))

--- a/main.py
+++ b/main.py
@@ -3,8 +3,9 @@ import json
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import ray
@@ -32,7 +33,27 @@ logging.basicConfig(
 priors: Dict[int, float] = {}
 
 
-def parse_args() -> argparse.Namespace:
+@dataclass
+class CLIConfig:
+    """Command-line configuration."""
+
+    grid: str
+    iterations: int
+    global_iter: Optional[int]
+    focus_iter: Optional[int]
+    top_n: int
+    top_k: Optional[int]
+    epsilon: float
+    target: Optional[int]
+    heatmap_k: Optional[int]
+    heatmap_iter: int
+    heatmap_format: str
+    sample_gamma: float
+    use_neighbor_lock: bool
+    strategy: Strategy
+
+
+def parse_args(argv: Optional[List[str]] = None) -> CLIConfig:
     """Parse command-line arguments for grid input and iterations."""
     parser = argparse.ArgumentParser(
         description="Predict hidden numbers in a scratch card grid."
@@ -110,7 +131,23 @@ def parse_args() -> argparse.Namespace:
         default=Strategy.LEGACY.value,
         help="Prediction ranking strategy",
     )
-    return parser.parse_args()
+    ns = parser.parse_args(argv)
+    return CLIConfig(
+        grid=ns.grid,
+        iterations=ns.iterations,
+        global_iter=ns.global_iter,
+        focus_iter=ns.focus_iter,
+        top_n=ns.top_n,
+        top_k=ns.top_k,
+        epsilon=ns.epsilon,
+        target=ns.target,
+        heatmap_k=ns.heatmap_k,
+        heatmap_iter=ns.heatmap_iter,
+        heatmap_format=ns.heatmap_format,
+        sample_gamma=ns.sample_gamma,
+        use_neighbor_lock=ns.use_neighbor_lock,
+        strategy=Strategy(ns.strategy),
+    )
 
 
 def parse_grid(grid_str: str) -> List[List[int]]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+import os
+
+import brain
+from env_config import EnvConfig
+from main import CLIConfig, parse_args
+
+
+def test_cli_parse_returns_dataclass():
+    cfg = parse_args(["--grid", "1,-1;2,3", "--iterations", "4", "--target", "3"])
+    assert isinstance(cfg, CLIConfig)
+    assert cfg.grid == "1,-1;2,3"
+    assert cfg.iterations == 4
+    assert cfg.target == 3
+
+
+def test_env_config(monkeypatch):
+    monkeypatch.setenv("PHASE1_ITERATIONS", "111")
+    monkeypatch.setenv("PHASE2_ITERATIONS", "222")
+    cfg = EnvConfig()
+    assert cfg.phase1_iter == 111
+    assert cfg.phase2_iter == 222

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,4 @@
-import os
 
-import brain
 from env_config import EnvConfig
 from main import CLIConfig, parse_args
 

--- a/tests/test_core_modules.py
+++ b/tests/test_core_modules.py
@@ -27,3 +27,24 @@ def test_get_core_modules_invalid_env_default(monkeypatch):
     mods = brain.get_core_modules()
     assert len(mods) == 6
     monkeypatch.delenv("CORE_LIMIT", raising=False)
+
+
+def test_get_core_modules_negative_limit():
+    mods = brain.get_core_modules(limit=-2)
+    assert len(mods) == 1
+
+
+def test_get_core_modules_env_negative(monkeypatch):
+    monkeypatch.setenv("CORE_LIMIT", "-3")
+    mods = brain.get_core_modules()
+    assert len(mods) == 1
+    monkeypatch.delenv("CORE_LIMIT", raising=False)
+
+
+def test_get_core_modules_invalid_param(monkeypatch, caplog):
+    monkeypatch.setenv("CORE_LIMIT", "4")
+    with caplog.at_level("WARNING"):
+        mods = brain.get_core_modules(limit="bad")  # type: ignore[arg-type]
+    assert len(mods) == 4
+    assert any("Invalid limit" in r.message for r in caplog.records)
+    monkeypatch.delenv("CORE_LIMIT", raising=False)


### PR DESCRIPTION
## Summary
- define `CLIConfig` dataclass and return it from `parse_args`
- centralize environment variables via new `EnvConfig`
- improve `get_core_modules` validation
- update app/analyzer to use the new env config
- add tests for new dataclasses and extra `get_core_modules` cases

## Testing
- `black . --check`
- `isort . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(full suite)*

------
https://chatgpt.com/codex/tasks/task_e_686dd9ce5390832489d715a104a461b6