### PR TITLE
Fix feature mismatch in rf inference

### DIFF
--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -73,7 +73,11 @@ def _load_model(path: str) -> ClassifierMixin:
 
     class _ModelWrapper(ClassifierMixin):
         def __init__(
-            self, model: Any, scaler: Any | None, classes: List[int] | None
+            self,
+            model: Any,
+            scaler: Any | None,
+            classes: List[int] | None,
+            n_features: int | None = None,
         ) -> None:
             self.model = model
             self.scaler = scaler
@@ -81,6 +85,11 @@ def _load_model(path: str) -> ClassifierMixin:
                 self.classes_ = np.array(classes)
             else:
                 self.classes_ = getattr(model, "classes_", None)
+            self.n_features_in_ = (
+                int(n_features)
+                if n_features is not None
+                else getattr(model, "n_features_in_", None)
+            )
 
         def predict_proba(self, X: np.ndarray) -> np.ndarray:  # type: ignore[override]
             if self.scaler is not None:
@@ -106,7 +115,12 @@ def _load_model(path: str) -> ClassifierMixin:
     classes = _classes_from_path(path)
 
     if isinstance(obj, dict) and "model" in obj:
-        return _ModelWrapper(obj["model"], obj.get("scaler"), classes)
+        return _ModelWrapper(
+            obj["model"],
+            obj.get("scaler"),
+            classes,
+            obj.get("n_features_in_"),
+        )
     if isinstance(obj, tuple) and len(obj) == 2:
         return _ModelWrapper(obj[1], obj[0], classes)
     return obj
@@ -278,10 +292,21 @@ def predict_top_k(
 
     feats_list: List[np.ndarray] = []
     coords: List[tuple[int, int]] = []
+    n_features = getattr(model, "n_features_in_", None)
     for r in range(rows):
         for c in range(cols):
             if board[r, c] == -1:
-                feats_list.append(extract_features(board, r, c))
+                if n_features and n_features > 22:
+                    try:
+                        from train_lgbm_pipeline import _board_features
+
+                        feats = _board_features(board, target, (r, c))
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("failed advanced feature extraction: %s", exc)
+                        feats = extract_features(board, r, c)
+                else:
+                    feats = extract_features(board, r, c)
+                feats_list.append(np.asarray(feats, dtype=float))
                 coords.append((r, c))
     if not feats_list:
         return {

--- a/tests/test_inference_rf.py
+++ b/tests/test_inference_rf.py
@@ -6,7 +6,11 @@ import numpy as np
 from lightgbm import LGBMClassifier
 
 from coco_common.scalers import Float32StandardScaler
-from rf_infer.core import extract_features, infer_top3_for_target, predict_top_k
+# fmt: off
+from rf_infer.core import (_load_model, extract_features,
+                           infer_top3_for_target, predict_top_k)
+
+# fmt: on
 
 
 def _train_simple_model(
@@ -124,7 +128,16 @@ def test_load_model_dict(tmp_path: Path) -> None:
     ]
     scaler = Float32StandardScaler().fit(np.vstack(feats))
     model_path = tmp_path / "2x2.pkl"
-    joblib.dump({"model": clf.booster_, "scaler": scaler}, model_path)
+    joblib.dump(
+        {
+            "model": clf.booster_,
+            "scaler": scaler,
+            "n_features_in_": len(feats[0]),
+        },
+        model_path,
+    )
 
     coords = infer_top3_for_target(board_masked, 4, models_dir=str(tmp_path))
     assert coords and coords[0] == (1, 1)
+    m = _load_model(str(model_path))
+    assert getattr(m, "n_features_in_", None) == len(feats[0])

--- a/train_lgbm_pipeline.py
+++ b/train_lgbm_pipeline.py
@@ -11,7 +11,7 @@ import random
 import zipfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterator, List, Set, Tuple
+from typing import Any, Iterator, List, Set, Tuple
 
 import joblib
 import lightgbm as lgb
@@ -478,6 +478,15 @@ def _flush(
     buf.clear()
 
 
+def _save_model(model: Any, scaler: Any | None, path: Path, n_features: int) -> None:
+    """Persist model dictionary including feature count."""
+
+    joblib.dump(
+        {"model": model, "scaler": scaler, "n_features_in_": int(n_features)},
+        path,
+    )
+
+
 def _apply_random_mask(
     board: np.ndarray, ratio: float, rng: random.Random
 ) -> Tuple[np.ndarray, list[Tuple[int, int, int]]]:
@@ -680,7 +689,7 @@ def train_models(out_feat: Path, out_model: Path, trees_per: int, workers: int) 
             callbacks=[lgb.early_stopping(100)],  # More patience
         )
 
-        joblib.dump({"model": booster, "scaler": scaler}, out_model / f"{sd.name}.pkl")
+        _save_model(booster, scaler, out_model / f"{sd.name}.pkl", X_train.shape[1])
 
         preds = booster.predict(X_valid, num_iteration=booster.best_iteration)
         auc = roc_auc_score(y_valid, preds)


### PR DESCRIPTION
## Summary
- support new feature size in `predict_top_k`
- use advanced `_board_features` from training pipeline when model expects >22 features
- record feature count when saving models and expose via `_load_model`

## Testing
- `black train_lgbm_pipeline.py rf_infer/core.py tests/test_inference_rf.py --check`
- `isort train_lgbm_pipeline.py rf_infer/core.py tests/test_inference_rf.py --check`
- `flake8 train_lgbm_pipeline.py rf_infer/core.py tests/test_inference_rf.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dee0cffe083248a6b5381f61dddf2