### PR TITLE
Implement adaptive sample matching

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1843,24 +1843,101 @@ def evaluate_prediction_accuracy(num_trials: int = 50, seed: int = 0) -> float:
 
 
 def match_samples(
-    grid: np.ndarray, target_num: int, history_dir: str, limit: int | None = None
+    grid: np.ndarray,
+    target_num: int,
+    history_dir: str,
+    limit: int | None = None,
+    *,
+    max_mismatch: int = 2,
+    n1: int = 5,
+    n2: int = 10,
+    top_k: int = 10,
+    legacy: bool = False,
 ) -> List[np.ndarray]:
-    """Return boards matching known cells and containing ``target_num``."""
+    """Return boards similar to ``grid`` that contain ``target_num``.
+
+    The search progressively relaxes matching strictness:
+    1. Strict match of all known cells.
+    2. Allow up to ``max_mismatch`` mismatched cells.
+    3. Fall back to nearest neighbors by Hamming distance.
+    """
+
     rows, cols = grid.shape
     mask = grid != -1
-    matches: List[np.ndarray] = []
+    ref = grid[mask]
+
+    strict: List[np.ndarray] = []
+    partial: List[tuple[int, np.ndarray]] = []
+    others: List[tuple[float, int, np.ndarray]] = []
+    seen: set[bytes] = set()
+
     for sample in iter_sample_jsons(history_dir):
         if sample["rows"] != rows or sample["cols"] != cols:
             continue
         board = np.asarray(sample["grid"], dtype=int)
-        if not np.array_equal(board[mask], grid[mask]):
-            continue
         if target_num not in board:
             continue
-        matches.append(board)
-        if limit is not None and len(matches) >= limit:
+
+        key = board.tobytes()
+        if key in seen:
+            continue
+        mism = int(np.sum(board[mask] != ref))
+        if legacy:
+            if mism == 0:
+                strict.append(board)
+                if limit is not None and len(strict) >= limit:
+                    break
+            seen.add(key)
+            continue
+
+        if mism == 0:
+            strict.append(board)
+        elif mism <= max_mismatch:
+            partial.append((mism, board))
+        else:
+            ratio = mism / (mask.sum() or 1)
+            others.append((ratio, mism, board))
+        seen.add(key)
+
+    logger.debug("Strict matches collected: %d", len(strict))
+    if legacy:
+        return strict[:limit] if limit is not None else strict
+
+    if len(strict) >= n1 or (limit is not None and len(strict) >= limit):
+        result = strict
+        logger.debug("Returning strict matches")
+        return result[:limit] if limit is not None else result
+
+    partial.sort(key=lambda x: x[0])
+    logger.debug("Partial matches collected: %d", len(partial))
+    boards = strict[:]
+    seen_bytes = {b.tobytes() for b in boards}
+    for _, b in partial:
+        key = b.tobytes()
+        if key not in seen_bytes:
+            boards.append(b)
+            seen_bytes.add(key)
+        if limit is not None and len(boards) >= limit:
             break
-    return matches
+    if len(boards) >= n2 or (limit is not None and len(boards) >= limit):
+        logger.debug("Returning partial matches")
+        return boards[:limit] if limit is not None else boards
+
+    others.sort(key=lambda x: (x[0], x[1]))
+    logger.debug("Approx matches collected: %d", len(others))
+    for _, _, b in others:
+        key = b.tobytes()
+        if key not in seen_bytes:
+            boards.append(b)
+            seen_bytes.add(key)
+        if len(boards) >= (top_k if limit is None else min(top_k, limit)):
+            break
+    if not boards and others:
+        boards.append(others[0][2])
+    if not boards and partial:
+        boards.append(partial[0][1])
+    logger.debug("Total matches returned: %d", len(boards))
+    return boards[:limit] if limit is not None else boards
 
 
 def compute_sample_heatmap(

--- a/tests/test_match_samples.py
+++ b/tests/test_match_samples.py
@@ -1,0 +1,56 @@
+import json
+import zipfile
+from pathlib import Path
+
+import numpy as np
+
+import analyzer
+
+
+def _create_zip(samples_dir: Path, boards):
+    zpath = samples_dir / "s.zip"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        for i, board in enumerate(boards):
+            data = {"rows": 2, "cols": 2, "grid": board}
+            zf.writestr(f"b{i}.json", json.dumps(data))
+
+
+def test_match_samples_partial(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    base_board = [[1, 2], [3, 4]]
+    _create_zip(samples, [base_board])
+    grid = np.array([[1, -1], [3, 5]])
+    matches = analyzer.match_samples(grid, 2, str(samples))
+    assert len(matches) == 1
+    assert np.array_equal(matches[0], np.array(base_board))
+
+
+def test_match_samples_nearest(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    base_board = [[1, 2], [3, 4]]
+    _create_zip(samples, [base_board])
+    grid = np.array([[6, -1], [8, 9]])
+    matches = analyzer.match_samples(grid, 2, str(samples))
+    assert matches
+
+
+def test_match_samples_dedup(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    base_board = [[1, 2], [3, 4]]
+    _create_zip(samples, [base_board, base_board, base_board])
+    grid = np.array([[1, 2], [3, 4]])
+    matches = analyzer.match_samples(grid, 2, str(samples))
+    assert len(matches) == 1
+
+
+def test_match_samples_legacy(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    base_board = [[1, 2], [3, 4]]
+    _create_zip(samples, [base_board])
+    grid = np.array([[1, -1], [3, 5]])
+    matches = analyzer.match_samples(grid, 2, str(samples), legacy=True)
+    assert not matches


### PR DESCRIPTION
## Summary
- implement multi-stage fallback for sample matching
- add regression tests for partial and nearest-neighbor match logic
- support deduplication and optional legacy behavior

## Testing
- `black analyzer.py tests/test_match_samples.py --check`
- `isort analyzer.py tests/test_match_samples.py --check`
- `flake8 analyzer.py tests/test_match_samples.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_match_samples.py`

------
https://chatgpt.com/codex/tasks/task_e_68726041e2b48324b1e5122fe03e2b96