### PR TITLE
Apply API output filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,14 +22,9 @@ from pydantic import BaseModel
 # fmt: off
 import analyzer
 import brain
-from analyzer import (
-    compute_position_probabilities,
-    fuse_score_matrices,
-    parse_penalty_string,
-    predict_scratch_card,
-    probability_heatmap,
-    render_heatmap,
-)
+from analyzer import (compute_position_probabilities, fuse_score_matrices,
+                      parse_penalty_string, predict_scratch_card,
+                      probability_heatmap, render_heatmap)
 
 # fmt: on
 brain.priors_map: Dict[str, Dict[int, float]] = {}
@@ -277,6 +272,26 @@ def _full_probs_to_1_based(
     return converted
 
 
+# ==== Helpers: trim large fields ============================================
+SAFE_KEYS = [
+    "predictions",
+    "top_predictions",
+    "final_recommendations",
+    "top_recommendations",
+    "strategy",
+    "sample_gamma_used",
+    "heatmap",
+]
+
+
+def filter_response(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep only SAFE_KEYS and drop heavy score maps."""
+    payload = {k: data.get(k) for k in SAFE_KEYS if k in data}
+    for key in ["full_probabilities", "prob_map", "all_scores"]:
+        payload.pop(key, None)
+    return payload
+
+
 # ==== Routes ==============================================================
 
 
@@ -413,9 +428,6 @@ async def predict(req: GridRequest):
             )
             result["final_recommendations"] = recs
 
-        full_probs = result.get("full_probabilities", {})
-        clean_probs = _full_probs_to_1_based(full_probs)
-
         preds = _to_1_based(result.get("predictions"))
         tops = _to_1_based(result.get("top_predictions"))
         recs = _to_1_based(result.get("final_recommendations"))
@@ -424,13 +436,12 @@ async def predict(req: GridRequest):
         payload = {
             "predictions": preds,
             "top_predictions": tops,
-            "full_probabilities": clean_probs,
             "sample_gamma_used": sample_gamma,
             "final_recommendations": recs,
             "top_recommendations": top_recs,
             "strategy": result.get("strategy"),
         }
-        safe_payload = sanitize_floats(payload)
+        safe_payload = sanitize_floats(filter_response(payload))
         logger.info("✅ Response ready")
         return JSONResponse(content=safe_payload, status_code=200)
 
@@ -507,53 +518,31 @@ async def heatmap(req: HeatmapRequest):
             )
             pred_result["final_recommendations"] = recs
 
-        full_probs = pred_result.get("full_probabilities", {})
-        clean_probs = _full_probs_to_1_based(full_probs)
-
         preds = _to_1_based(pred_result.get("predictions"))
         tops = _to_1_based(pred_result.get("top_predictions"))
         recs = _to_1_based(pred_result.get("final_recommendations"))
         top_recs = _to_1_based(pred_result.get("top_recommendations"))
 
-        if isinstance(prob, dict):
-            pm = {str(int(k)): v.tolist() for k, v in prob.items()}
-            resp = {
-                "prob_map": pm,
-                "heatmap": None,
-                "predictions": preds,
-                "top_predictions": tops,
-                "full_probabilities": clean_probs,
-                "final_recommendations": recs,
-                "top_recommendations": top_recs,
-                "strategy": pred_result.get("strategy"),
-            }
-        elif req.output_format.lower() in ("raw", "json"):
-            resp = {
-                "prob_map": prob.tolist(),
-                "heatmap": None,
-                "predictions": preds,
-                "top_predictions": tops,
-                "full_probabilities": clean_probs,
-                "final_recommendations": recs,
-                "top_recommendations": top_recs,
-                "sample_gamma_used": sample_gamma,
-                "strategy": pred_result.get("strategy"),
-            }
-        else:
+        heatmap_b64: Optional[str] = None
+        if req.output_format.lower() not in ("raw", "json"):
             img = render_heatmap(prob, req.output_format)
-            b64 = base64.b64encode(img).decode() if isinstance(img, bytes) else img
-            resp = {
-                "prob_map": prob.tolist(),
-                "heatmap": b64,
-                "predictions": preds,
-                "top_predictions": tops,
-                "full_probabilities": clean_probs,
-                "final_recommendations": recs,
-                "top_recommendations": top_recs,
-                "strategy": pred_result.get("strategy"),
-            }
+            heatmap_b64 = (
+                base64.b64encode(img).decode() if isinstance(img, bytes) else img
+            )
 
-        return JSONResponse(content=sanitize_floats(resp), status_code=200)
+        resp = {
+            "heatmap": heatmap_b64,
+            "predictions": preds,
+            "top_predictions": tops,
+            "final_recommendations": recs,
+            "top_recommendations": top_recs,
+            "sample_gamma_used": sample_gamma,
+            "strategy": pred_result.get("strategy"),
+        }
+
+        return JSONResponse(
+            content=sanitize_floats(filter_response(resp)), status_code=200
+        )
     except HTTPException:
         raise
     except Exception as exc:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ def test_root_alive(client):
 
 
 def test_predict_basic(client):
-    """POST /predict → 200 且 predictions 至少 1 筆，full_probabilities 是 dict"""
+    """POST /predict → 200 且 predictions 至少 1 筆"""
     grid = empty_grid(2, 2)  # 最小合法 2×2 全未知
     payload: Dict[str, Any] = {
         "grid": grid,
@@ -44,9 +44,8 @@ def test_predict_basic(client):
     assert resp.status_code == 200
     assert isinstance(body.get("predictions"), list) and len(body["predictions"]) > 0
     assert isinstance(body.get("top_predictions"), list)
-    assert isinstance(body.get("full_probabilities"), dict)
+    assert "full_probabilities" not in body
     assert isinstance(body.get("final_recommendations"), list)
-    assert isinstance(body.get("top_recommendations"), list)
     assert isinstance(body.get("top_recommendations"), list)
     assert body.get("strategy") == "heatmap_only"
     if body["final_recommendations"]:
@@ -67,7 +66,8 @@ def test_heatmap_basic(client):
     assert heat.startswith("iVBOR")
     assert isinstance(body.get("predictions"), list)
     assert isinstance(body.get("top_predictions"), list)
-    assert isinstance(body.get("full_probabilities"), dict)
+    assert "full_probabilities" not in body
+    assert "prob_map" not in body
     assert isinstance(body.get("final_recommendations"), list)
     assert isinstance(body.get("top_recommendations"), list)
     if body["final_recommendations"]:
@@ -75,18 +75,18 @@ def test_heatmap_basic(client):
 
 
 def test_heatmap_json(client):
-    """POST /heatmap with output_format=json → prob_map JSON"""
+    """POST /heatmap with output_format=json"""
     grid = empty_grid(2, 2)
     payload = {"grid": grid, "target_num": 1, "iterations": 4, "output_format": "json"}
     resp = client.post("/heatmap", json=payload)
     body = resp.json()
 
     assert resp.status_code == 200
-    assert isinstance(body.get("prob_map"), list)
+    assert "prob_map" not in body
     assert body.get("heatmap") is None
     assert isinstance(body.get("predictions"), list)
     assert isinstance(body.get("top_predictions"), list)
-    assert isinstance(body.get("full_probabilities"), dict)
+    assert "full_probabilities" not in body
     assert isinstance(body.get("final_recommendations"), list)
 
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -41,7 +41,7 @@ def test_predict_valid_grid():
     body = res.json()
     assert "predictions" in body
     assert "top_predictions" in body
-    assert "full_probabilities" in body
+    assert "full_probabilities" not in body
     assert isinstance(body["predictions"], list)
     assert isinstance(body.get("final_recommendations"), list)
 


### PR DESCRIPTION
## Summary
- add `filter_response` helper to trim heavy fields
- return only summary fields for `/predict` and `/heatmap`
- update API tests to expect filtered payloads
- adjust predict tests accordingly

## Testing
- `black --check app.py tests/test_api.py tests/test_predict.py`
- `isort --check app.py tests/test_api.py tests/test_predict.py`
- `flake8 app.py tests/test_api.py tests/test_predict.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687214d171388324828e02f6586ee0dc