### PR TITLE
Implement tie-breaker for uniform scores

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1099,8 +1099,15 @@ def rank_cells_by_prior_and_modules(
     final = w_prior * prior_k + (1.0 - w_prior) * agg
 
     mask = grid == -1
-    total = final[mask].sum() or 1.0
-    final[mask] = final[mask] / total
+    if np.isclose(np.ptp(final[mask]), 0.0):
+        rings = BoardAnalyzerUtils.ring_index(rows, cols)
+        weights = rings.max() - rings
+        weights[~mask] = 0.0
+        total = weights.sum() or 1.0
+        final = weights / total
+    else:
+        total = final[mask].sum() or 1.0
+        final[mask] = final[mask] / total
 
     results = [
         (int(r), int(c), float(final[r, c] * 100.0))

--- a/app.py
+++ b/app.py
@@ -22,14 +22,9 @@ from pydantic import BaseModel
 # fmt: off
 import analyzer
 import brain
-from analyzer import (
-    compute_position_probabilities,
-    fuse_score_matrices,
-    parse_penalty_string,
-    predict_scratch_card,
-    probability_heatmap,
-    render_heatmap,
-)
+from analyzer import (compute_position_probabilities, fuse_score_matrices,
+                      parse_penalty_string, predict_scratch_card,
+                      probability_heatmap, render_heatmap)
 
 # fmt: on
 brain.priors_map: Dict[str, Dict[int, float]] = {}

--- a/tests/test_prior_module_rank.py
+++ b/tests/test_prior_module_rank.py
@@ -77,3 +77,24 @@ def test_rank_cells_normalization(tmp_path, monkeypatch):
     assert abs(total_prob - 1.0) < 1e-6
     assert ranks[0][2] < 100.0
     assert ranks[0][2] >= ranks[1][2] >= ranks[2][2]
+
+
+def test_rank_cells_uniform_tie_break(monkeypatch):
+    grid = np.full((3, 3), -1)
+    cube = np.ones((3, 3, 10), dtype=float)
+
+    monkeypatch.setattr(
+        analyzer,
+        "get_module_score",
+        lambda mod, g, target=None: np.ones_like(g, dtype=float),
+    )
+
+    ranks = analyzer.rank_cells_by_prior_and_modules(
+        grid,
+        cube,
+        ["dummy"],
+        [1.0],
+        target_num=1,
+        w_prior=0.5,
+    )
+    assert all((r, c) != (1, 1) for r, c, _ in ranks)


### PR DESCRIPTION
## Summary
- normalize rank results using ring index when module/prior scores are uniform
- update import formatting
- add regression test for tie-break behavior

## Testing
- `black --check . && isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `FAST_TEST=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b2a8bb1483249f48cad7c57a3b29