### PR TITLE
Fix LightGBM model wrapper

### DIFF
--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import sys
 import time
 from glob import glob
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
@@ -67,7 +68,48 @@ def _validate_path(
 def _load_model(path: str) -> ClassifierMixin:
     _validate_path(path, suffix=".pkl")
     logger.info("Loading model %s", path)
-    return joblib.load(path)
+    sys.modules["__main__"].Float32StandardScaler = Float32StandardScaler
+    obj = joblib.load(path)
+
+    class _ModelWrapper(ClassifierMixin):
+        def __init__(
+            self, model: Any, scaler: Any | None, classes: List[int] | None
+        ) -> None:
+            self.model = model
+            self.scaler = scaler
+            if classes is not None:
+                self.classes_ = np.array(classes)
+            else:
+                self.classes_ = getattr(model, "classes_", None)
+
+        def predict_proba(self, X: np.ndarray) -> np.ndarray:  # type: ignore[override]
+            if self.scaler is not None:
+                X = self.scaler.transform(X)
+            if hasattr(self.model, "predict_proba"):
+                return self.model.predict_proba(X)
+            probs = self.model.predict(
+                X, num_iteration=getattr(self.model, "best_iteration", None)
+            )
+            if probs.ndim == 1:
+                return np.column_stack([1 - probs, probs])
+            return probs
+
+    def _classes_from_path(p: str) -> List[int] | None:
+        base = os.path.splitext(os.path.basename(p))[0]
+        if "x" in base:
+            a, b = base.split("x", 1)
+            if a.isdigit() and b.isdigit():
+                rows, cols = int(a), int(b)
+                return list(range(1, rows * cols + 1))
+        return None
+
+    classes = _classes_from_path(path)
+
+    if isinstance(obj, dict) and "model" in obj:
+        return _ModelWrapper(obj["model"], obj.get("scaler"), classes)
+    if isinstance(obj, tuple) and len(obj) == 2:
+        return _ModelWrapper(obj[1], obj[0], classes)
+    return obj
 
 
 def _load_board_file(path: str) -> List[Dict[str, Any]]:

--- a/tests/test_inference_rf.py
+++ b/tests/test_inference_rf.py
@@ -5,7 +5,8 @@ import joblib
 import numpy as np
 from lightgbm import LGBMClassifier
 
-from rf_infer.core import extract_features, predict_top_k
+from coco_common.scalers import Float32StandardScaler
+from rf_infer.core import extract_features, infer_top3_for_target, predict_top_k
 
 
 def _train_simple_model(
@@ -110,3 +111,20 @@ def test_filter_invalid_prediction(tmp_path: Path) -> None:
     res = predict_top_k(model, board_masked, 1, k=2)
     assert res["predictions"] == []
     assert res["status"] == "no_valid_solution"
+
+
+def test_load_model_dict(tmp_path: Path) -> None:
+    board_full = np.array([[1, 2], [3, 4]])
+    board_masked = np.array([[1, -1], [3, -1]])
+    clf = _train_simple_model(board_full, board_masked)
+    feats = [
+        extract_features(board_masked, r, c)
+        for r in range(board_full.shape[0])
+        for c in range(board_full.shape[1])
+    ]
+    scaler = Float32StandardScaler().fit(np.vstack(feats))
+    model_path = tmp_path / "2x2.pkl"
+    joblib.dump({"model": clf.booster_, "scaler": scaler}, model_path)
+
+    coords = infer_top3_for_target(board_masked, 4, models_dir=str(tmp_path))
+    assert coords and coords[0] == (1, 1)


### PR DESCRIPTION
## Summary
- wrap loaded LightGBM models when stored as dict to provide `predict_proba`
- parse board size from filename for class labels
- add regression test to ensure wrapped models work

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ddaef49188324b889c891411ed0e1