### PR TITLE
Implement adaptive sample matching

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1843,24 +1843,72 @@ def evaluate_prediction_accuracy(num_trials: int = 50, seed: int = 0) -> float:
 
 
 def match_samples(
-    grid: np.ndarray, target_num: int, history_dir: str, limit: int | None = None
+    grid: np.ndarray,
+    target_num: int,
+    history_dir: str,
+    limit: int | None = None,
+    *,
+    max_mismatch: int = 2,
+    n1: int = 5,
+    n2: int = 10,
+    top_k: int = 10,
 ) -> List[np.ndarray]:
-    """Return boards matching known cells and containing ``target_num``."""
+    """Return boards similar to ``grid`` that contain ``target_num``.
+
+    The search progressively relaxes matching strictness:
+    1. Strict match of all known cells.
+    2. Allow up to ``max_mismatch`` mismatched cells.
+    3. Fall back to nearest neighbors by Hamming distance.
+    """
+
     rows, cols = grid.shape
     mask = grid != -1
-    matches: List[np.ndarray] = []
+    ref = grid[mask]
+
+    strict: List[np.ndarray] = []
+    partial: List[tuple[int, np.ndarray]] = []
+    approx: List[tuple[float, np.ndarray]] = []
+    seen: set[bytes] = set()
+
     for sample in iter_sample_jsons(history_dir):
         if sample["rows"] != rows or sample["cols"] != cols:
             continue
         board = np.asarray(sample["grid"], dtype=int)
-        if not np.array_equal(board[mask], grid[mask]):
-            continue
         if target_num not in board:
             continue
-        matches.append(board)
-        if limit is not None and len(matches) >= limit:
-            break
-    return matches
+        key = board.tobytes()
+        if key in seen:
+            continue
+        seen.add(key)
+
+        mism = int(np.sum(board[mask] != ref))
+        if mism == 0:
+            strict.append(board)
+            if limit is not None and len(strict) >= limit:
+                break
+        elif mism <= max_mismatch:
+            partial.append((mism, board))
+        else:
+            ratio = mism / float(mask.sum() or 1)
+            approx.append((ratio, board))
+
+    logger.info("嚴格匹配 %d 筆", len(strict))
+    if len(strict) >= n1 or (limit is not None and len(strict) >= limit):
+        return strict[:limit] if limit is not None else strict
+
+    partial.sort(key=lambda x: x[0])
+    logger.info("partial 匹配 %d 筆", len(partial))
+    boards = strict + [b for _, b in partial]
+    if len(boards) >= n2 or (limit is not None and len(boards) >= limit):
+        return boards[:limit] if limit is not None else boards
+
+    approx.sort(key=lambda x: x[0])
+    logger.info("近鄰匹配 %d 筆", len(approx))
+    boards.extend(b for _, b in approx[:top_k])
+    if not boards:
+        logger.warning("無法匹配任何樣本，回傳輸入盤面")
+        return [grid.copy()]
+    return boards[:limit] if limit is not None else boards
 
 
 def compute_sample_heatmap(

--- a/tests/test_match_samples.py
+++ b/tests/test_match_samples.py
@@ -1,0 +1,55 @@
+import json
+import zipfile
+from pathlib import Path
+
+import numpy as np
+
+import analyzer
+
+
+def _create_zip(samples_dir: Path, boards):
+    zpath = samples_dir / "s.zip"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        for i, board in enumerate(boards):
+            rows = len(board)
+            cols = len(board[0]) if rows else 0
+            data = {"rows": rows, "cols": cols, "grid": board}
+            zf.writestr(f"b{i}.json", json.dumps(data))
+
+
+def test_match_samples_partial(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    base_board = [[1, 2], [3, 4]]
+    _create_zip(samples, [base_board])
+    grid = np.array([[1, -1], [3, 5]])
+    matches = analyzer.match_samples(grid, 2, str(samples))
+    assert len(matches) == 1
+    assert np.array_equal(matches[0], np.array(base_board))
+
+
+def test_match_samples_nearest(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    base_board = [[1, 2], [3, 4]]
+    _create_zip(samples, [base_board])
+    grid = np.array([[6, -1], [8, 9]])
+    matches = analyzer.match_samples(grid, 2, str(samples))
+    assert matches
+
+
+def test_match_samples_dedup_and_ratio_sort(tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    b1 = [[1, 2, 6], [3, 4, 5]]
+    b2 = [[1, 2, 6], [7, 4, 5]]  # partial mism 1
+    b3 = [[9, 2, 6], [8, 4, 5]]  # approx ratio 2/3
+    b4 = [[9, 2, 6], [8, 7, 5]]  # approx ratio 1.0
+    _create_zip(samples, [b1, b1, b2, b3, b4])
+    grid = np.array([[1, -1, -1], [3, 4, -1]])
+    matches = analyzer.match_samples(grid, 2, str(samples), n1=2, n2=4, top_k=10)
+    assert len(matches) == 4
+    assert np.array_equal(matches[0], np.array(b1))
+    assert np.array_equal(matches[1], np.array(b2))
+    assert np.array_equal(matches[2], np.array(b3))
+    assert np.array_equal(matches[3], np.array(b4))


### PR DESCRIPTION
## Summary
- add progressive sample matching with dedup and nearest-neighbor fallback
- expand test suite for adaptive matching

## Testing
- `black . --check`
- `isort . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_match_samples.py`


------
https://chatgpt.com/codex/tasks/task_e_68726041e2b48324b1e5122fe03e2b96