### PR TITLE
Implement NPZ sample stats loader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,17 @@
 FROM python:3.11-slim
 
-# 設定工作目錄
+# 1. 設定工作目錄
 WORKDIR /app
 
-# 安裝依賴
+# 2. 安裝 Python 依賴
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN echo "samples 內容：" && ls -l samples
-# 複製程式碼 + 熱力圖資料
+
+# 3. 複製整個專案（包含 samples/）
 COPY . .
 
-# ✅ 已預先準備 out_npz/*.npz、samples/*.npz，不需再重產
-# ❌ 以下兩行可移除避免浪費時間或意外覆蓋
-# RUN python3 build_global_pos_freq.py -s samples -o out_npz
-# RUN python3 precompute_heatmap.py
+# 4. 列出 /app/samples 內容，確認檔案已經在 image 裡
+RUN echo ">>> /app/samples 內容：" && ls -l /app/samples
 
-# 啟動 API 伺服器
+# 5. 啟動 API 伺服器
 ENTRYPOINT ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # 安裝依賴
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-
+RUN echo "samples 內容：" && ls -l samples
 # 複製程式碼 + 熱力圖資料
 COPY . .
 

--- a/analyzer.py
+++ b/analyzer.py
@@ -45,10 +45,6 @@ from csp_solver import heuristic_csp_sampling
 env = EnvConfig()
 
 # Logger configuration
-def load_all_sample_stats(samples_dir: str) -> None:
-    p = Path(samples_dir)
-    # **新增這行**：列出 samples/ 底下所有檔
-    logging.info(">> Samples 目錄內容: %s", [
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",

--- a/analyzer.py
+++ b/analyzer.py
@@ -45,6 +45,10 @@ from csp_solver import heuristic_csp_sampling
 env = EnvConfig()
 
 # Logger configuration
+def load_all_sample_stats(samples_dir: str) -> None:
+    p = Path(samples_dir)
+    # **新增這行**：列出 samples/ 底下所有檔
+    logging.info(">> Samples 目錄內容: %s", [
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",

--- a/analyzer.py
+++ b/analyzer.py
@@ -293,6 +293,35 @@ def _load_sample_stats(
     return freq
 
 
+def extract_shape_from_filename(fname: str) -> Optional[tuple[int, int]]:
+    m = re.match(r"sample_stats_(\d+)x(\d+)\.npz", fname)
+    if m:
+        return int(m[1]), int(m[2])
+    return None
+
+
+def load_sample_npz_for_shape(
+    shape: tuple[int, int], samples_dir: Path = Path("samples")
+) -> None:
+    rows, cols = shape
+    fname = f"sample_stats_{rows}x{cols}.npz"
+    path = samples_dir / fname
+    if not path.exists():
+        logger.warning("找不到樣本檔 %s", path)
+        return
+    try:
+        data = np.load(path, allow_pickle=True)
+        freq = data.get("freq")
+        if freq is not None:
+            _SAMPLE_STATS_LOADED.add((rows, cols, "npz"))
+            _SAMPLE_CACHE[(rows, cols, "npz")] = [(freq, "npz")]
+            logger.info("載入樣本 npz：%s", path.name)
+        else:
+            logger.warning("npz 檔案中沒有 freq 欄位：%s", path.name)
+    except Exception as e:
+        logger.error("讀取樣本 npz 檔失敗 %s：%s", path.name, e)
+
+
 @lru_cache(maxsize=6)
 def get_sample_stats_cached(
     rows: int, cols: int, samples_dir: str
@@ -304,16 +333,15 @@ def get_sample_stats_cached(
 
 
 def load_all_sample_stats(samples_dir: str) -> None:
-    """Preload valid ``NxM.npz`` files with version check."""
+    """Load all ``sample_stats_*x*.npz`` files from ``samples_dir``."""
 
-    pattern = re.compile(r"^(\d+)x(\d+)\.npz$")
+    samples_path = Path(samples_dir)
     count = 0
-    for npz_file in Path(samples_dir).glob("*.npz"):
-        m = pattern.match(npz_file.name)
-        if not m:
-            continue
-        rows, cols = map(int, m.groups())
-        if get_sample_stats_cached(rows, cols, samples_dir) is not None:
+    npz_files = samples_path.glob("sample_stats_*x*.npz")
+    for path in npz_files:
+        shape = extract_shape_from_filename(path.name)
+        if shape:
+            load_sample_npz_for_shape(shape, samples_path)
             count += 1
     logger.info("Total loaded sample freq: %d", count)
 

--- a/tests/test_npz_validation.py
+++ b/tests/test_npz_validation.py
@@ -15,7 +15,8 @@ def test_invalid_npz_counter(tmp_path):
     np.savez(samples / "3x3.npz", freq=np.zeros((3, 3, 10), int), meta=invalid_meta)
     analyzer.get_sample_stats_cached.cache_clear()
     before = analyzer.INVALID_NPZ_COUNTER._value.get()
-    analyzer.load_all_sample_stats(str(samples))
+    analyzer.get_sample_stats_cached(2, 2, str(samples))
+    analyzer.get_sample_stats_cached(3, 3, str(samples))
     after = analyzer.INVALID_NPZ_COUNTER._value.get()
     assert after - before == 1
     assert analyzer.get_sample_stats_cached.cache_info().currsize <= 6

--- a/tests/test_sample_stats_npz.py
+++ b/tests/test_sample_stats_npz.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+import analyzer
+
+
+def test_load_sample_stats_npz(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    freq = np.ones((3, 4, 5))
+    np.savez(samples / "sample_stats_4x5.npz", freq=freq)
+    analyzer._SAMPLE_STATS_LOADED.clear()
+    analyzer._SAMPLE_CACHE.clear()
+    analyzer.load_all_sample_stats(str(samples))
+    assert (4, 5, "npz") in analyzer._SAMPLE_STATS_LOADED
+    cached = analyzer._SAMPLE_CACHE.get((4, 5, "npz"))
+    assert cached and np.array_equal(cached[0][0], freq)


### PR DESCRIPTION
## Summary
- load sample_stats_*x*.npz files to use in fallback stats
- allow retrieval via `extract_shape_from_filename` and `load_sample_npz_for_shape`
- update loader tests and add coverage for the new npz samples

## Testing
- `black analyzer.py tests/test_npz_validation.py tests/test_sample_stats_npz.py`
- `isort --check-only analyzer.py tests/test_npz_validation.py tests/test_sample_stats_npz.py`
- `flake8 analyzer.py tests/test_npz_validation.py tests/test_sample_stats_npz.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f37de02708324b947a416dd5b5364