### PR TITLE
Add board status to LightGBM inference

### DIFF
--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -159,6 +159,47 @@ def find_solutions(board: np.ndarray, limit: int = 2) -> List[np.ndarray]:
     return solutions
 
 
+def _is_valid_board(board: np.ndarray) -> bool:
+    """Return True if board has no duplicate or out-of-range numbers."""
+    rows, cols = board.shape
+    row_sets: List[Set[int]] = [set() for _ in range(rows)]
+    col_sets: List[Set[int]] = [set() for _ in range(cols)]
+    max_val = rows * cols
+    for r in range(rows):
+        for c in range(cols):
+            val = int(board[r, c])
+            if val == -1:
+                continue
+            if val < 1 or val > max_val:
+                return False
+            if val in row_sets[r] or val in col_sets[c]:
+                return False
+            row_sets[r].add(val)
+            col_sets[c].add(val)
+    return True
+
+
+def _is_unique_board(board: np.ndarray) -> bool:
+    """Return True if the board is valid and solvable."""
+    if not _is_valid_board(board):
+        return False
+    return bool(find_solutions(board, limit=1))
+
+
+def _filter_unique_candidates(
+    board: np.ndarray, predictions: List[Dict[str, Any]], target: int
+) -> List[Dict[str, Any]]:
+    """Filter candidate cells to those keeping the board solvable and unique."""
+    valid: List[Dict[str, Any]] = []
+    for p in predictions:
+        r, c = p["r"], p["c"]
+        tmp = board.copy()
+        tmp[r, c] = target
+        if _is_unique_board(tmp):
+            valid.append(p)
+    return valid
+
+
 def predict_top_k(
     model: ClassifierMixin,
     board: np.ndarray,
@@ -168,6 +209,14 @@ def predict_top_k(
     enforce_unique: bool = False,
 ) -> Dict[str, Any]:
     rows, cols = board.shape
+    solutions = find_solutions(board, limit=2)
+    num_solutions = len(solutions)
+    status = "no_valid_solution"
+    if num_solutions == 1:
+        status = "unique"
+    elif num_solutions > 1:
+        status = "multiple"
+
     feats_list: List[np.ndarray] = []
     coords: List[tuple[int, int]] = []
     for r in range(rows):
@@ -176,14 +225,30 @@ def predict_top_k(
                 feats_list.append(extract_features(board, r, c))
                 coords.append((r, c))
     if not feats_list:
-        return {"rows": rows, "cols": cols, "target": target, "predictions": []}
+        return {
+            "rows": rows,
+            "cols": cols,
+            "target": target,
+            "predictions": [],
+            "unique": num_solutions == 1,
+            "num_solutions": num_solutions,
+            "status": status,
+        }
     X = np.vstack(feats_list)
     probs = model.predict_proba(X)
     try:
         idx = list(model.classes_).index(target)
     except ValueError:
         logger.warning("target %s not in model classes", target)
-        return {"rows": rows, "cols": cols, "target": target, "predictions": []}
+        return {
+            "rows": rows,
+            "cols": cols,
+            "target": target,
+            "predictions": [],
+            "unique": num_solutions == 1,
+            "num_solutions": num_solutions,
+            "status": "no_valid_solution",
+        }
     target_probs = probs[:, idx]
     top_idx = np.argsort(target_probs)[-k:][::-1]
     results = [
@@ -194,6 +259,7 @@ def predict_top_k(
         }
         for i in top_idx
     ]
+    results = _filter_unique_candidates(board, results, target)
     if enforce_unique:
         solutions = find_solutions(board, limit=k + 1)
         valid_coords = {
@@ -207,7 +273,18 @@ def predict_top_k(
                 ]
         else:
             results = []
-    return {"rows": rows, "cols": cols, "target": target, "predictions": results}
+
+    if not results:
+        status = "no_valid_solution"
+    return {
+        "rows": rows,
+        "cols": cols,
+        "target": target,
+        "predictions": results,
+        "unique": num_solutions == 1,
+        "num_solutions": num_solutions,
+        "status": status,
+    }
 
 
 def batch_predict(

--- a/tests/test_inference_rf.py
+++ b/tests/test_inference_rf.py
@@ -38,6 +38,8 @@ def test_predict_top_k_simple(tmp_path: Path) -> None:
     res = predict_top_k(model, board_masked, 4, k=1)
 
     assert res["target"] == 4
+    assert res["status"] == "multiple"
+    assert res["num_solutions"] == 2
     assert res["predictions"]
     pred = res["predictions"][0]
     assert (pred["r"], pred["c"]) == (1, 1)
@@ -51,6 +53,7 @@ def test_predict_no_blanks(tmp_path: Path) -> None:
 
     res = predict_top_k(model, board_masked, 2, k=3)
     assert res["predictions"] == []
+    assert res["status"] == "unique"
 
 
 def test_predict_all_blanks_large_k(tmp_path: Path) -> None:
@@ -61,6 +64,7 @@ def test_predict_all_blanks_large_k(tmp_path: Path) -> None:
 
     res = predict_top_k(model, board_masked, 1, k=10)
     assert len(res["predictions"]) == board_masked.size
+    assert res["status"] == "multiple"
 
 
 def test_predict_target_missing(tmp_path: Path) -> None:
@@ -71,6 +75,7 @@ def test_predict_target_missing(tmp_path: Path) -> None:
 
     res = predict_top_k(model, board_masked, 99, k=2)
     assert res["predictions"] == []
+    assert res["status"] == "no_valid_solution"
 
 
 def test_predict_enforce_unique(tmp_path: Path) -> None:
@@ -82,3 +87,26 @@ def test_predict_enforce_unique(tmp_path: Path) -> None:
     res = predict_top_k(model, board_masked, 2, k=2, enforce_unique=True)
     coords = {(p["r"], p["c"]) for p in res["predictions"]}
     assert coords == {(0, 1), (1, 1)}
+    assert res["unique"] is False
+
+
+def test_invalid_board_status(tmp_path: Path) -> None:
+    board_full = np.array([[1, 2], [3, 4]])
+    board_masked = np.array([[1, 1], [3, -1]])
+    clf = _train_simple_model(board_full, board_masked)
+    model = clf
+
+    res = predict_top_k(model, board_masked, 2, k=2)
+    assert res["predictions"] == []
+    assert res["status"] == "no_valid_solution"
+
+
+def test_filter_invalid_prediction(tmp_path: Path) -> None:
+    board_full = np.array([[1, 2], [3, 4]])
+    board_masked = np.array([[1, -1], [3, -1]])
+    clf = _train_simple_model(board_full, board_masked)
+    model = clf
+
+    res = predict_top_k(model, board_masked, 1, k=2)
+    assert res["predictions"] == []
+    assert res["status"] == "no_valid_solution"


### PR DESCRIPTION
## Summary
- ensure LightGBM predictor validates candidate boards
- expose `unique`, `num_solutions`, and `status` in prediction results
- mark `no_valid_solution` when no valid candidates exist
- adjust unit tests for new behaviour

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68774dc34ebc8324b8c998f60460d27f