### PR TITLE
Add simulation time limit option

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1180,6 +1180,7 @@ def simulate_full_board(
     check_interval: int = 500,
     mask: Optional[np.ndarray] = None,
     _internal: bool = False,
+    time_limit: Optional[float] = None,
 ) -> Dict[Tuple[int, int], Dict[int, float]]:
     """Simulate full boards with optional focus and ε-exploration."""
     logger.info(
@@ -1188,6 +1189,7 @@ def simulate_full_board(
         n_iter,
     )
     # 中文說明：開始 Monte Carlo 模擬，列出目標數字與總迭代次數
+    start_time = time.monotonic()
     if rng is None:
         rng = np.random.default_rng()
 
@@ -1248,6 +1250,8 @@ def simulate_full_board(
     early_stop = False
 
     while remain > 0:
+        if time_limit is not None and time.monotonic() - start_time >= time_limit:
+            break
         batch = min(4000, remain)
         boards = generate_full_boards(
             rows, cols, batch, rng, formulas, weights, grid_gen
@@ -1341,6 +1345,7 @@ def simulate_full_board(
             check_interval=check_interval,
             mask=mask_arr,
             _internal=True,
+            time_limit=time_limit,
         )
         for cell in focus:
             prob_map[cell] = refine.get(cell, prob_map.get(cell, {}))
@@ -1771,6 +1776,7 @@ def predict_scratch_card(
     strategy: Union[str, Strategy] = Strategy.LEGACY,
     use_neighbor_lock: bool = False,
     neighbor_threshold: float = 0.0,
+    time_limit: Optional[float] = None,
 ) -> Dict[str, Any]:
 
     BLANK_VAL = -1
@@ -1818,7 +1824,10 @@ def predict_scratch_card(
 
     try:
         _ = probability_heatmap(
-            grid_np, sample_gamma=sample_gamma, history_dir=history_dir
+            grid_np,
+            sample_gamma=sample_gamma,
+            history_dir=history_dir,
+            time_limit=time_limit,
         )
     except Exception:
         pass
@@ -1920,6 +1929,7 @@ def predict_scratch_card(
                 sample_gamma=sample_gamma,
                 fusion_alpha=fusion_alpha,
                 threshold=neighbor_threshold,
+                time_limit=time_limit,
             )
             return {
                 "mode": "neighbor_lock",
@@ -1991,6 +2001,7 @@ def predict_scratch_card(
             n_iter=10000,
             sample_gamma=sample_gamma,
             history_dir=history_dir,
+            time_limit=time_limit,
         )
         top_k = result_top_k or env.result_top_k
         ranked = sorted([(float(heat[r, c]), r, c) for r, c in blanks], reverse=True)[
@@ -2050,6 +2061,7 @@ def predict_scratch_card(
             n_iter=iterations or 500,
             sample_gamma=sample_gamma,
             history_dir=history_dir,
+            time_limit=time_limit,
         )
         for r, c in blanks:
             final_score_map[r, c] = float(heat[r, c])
@@ -2262,6 +2274,7 @@ def probability_heatmap(
     history_dir: str = "samples",
     nearest_weight: float = 0.0,
     fusion_alpha: float = 0.1,
+    time_limit: Optional[float] = None,
 ) -> Union[np.ndarray, Dict[int, np.ndarray]]:
     """Heatmap simulation using :func:`simulate_full_board`.
 
@@ -2287,7 +2300,9 @@ def probability_heatmap(
 
     rng = np.random.default_rng(seed)
     grid_np = np.asarray(grid, dtype=int)
-    prob_map_dict = simulate_full_board(grid_np, k, n_iter=n_iter, rng=rng)
+    prob_map_dict = simulate_full_board(
+        grid_np, k, n_iter=n_iter, rng=rng, time_limit=time_limit
+    )
 
     mask_ratio = float(np.mean(grid_np == -1))
     gamma = sample_gamma * (1.0 + mask_ratio)
@@ -2386,6 +2401,7 @@ def neighbor_lock_or_fuse(
     sample_gamma: float = 0.9,
     fusion_alpha: float = 0.1,
     threshold: float = 0.0,
+    time_limit: Optional[float] = None,
 ) -> Tuple[Tuple[int, int], float]:
     """Return cell selection using neighbor lock then sample+simulation fusion."""
 
@@ -2430,7 +2446,12 @@ def neighbor_lock_or_fuse(
         used,
     )
     # 中文說明：記錄 fallback 階段實際取得的歷史位置分布數量
-    sim_map = simulate_full_board(grid, target_num, n_iter=phase1)
+    sim_map = simulate_full_board(
+        grid,
+        target_num,
+        n_iter=phase1,
+        time_limit=time_limit,
+    )
 
     prior_scores = {pos: prior_map.get(pos, {}).get(target_num, 0.0) for pos in blanks}
     sim_scores = {pos: sim_map.get(pos, {}).get(target_num, 0.0) for pos in blanks}

--- a/app.py
+++ b/app.py
@@ -174,6 +174,7 @@ class GridRequest(BaseModel):
     pseudo_count: Optional[float] = None
     exclude_filled: bool = True
     strategy: Strategy = Strategy.LEGACY
+    time_limit: Optional[float] = None
 
 
 class Prediction(BaseModel):
@@ -203,6 +204,7 @@ class HeatmapRequest(BaseModel):
     sample_gamma: Optional[float] = 0.9
     use_neighbor_lock: bool = True
     fusion_alpha: Optional[float] = None
+    time_limit: Optional[float] = None
 
 
 class HeatmapResponse(BaseModel):
@@ -356,6 +358,11 @@ async def predict(req: GridRequest):
         top_n = req.top_n or env.phase2_top_n
         eps = req.epsilon or env.phase2_epsilon
         top_k = req.result_top_k or env.result_top_k
+        time_limit = (
+            req.time_limit
+            if "time_limit" in req.model_fields_set and req.time_limit is not None
+            else env.sim_time_limit
+        )
 
         logger.info(
             "Predict | size=%dx%d | target=%s | ph1=%d | ph2=%d | top_k=%d | top_n=%d | eps=%.3f - 開始預測",
@@ -402,6 +409,7 @@ async def predict(req: GridRequest):
             force_legacy=force_legacy,
             pseudo_count=req.pseudo_count or 0.0,
             strategy=req.strategy,
+            time_limit=time_limit,
         )
 
         if req.target_num is not None:
@@ -412,6 +420,7 @@ async def predict(req: GridRequest):
                 hm_iter,
                 sample_gamma=req.sample_gamma,
                 history_dir="samples",
+                time_limit=time_limit,
             )
             fusion_alpha = req.fusion_alpha if req.fusion_alpha is not None else 0.7
             result["final_recommendations"] = fuse_predictions_with_heatmap(
@@ -476,6 +485,11 @@ async def heatmap(req: HeatmapRequest):
             seed=req.seed,
             sample_gamma=req.sample_gamma,
             history_dir="samples",
+            time_limit=(
+                req.time_limit
+                if "time_limit" in req.model_fields_set and req.time_limit is not None
+                else env.sim_time_limit
+            ),
         )
 
         rows, cols = len(req.grid), len(req.grid[0])
@@ -502,6 +516,11 @@ async def heatmap(req: HeatmapRequest):
             priors=priors,
             sample_gamma=req.sample_gamma,
             use_neighbor_lock=req.use_neighbor_lock,
+            time_limit=(
+                req.time_limit
+                if "time_limit" in req.model_fields_set and req.time_limit is not None
+                else env.sim_time_limit
+            ),
         )
 
         fusion_alpha = req.fusion_alpha or 0.7

--- a/env_config.py
+++ b/env_config.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass, field
+from typing import Optional
 
 
 @dataclass
@@ -22,3 +23,8 @@ class EnvConfig:
         default_factory=lambda: int(os.getenv("RESULT_TOP_K", "3"))
     )
     log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))
+    sim_time_limit: Optional[float] = field(
+        default_factory=lambda: (
+            float(v) if (v := os.getenv("SIM_TIME_LIMIT")) else None
+        )
+    )

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,12 @@
+import time
+
+import numpy as np
+
+from analyzer import simulate_full_board
+
+
+def test_simulate_full_board_time_limit():
+    grid = np.array([[-1, 1], [2, 3]])
+    start = time.monotonic()
+    simulate_full_board(grid, None, n_iter=100000, time_limit=0.0)
+    assert time.monotonic() - start < 0.2


### PR DESCRIPTION
## Summary
- support `SIM_TIME_LIMIT` env in `EnvConfig`
- expose optional `time_limit` in API requests
- respect time limit in `predict_scratch_card` and heatmap generation
- implement time-bound stopping in `simulate_full_board`
- test early exit with a new unit test

## Testing
- `black --check analyzer.py app.py env_config.py tests/test_timeout.py`
- `isort --check analyzer.py app.py env_config.py tests/test_timeout.py`
- `flake8 analyzer.py app.py env_config.py tests/test_timeout.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d43bafb8832486daacd05848dbd8