### PR TITLE
Implement faster feature extraction

### DIFF
--- a/src/features.py
+++ b/src/features.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from multiprocessing import Pool
+
 import numpy as np
 import pandas as pd
 from scipy.ndimage import uniform_filter
+from sklearn.utils.extmath import randomized_svd
 
 
 def _board_features(board: np.ndarray) -> np.ndarray:
@@ -31,7 +34,7 @@ def _board_features(board: np.ndarray) -> np.ndarray:
     col_mean_avg = np.nanmean(col_means)
     col_mean_std = np.nanstd(col_means)
     filled = np.nan_to_num(board, nan=global_mean)
-    _, s, _ = np.linalg.svd(filled, full_matrices=False)
+    _, s, _ = randomized_svd(filled, n_components=4, random_state=0)
     svd_3 = s[:3]
     local_mean = uniform_filter(filled, size=3)
     local_mean_avg = local_mean.mean()
@@ -56,12 +59,30 @@ def _board_features(board: np.ndarray) -> np.ndarray:
     return features
 
 
-def build_features(df: pd.DataFrame, board_shape: tuple[int, int]) -> pd.DataFrame:
-    """Build features for the entire dataframe."""
+def build_features(
+    df: pd.DataFrame, board_shape: tuple[int, int], n_jobs: int = 1
+) -> pd.DataFrame:
+    """Build features for the entire dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing board cells.
+    board_shape : tuple[int, int]
+        Shape of the board (rows, cols).
+    n_jobs : int, optional
+        Number of worker processes for feature extraction, by default ``1``.
+    """
     board_cols = [f"cell_{i}" for i in range(board_shape[0] * board_shape[1])]
     boards = (
         df[board_cols].to_numpy(dtype=float).reshape(-1, board_shape[0], board_shape[1])
     )
-    feats = np.vstack([_board_features(b) for b in boards])
+    if n_jobs == 1:
+        feats = np.vstack([_board_features(b) for b in boards])
+    else:
+        with Pool(n_jobs) as pool:
+            feats = np.vstack(
+                list(pool.imap_unordered(_board_features, boards, chunksize=500))
+            )
     feat_df = pd.DataFrame(feats, columns=[f"f{i}" for i in range(feats.shape[1])])
     return feat_df

--- a/src/train.py
+++ b/src/train.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import hydra
@@ -25,11 +26,21 @@ LOGGER = logging.getLogger(__name__)
 
 
 def train_model(cfg: Any) -> dict[str, float]:
-    """Train LightGBM model and return evaluation metrics."""
+    """Train LightGBM model and return evaluation metrics.
+
+    Parameters
+    ----------
+    cfg : Any
+        Hydra configuration object. Optional keys include ``n_jobs`` for
+        feature extraction workers, ``use_gpu`` to enable GPU training and
+        ``num_threads`` to limit CPU threads.
+    """
     LOGGER.info("Configuration:\n%s", OmegaConf.to_yaml(cfg))
     set_seed(cfg.seed)
     X, y = load_data(cfg.train_data, cfg.target_col)
-    feature_df = build_features(X, tuple(cfg.board_shape))
+    feature_df = build_features(
+        X, tuple(cfg.board_shape), n_jobs=getattr(cfg, "n_jobs", 1)
+    )
     X_train, X_valid, y_train, y_valid = split_data(
         feature_df, y, test_size=0.2, seed=cfg.seed
     )
@@ -37,7 +48,16 @@ def train_model(cfg: Any) -> dict[str, float]:
     X_train = scaler.fit_transform(X_train)
     X_valid = scaler.transform(X_valid)
 
-    estimator = LGBMClassifier(random_state=cfg.seed, **cfg.model)
+    model_params = dict(cfg.model)
+    if getattr(cfg, "use_gpu", False):
+        model_params.update({"device": "gpu", "gpu_platform_id": 0, "gpu_device_id": 0})
+    num_threads = getattr(cfg, "num_threads", None)
+    if num_threads:
+        os.environ["OMP_NUM_THREADS"] = str(num_threads)
+        os.environ["MKL_NUM_THREADS"] = str(num_threads)
+        model_params["n_jobs"] = num_threads
+
+    estimator = LGBMClassifier(random_state=cfg.seed, **model_params)
 
     param_dist = {
         "num_leaves": sp_randint(15, 63),

--- a/tests/test_pipeline/test_features.py
+++ b/tests/test_pipeline/test_features.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pandas as pd
 
-from src.features import _board_features
+from src.features import _board_features, build_features
 
 
 def test_board_features_shape():
@@ -9,3 +10,11 @@ def test_board_features_shape():
     board[0, 0] = -1
     features = _board_features(board)
     assert features.shape == (13,)
+
+
+def test_build_features_parallel():
+    rng = np.random.default_rng(1)
+    boards = rng.integers(0, 10, size=(5, 16))
+    df = pd.DataFrame(boards, columns=[f"cell_{i}" for i in range(16)])
+    feat_df = build_features(df, (4, 4), n_jobs=2)
+    assert feat_df.shape == (5, 13)


### PR DESCRIPTION
## Summary
- parallelize feature extraction with multiprocessing
- switch to randomized SVD
- expose optional GPU/CPU thread config in training pipeline
- add unit test for parallel feature building

## Testing
- `black --check src tests`
- `isort --check src tests`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a446d10288324af6b84a48521e106