### PR TITLE
Fix memory issue in LightGBM pipeline

### DIFF
--- a/train_lgbm_pipeline.py
+++ b/train_lgbm_pipeline.py
@@ -19,7 +19,34 @@ import lightgbm as lgb
 import numpy as np
 from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import StandardScaler
+
+
+class Float32StandardScaler:
+    """Lightweight scaler that keeps data in float32 precision."""
+
+    def __init__(self) -> None:
+        self.mean_: np.ndarray | None = None
+        self.scale_: np.ndarray | None = None
+
+    def fit(self, X: np.ndarray) -> "Float32StandardScaler":
+        X = X.astype(np.float32, copy=False)
+        self.mean_ = X.mean(axis=0)
+        self.scale_ = X.std(axis=0)
+        self.scale_[self.scale_ == 0] = 1.0
+        return self
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        if self.mean_ is None or self.scale_ is None:
+            raise ValueError("Scaler has not been fitted")
+        X = X.astype(np.float32, copy=False)
+        X -= self.mean_
+        X /= self.scale_
+        return X
+
+    def fit_transform(self, X: np.ndarray) -> np.ndarray:
+        self.fit(X)
+        return self.transform(X)
+
 
 try:
     from tqdm.auto import tqdm
@@ -345,7 +372,7 @@ def train_models(out_feat: Path, out_model: Path, trees_per: int, workers: int) 
             y_valid = y_train
             valid_b = train_b
 
-        scaler = StandardScaler()
+        scaler = Float32StandardScaler()
         X_train = scaler.fit_transform(X_train)
         X_valid = scaler.transform(X_valid)
 


### PR DESCRIPTION
## Summary
- add `Float32StandardScaler` to avoid float64 upcast
- use the new scaler in `train_lgbm_pipeline.py`

## Testing
- `black train_lgbm_pipeline.py --check`
- `isort train_lgbm_pipeline.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b7758160c8324b4ca5b8731b6bd3a