### PR TITLE
Fix Float32StandardScaler pickle load

### DIFF
--- a/coco_common/scalers.py
+++ b/coco_common/scalers.py
@@ -5,6 +5,13 @@ from sklearn.preprocessing import StandardScaler
 class Float32StandardScaler(StandardScaler):
     """保持 float32，減少記憶體占用。"""
 
+    def __setstate__(self, state: dict) -> None:
+        """Restore state with backward compatibility."""
+        state.setdefault("with_mean", True)
+        state.setdefault("with_std", True)
+        state.setdefault("copy", True)
+        super().__setstate__(state)
+
     def fit(self, X, y=None):
         return super().fit(X.astype(np.float32, copy=False), y)
 

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from coco_common.scalers import Float32StandardScaler
+
+
+def test_backward_compatibility_setstate_transform() -> None:
+    state = {
+        "mean_": np.array([0.0, 1.0], dtype=np.float32),
+        "scale_": np.array([1.0, 2.0], dtype=np.float32),
+    }
+    scaler = Float32StandardScaler.__new__(Float32StandardScaler)
+    scaler.__setstate__(state)
+    X = np.array([[1.0, 3.0]], dtype=np.float32)
+    out = scaler.transform(X)
+    assert out.shape == (1, 2)


### PR DESCRIPTION
## Summary
- ensure missing attributes are restored when unpickling Float32StandardScaler
- add regression test covering old pickled scalers

## Testing
- `isort --check coco_common/scalers.py tests/test_scalers.py`
- `black --check coco_common/scalers.py tests/test_scalers.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de4a7fc248324802c885986c11d03