### PR TITLE
Implement score-heatmap fusion

### DIFF
--- a/app.py
+++ b/app.py
@@ -389,13 +389,19 @@ async def predict(req: GridRequest):
 
         if req.target_num is not None:
             hm_iter = phase1 if os.getenv("FAST_TEST") != "1" else min(phase1, 100)
-            _, recs = analyzer.neighbor_fused_heatmap(
+            heat = analyzer.probability_heatmap(
                 grid_norm,
                 req.target_num,
-                iterations=hm_iter,
+                hm_iter,
                 sample_gamma=sample_gamma,
                 history_dir="samples",
                 penalty_deltas=penalties,
+            )
+            alpha = req.fusion_alpha if req.fusion_alpha is not None else 0.5
+            recs = analyzer.fuse_predictions_with_heatmap(
+                heat,
+                result.get("predictions", []),
+                fusion_alpha=alpha,
                 top_k=top_k,
             )
             result["final_recommendations"] = recs
@@ -485,13 +491,11 @@ async def heatmap(req: HeatmapRequest):
         )
 
         if isinstance(prob, np.ndarray) and req.target_num is not None:
-            _, recs = analyzer.neighbor_fused_heatmap(
-                grid_norm,
-                req.target_num,
-                iterations=iters,
-                sample_gamma=sample_gamma,
-                history_dir="samples",
-                penalty_deltas=penalties,
+            alpha = req.fusion_alpha if req.fusion_alpha is not None else 0.5
+            recs = analyzer.fuse_predictions_with_heatmap(
+                prob,
+                pred_result.get("predictions", []),
+                fusion_alpha=alpha,
                 top_k=3,
             )
             pred_result["final_recommendations"] = recs

--- a/main.py
+++ b/main.py
@@ -109,6 +109,12 @@ def parse_args() -> argparse.Namespace:
         help="Weight for sample-based frequency prior",
     )
     parser.add_argument(
+        "--fusion-alpha",
+        type=float,
+        default=0.5,
+        help="Weight for prediction score when fusing with heatmap",
+    )
+    parser.add_argument(
         "--strategy",
         type=str,
         choices=["legacy", "modern"],
@@ -185,6 +191,23 @@ def main():
         )
         ray.shutdown()
 
+        if args.target is not None:
+            heat = probability_heatmap(
+                grid_np,
+                args.target,
+                iterations,
+                sample_gamma=args.sample_gamma,
+                history_dir="samples",
+                penalty_deltas=penalties,
+            )
+            recs = analyzer.fuse_predictions_with_heatmap(
+                heat,
+                result.get("predictions", []),
+                fusion_alpha=args.fusion_alpha,
+                top_k=args.top_k or 3,
+            )
+            result["final_recommendations"] = recs
+
         if args.heatmap_k is not None:
             prob = probability_heatmap(
                 grid_np,
@@ -217,6 +240,13 @@ def main():
             else:
                 msg = f"Cell ({r}, {c})"
             logging.info(msg)
+        if result.get("final_recommendations"):
+            logging.info("Top fused recommendations:")
+            for rec in result["final_recommendations"]:
+                r = int(rec.get("row", 0)) + 1
+                c = int(rec.get("col", 0)) + 1
+                score = rec.get("final_score", 0.0)
+                logging.info("Cell (%d, %d) final_score %.4f", r, c, score)
         logging.info("Full probabilities available in result['full_probabilities']")
         logging.info("Complete!")
         return result

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -167,3 +167,33 @@ def test_neighbor_fused_heatmap(monkeypatch):
     assert heat.shape == (2, 2)
     assert len(recs) == 2
     assert recs[0]["final_score"] >= recs[1]["final_score"]
+
+
+def test_fuse_predictions_with_heatmap():
+    heat = np.array([[0.5, 0.1], [0.3, 0.2]])
+    preds = [
+        {"row": 0, "col": 0, "score": 0.9},
+        {"row": 1, "col": 1, "score": 0.2},
+    ]
+    recs = analyzer.fuse_predictions_with_heatmap(
+        heat,
+        preds,
+        fusion_alpha=0.5,
+        top_k=2,
+    )
+
+    def softmax(arr: np.ndarray) -> np.ndarray:
+        ex = np.exp(arr - np.max(arr))
+        return ex / ex.sum()
+
+    pred_mat = np.zeros_like(heat)
+    for p in preds:
+        pred_mat[p["row"], p["col"]] = p["score"]
+    expected = 0.5 * softmax(pred_mat) + 0.5 * softmax(heat)
+    top = expected.ravel().argsort()[::-1][:2]
+    rows, cols = np.unravel_index(top, expected.shape)
+    exp = [
+        {"row": int(r), "col": int(c), "final_score": float(expected[r, c])}
+        for r, c in zip(rows, cols)
+    ]
+    assert recs == exp


### PR DESCRIPTION
## Summary
- combine prediction scores with heatmap via `fuse_predictions_with_heatmap`
- expose `--fusion-alpha` in CLI
- print fused recommendations in CLI
- update API `/predict` and `/heatmap` to use new fusion logic
- test `fuse_predictions_with_heatmap`

## Testing
- `isort --check .`
- `black --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d04ce72083248d1fc61701521ae4