### PR TITLE
Enhance matrix factorization agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ cell. Cells are returned sorted by this difference with scores
 `1 / (1 + diff)`.
 
 This method does not rely on memorized boards and only uses the structure of the
-provided grid. Parameters such as rank and learning rate can be tuned via
-keyword arguments to `predict`.
+provided grid. Parameters such as rank, learning rate and the optional
+`max_val` bound can be tuned via keyword arguments to `predict`.
 
 ## Testing
 

--- a/agent_demo.py
+++ b/agent_demo.py
@@ -1,0 +1,31 @@
+"""Simple CLI to run the matrix factorization agent on a sample board."""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from coco_agents.predict_agent import predict
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run prediction agent")
+    parser.add_argument(
+        "board", type=Path, help="Path to JSON file containing board list"
+    )
+    parser.add_argument("target", type=int, help="Target number to search")
+    parser.add_argument("--rank", type=int, default=3)
+    parser.add_argument("--max-iter", type=int, default=1000)
+    args = parser.parse_args()
+
+    with args.board.open() as f:
+        data = json.load(f)
+    board = np.array(data)
+    preds = predict(board, args.target, rank=args.rank, max_iter=args.max_iter)
+    for p in preds[:5]:
+        print(f"row={p['row']} col={p['col']} score={p['score']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/coco_agents/predict_agent.py
+++ b/coco_agents/predict_agent.py
@@ -1,3 +1,5 @@
+"""Prediction agent based on matrix factorization."""
+
 from typing import Any, Dict, List
 
 import numpy as np
@@ -9,6 +11,7 @@ def _matrix_factorization(
     lr: float = 0.005,
     max_iter: int = 1000,
     seed: int | None = None,
+    max_val: int | None = None,
 ) -> np.ndarray:
     """Fill missing values using simple matrix factorization.
 
@@ -18,13 +21,18 @@ def _matrix_factorization(
         lr: learning rate for gradient descent.
         max_iter: maximum number of iterations.
         seed: random seed for reproducibility.
+        max_val: upper bound of the value range. If ``None`` the bound is
+            inferred from the observed board entries or ``board.size - 1``.
 
     Returns:
-        Completed board with integers in range 0-99.
+        Completed board with integers clipped to ``max_val``.
     """
     rng = np.random.default_rng(seed)
     mask = board != -1
     m, n = board.shape
+    if max_val is None:
+        observed_max = board[mask].max(initial=0)
+        max_val = max(observed_max, board.size - 1)
 
     # initial guess: row mean
     row_sum = np.where(mask, board, 0).sum(axis=1)
@@ -52,7 +60,7 @@ def _matrix_factorization(
         V -= lr * grad_V
         if np.linalg.norm(error) < 1e-3:
             break
-    result = np.clip(np.round(U @ V), 0, 99).astype(int)
+    result = np.clip(np.round(U @ V), 0, max_val).astype(int)
     return result
 
 

--- a/tests/test_agents/test_predict_agent.py
+++ b/tests/test_agents/test_predict_agent.py
@@ -35,7 +35,8 @@ def test_matrix_factorization_shape_and_range():
 
     completed = _matrix_factorization(masked_grid, seed=0)
     assert completed.shape == ground_truth.shape
-    assert np.all((0 <= completed) & (completed < 100))
+    limit = ground_truth.size
+    assert np.all((0 <= completed) & (completed < limit))
 
     accuracy = (completed == ground_truth).mean()
     assert accuracy > 0.0
@@ -49,3 +50,35 @@ def test_predict_returns_candidate_list():
     for item in result:
         assert isinstance(item, dict)
         assert {"row", "col", "score"} <= item.keys()
+
+
+def test_metrics_on_unique_board():
+    rng = np.random.default_rng(123)
+    rows, cols = 10, 12
+    values = rng.permutation(rows * cols).reshape(rows, cols)
+    mask_indices = rng.choice(rows * cols, size=int(rows * cols * 0.6), replace=False)
+    masked = values.copy()
+    for idx in mask_indices:
+        r, c = divmod(int(idx), cols)
+        masked[r, c] = -1
+
+    completed = _matrix_factorization(masked, seed=123)
+    mask = masked == -1
+    final_accuracy = (completed[mask] == values[mask]).mean()
+
+    hit_count = 0
+    top3_hits = 0
+    for idx in mask_indices:
+        r, c = divmod(int(idx), cols)
+        target = int(values[r, c])
+        preds = predict(masked, target=target, seed=123)
+        if preds and (preds[0]["row"], preds[0]["col"]) == (r, c):
+            hit_count += 1
+        if (r, c) in {(p["row"], p["col"]) for p in preds[:3]}:
+            top3_hits += 1
+
+    top3_rate = top3_hits / len(mask_indices)
+
+    assert 0 <= final_accuracy <= 1
+    assert 0 <= top3_rate <= 1
+    assert hit_count <= len(mask_indices)


### PR DESCRIPTION
## Summary
- support dynamic value range in `predict_agent`
- add CLI demo for the agent
- extend tests with accuracy metrics for a unique 10x12 board
- update documentation

## Testing
- `black agent_demo.py coco_agents/predict_agent.py tests/test_agents/test_predict_agent.py`
- `isort --check-only agent_demo.py coco_agents/predict_agent.py tests/test_agents/test_predict_agent.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758c08bdbc832480d39810f2e7c149