### PR TITLE
Add RandomForest training utility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,4 @@ dependencies = [
 
 [project.scripts]
 rf-infer = "rf_infer.cli:main"
+rf-train = "rf_infer.train:main"

--- a/rf_infer/__init__.py
+++ b/rf_infer/__init__.py
@@ -1,7 +1,10 @@
-from .core import batch_predict, extract_features, predict_top_k
+from .core import batch_predict, extract_features, infer_top3_for_target, predict_top_k
+from .train import train_from_features
 
 __all__ = [
     "batch_predict",
     "extract_features",
     "predict_top_k",
+    "infer_top3_for_target",
+    "train_from_features",
 ]

--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -178,3 +178,14 @@ def batch_predict(
             failures,
         )
     return results
+
+
+def infer_top3_for_target(
+    board: np.ndarray, target: int, models_dir: str = "models"
+) -> List[tuple[int, int]]:
+    """Return the top-3 coordinates most likely to contain ``target``."""
+    rows, cols = board.shape
+    model_path = _select_model(models_dir, rows, cols)
+    model = _load_model(model_path)
+    res = predict_top_k(model, board, target, 3)
+    return [(p["r"], p["c"]) for p in res["predictions"]]

--- a/rf_infer/train.py
+++ b/rf_infer/train.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+from typing import List
+
+import joblib
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+
+
+def train_from_features(
+    features_dir: str = "features",
+    models_dir: str = "models",
+    n_estimators: int = 100,
+) -> None:
+    """Train RandomForest models from feature .npz files.
+
+    Each subdirectory in ``features_dir`` should be named ``<rows>x<cols>`` and
+    contain ``<rows>x<cols>_features.npz``. The trained models are saved to
+    ``models_dir`` with the same name and ``.pkl`` extension.
+    """
+    os.makedirs(models_dir, exist_ok=True)
+    for size in os.listdir(features_dir):
+        npz_path = os.path.join(features_dir, size, f"{size}_features.npz")
+        if not os.path.exists(npz_path):
+            continue
+        data = np.load(npz_path)
+        X, y = data["X"], data["y"]
+        clf = RandomForestClassifier(
+            n_estimators=n_estimators, n_jobs=-1, random_state=0
+        )
+        clf.fit(X, y)
+        out_path = os.path.join(models_dir, f"{size}.pkl")
+        joblib.dump(clf, out_path)
+        print(f"Trained and saved model for {size} -> {out_path}")
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Train RF models from features")
+    parser.add_argument("--features-dir", default="features")
+    parser.add_argument("--models-dir", default="models")
+    parser.add_argument("--n-estimators", type=int, default=100)
+    args = parser.parse_args(argv)
+    train_from_features(args.features_dir, args.models_dir, args.n_estimators)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_cli_rf.py
+++ b/tests/test_cli_rf.py
@@ -41,8 +41,9 @@ def test_cli_help() -> None:
 
 
 def test_cli_run(tmp_path: Path) -> None:
-    repo_root = Path(__file__).resolve().parent.parent
-    input_path = repo_root / "boards" / "2x2_input.json"
+    input_path = tmp_path / "input.json"
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump({"board": [[-1, -1], [-1, -1]], "target": 3}, f)
     models_dir = tmp_path / "models"
     models_dir.mkdir()
     model_file = models_dir / "2x2.pkl"

--- a/tests/test_rf_train.py
+++ b/tests/test_rf_train.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import numpy as np
+
+from rf_infer.core import extract_features, infer_top3_for_target
+from rf_infer.train import train_from_features
+
+
+def test_train_and_infer(tmp_path: Path) -> None:
+    features_dir = tmp_path / "features" / "2x2"
+    features_dir.mkdir(parents=True)
+    board_full = np.array([[1, 2], [3, 4]])
+    X_list = []
+    y_list = []
+    board = board_full.copy()
+    for r in range(board.shape[0]):
+        for c in range(board.shape[1]):
+            board[r, c] = -1
+            X_list.append(extract_features(board, r, c))
+            y_list.append(board_full[r, c])
+            board[r, c] = board_full[r, c]
+    X = np.vstack(X_list)
+    y = np.array(y_list)
+    np.savez_compressed(features_dir / "2x2_features.npz", X=X, y=y)
+
+    models_dir = tmp_path / "models"
+    train_from_features(str(tmp_path / "features"), str(models_dir), n_estimators=5)
+
+    model_path = models_dir / "2x2.pkl"
+    assert model_path.exists()
+
+    board = np.array([[-1, -1], [-1, -1]])
+    top3 = infer_top3_for_target(board, 1, models_dir=str(models_dir))
+    assert len(top3) == 3
+    assert all(len(pos) == 2 for pos in top3)

--- a/train_rf_per_size.py
+++ b/train_rf_per_size.py
@@ -96,7 +96,7 @@ def extract_all_features(
 
 def process_zip(zip_path: str, out_dir: str) -> None:
     """
-    逐个打开 zip，读取其中所有 *.json，按文件名 (e.g. 4x5.json) 
+    逐个打开 zip，读取其中所有 *.json，按文件名 (e.g. 4x5.json)
     确定尺寸，提取特征并保存为 compressed .npz
     """
     zf = zipfile.ZipFile(zip_path)


### PR DESCRIPTION
## Summary
- add function to train RF models from NPZ feature sets
- expose helper to infer top-3 cells from trained model
- provide CLI test that creates its own input board
- add unit tests for training/inference workflow

## Testing
- `isort rf_infer tests`
- `black rf_infer tests`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68770240a6608324a774a54ed59bddf1