### PR TITLE
Implement sample_line strategy with neighbor stats

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1853,6 +1853,42 @@ def predict_scratch_card(
     rows, cols = grid_np.shape
     strat_name = strategy.value if isinstance(strategy, Strategy) else str(strategy)
 
+    if strat_name == "sample_line" and target_num is not None:
+        score = compute_neighbor_line_stats(
+            grid_np,
+            target_num,
+            samples_dir=history_dir,
+            weight_neighbor=0.5,
+            weight_line=0.5,
+        )
+        freq = get_sample_stats_cached(rows, cols, history_dir)
+        heat = np.zeros((rows, cols), dtype=float)
+        if freq is not None:
+            freq = _align_heatmap_axes(freq, rows, cols)
+            totals = freq.sum(axis=2, keepdims=True)
+            totals[totals == 0] = 1
+            heat = freq[:, :, int(target_num)] / totals[:, :, 0]
+        final_score = 0.5 * score + 0.5 * heat
+        for r in range(rows):
+            for c in range(cols):
+                if grid_np[r, c] != BLANK_VAL:
+                    final_score[r, c] = 0.0
+        blanks = [tuple(b) for b in np.argwhere(grid_np == BLANK_VAL)]
+        ranked = sorted(
+            [(r, c, float(final_score[r, c])) for r, c in blanks],
+            key=lambda x: x[2],
+            reverse=True,
+        )[:top_n]
+        preds = [{"row": r, "col": c, "score": s} for r, c, s in ranked]
+        return {
+            "mode": "sample_line",
+            "strategy": "sample_line",
+            "predictions": preds,
+            "top_predictions": preds,
+            "full_probabilities": {},
+            "final_recommendations": [],
+        }
+
     try:
         _ = probability_heatmap(
             grid_np, sample_gamma=sample_gamma, history_dir=history_dir

--- a/strategy_types.py
+++ b/strategy_types.py
@@ -6,6 +6,7 @@ class Strategy(Enum):
 
     LEGACY = "legacy"
     MODERN = "modern"
+    SAMPLE_LINE = "sample_line"
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return self.value

--- a/tests/test_neighbor_line_stats.py
+++ b/tests/test_neighbor_line_stats.py
@@ -3,6 +3,7 @@ import pytest
 
 import analyzer
 from neighbor_line_stats import compute_neighbor_line_stats
+from strategy_types import Strategy
 
 
 def test_score_shape_and_range(tmp_path):
@@ -61,3 +62,35 @@ def test_sample_neighbor_line_stats(tmp_path):
         top_k=1,
     )
     assert preds == [((0, 1), [4], [1.0])]
+
+
+def test_predict_strategy_sample_line(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    boards = np.array(
+        [
+            [[1, 4], [3, 2]],
+            [[1, 2], [3, 4]],
+        ],
+        dtype=np.int16,
+    )
+    np.savez(samples / "boards_2x2_part1.npz", boards=boards)
+    freq = np.zeros((2, 2, 5), dtype=int)
+    for b in boards:
+        for r in range(2):
+            for c in range(2):
+                freq[r, c, b[r, c]] += 1
+    meta = np.frombuffer(b"{}", dtype=np.uint8)
+    np.savez(samples / "sample_stats_2x2.npz", freq=freq, meta=meta)
+
+    grid = [[1, -1], [3, -1]]
+    res = analyzer.predict_scratch_card(
+        grid,
+        target_num=4,
+        history_dir=str(samples),
+        strategy=Strategy.SAMPLE_LINE,
+        top_n=1,
+    )
+    pred = res["predictions"][0]
+    assert res["strategy"] == "sample_line"
+    assert pred["row"] == 0 and pred["col"] == 1


### PR DESCRIPTION
## Summary
- add SAMPLE_LINE strategy enum
- integrate compute_neighbor_line_stats in `predict_scratch_card`
- compute blended score using sample stats and neighbor-line score
- test new strategy behavior

## Testing
- `black analyzer.py strategy_types.py tests/test_neighbor_line_stats.py --check`
- `isort strategy_types.py tests/test_neighbor_line_stats.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `FAST_TEST=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709cc7c064832498e8a14b52f63237