### PR TITLE
Fix model selection for inference

### DIFF
--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -151,9 +151,27 @@ def load_boards(pattern: str) -> Iterable[Dict[str, Any]]:
 
 
 def _select_model(models_dir: str, rows: int, cols: int) -> str:
-    cand = os.path.join(models_dir, f"{rows}x{cols}.pkl")
-    if os.path.exists(cand):
-        return cand
+    """Return a model path for the given board size.
+
+    Priority:
+    1. exact:   "<rows>x<cols>.pkl"
+    2. fallback "<rows>x<cols>_*.pkl" (first sorted hit)
+
+    Rationale:
+    - keep backward compatibility
+    - deterministic choice
+    """
+
+    base = f"{rows}x{cols}"
+    exact = os.path.join(models_dir, f"{base}.pkl")
+    if os.path.exists(exact):
+        return exact
+
+    pattern = os.path.join(models_dir, f"{base}_*.pkl")
+    matches = sorted(glob(pattern))
+    if matches:
+        return matches[0]
+
     raise FileNotFoundError(f"No model for {rows}x{cols}")
 
 
@@ -182,7 +200,9 @@ def _solve_boards(
         digits.remove(num)
         row_sets[r].add(num)
         col_sets[c].add(num)
-        _solve_boards(board, row_sets, col_sets, digits, blanks, solutions, limit)
+        _solve_boards(
+            board, row_sets, col_sets, digits, blanks, solutions, limit
+        )
         row_sets[r].remove(num)
         col_sets[c].remove(num)
         digits.add(num)
@@ -213,7 +233,9 @@ def find_solutions(board: np.ndarray, limit: int = 2) -> List[np.ndarray]:
             digits.discard(val)
 
     solutions: List[np.ndarray] = []
-    _solve_boards(board.copy(), row_sets, col_sets, digits, blanks, solutions, limit)
+    _solve_boards(
+        board.copy(), row_sets, col_sets, digits, blanks, solutions, limit
+    )
     return solutions
 
 
@@ -302,7 +324,9 @@ def predict_top_k(
 
                         feats = _board_features(board, target, (r, c))
                     except Exception as exc:  # noqa: BLE001
-                        logger.warning("failed advanced feature extraction: %s", exc)
+                        logger.warning(
+                            "failed advanced feature extraction: %s", exc
+                        )
                         feats = extract_features(board, r, c)
                 else:
                     feats = extract_features(board, r, c)
@@ -347,13 +371,16 @@ def predict_top_k(
     if enforce_unique:
         solutions = find_solutions(board, limit=k + 1)
         valid_coords = {
-            (int(r), int(c)) for sol in solutions for r, c in np.argwhere(sol == target)
+            (int(r), int(c))
+            for sol in solutions
+            for r, c in np.argwhere(sol == target)
         }
         if valid_coords:
             results = [p for p in results if (p["r"], p["c"]) in valid_coords]
             if not results:
                 results = [
-                    {"r": r, "c": c, "prob": 1.0} for r, c in sorted(valid_coords)
+                    {"r": r, "c": c, "prob": 1.0}
+                    for r, c in sorted(valid_coords)
                 ]
         else:
             results = []
@@ -398,7 +425,9 @@ def batch_predict(
         try:
             res = predict_top_k(model, board, target, k)
         except Exception as exc:  # noqa: BLE001
-            logger.warning("failed inference for %s: %s", data.get("__source__"), exc)
+            logger.warning(
+                "failed inference for %s: %s", data.get("__source__"), exc
+            )
             failures += 1
             res = {
                 "rows": board.shape[0],

--- a/tests/test_inference_rf.py
+++ b/tests/test_inference_rf.py
@@ -7,7 +7,7 @@ from lightgbm import LGBMClassifier
 
 from coco_common.scalers import Float32StandardScaler
 # fmt: off
-from rf_infer.core import (_load_model, extract_features,
+from rf_infer.core import (_load_model, _select_model, extract_features,
                            infer_top3_for_target, predict_top_k)
 
 # fmt: on
@@ -141,3 +141,21 @@ def test_load_model_dict(tmp_path: Path) -> None:
     assert coords and coords[0] == (1, 1)
     m = _load_model(str(model_path))
     assert getattr(m, "n_features_in_", None) == len(feats[0])
+
+
+def test_select_model_with_suffix(tmp_path: Path) -> None:
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    model_path = models_dir / "4x10_lgbm_best.pkl"
+    model_path.touch()
+    assert _select_model(str(models_dir), 4, 10) == str(model_path)
+
+
+def test_select_model_prefers_exact(tmp_path: Path) -> None:
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    exact = models_dir / "4x10.pkl"
+    with_suffix = models_dir / "4x10_lgbm_best.pkl"
+    exact.touch()
+    with_suffix.touch()
+    assert _select_model(str(models_dir), 4, 10) == str(exact)


### PR DESCRIPTION
## Summary
- update `_select_model` to handle suffixed models deterministically
- tests already cover suffix support and exact-match preference

## Testing
- `isort rf_infer/core.py tests/test_inference_rf.py --check`
- `black rf_infer/core.py tests/test_inference_rf.py --line-length 79 --check`
- `flake8 rf_infer/core.py tests/test_inference_rf.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688123c77e5c8324947826b49ec9067e