### PR TITLE
Add model-loading tests

### DIFF
--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -15,6 +15,43 @@ from coco_common.scalers import Float32StandardScaler  # noqa: F401
 logger = logging.getLogger(__name__)
 
 
+def _extract_features(board: np.ndarray, target: int) -> np.ndarray:
+    """Return feature matrix for all cells of ``board``."""
+
+    try:
+        from train_lgbm_pipeline import _board_features  # type: ignore
+
+        def _feats(r: int, c: int) -> List[float]:
+            return _board_features(board, target, (r, c))
+
+    except Exception:  # pragma: no cover - optional pipeline not available
+
+        def _feats(r: int, c: int) -> List[float]:
+            return extract_features(board, r, c).tolist()
+
+    feats_list: List[np.ndarray] = []
+    for r in range(board.shape[0]):
+        for c in range(board.shape[1]):
+            feats_list.append(np.asarray(_feats(r, c), dtype=float))
+    return np.vstack(feats_list)
+
+
+def _predict_proba_any(model: Any, X: np.ndarray) -> np.ndarray:
+    """Return probability predictions for ``X`` from any supported model."""
+
+    if hasattr(model, "predict_proba"):
+        return model.predict_proba(X)
+
+    probs = model.predict(
+        X,
+        num_iteration=getattr(model, "best_iteration", None),
+        predict_disable_shape_check=True,
+    )
+    if probs.ndim == 1:
+        return np.column_stack([1 - probs, probs])
+    return probs
+
+
 def extract_features(board: np.ndarray, r: int, c: int) -> np.ndarray:
     """Return feature vector for position (r, c)."""
     rows, cols = board.shape
@@ -200,9 +237,7 @@ def _solve_boards(
         digits.remove(num)
         row_sets[r].add(num)
         col_sets[c].add(num)
-        _solve_boards(
-            board, row_sets, col_sets, digits, blanks, solutions, limit
-        )
+        _solve_boards(board, row_sets, col_sets, digits, blanks, solutions, limit)
         row_sets[r].remove(num)
         col_sets[c].remove(num)
         digits.add(num)
@@ -233,9 +268,7 @@ def find_solutions(board: np.ndarray, limit: int = 2) -> List[np.ndarray]:
             digits.discard(val)
 
     solutions: List[np.ndarray] = []
-    _solve_boards(
-        board.copy(), row_sets, col_sets, digits, blanks, solutions, limit
-    )
+    _solve_boards(board.copy(), row_sets, col_sets, digits, blanks, solutions, limit)
     return solutions
 
 
@@ -324,9 +357,7 @@ def predict_top_k(
 
                         feats = _board_features(board, target, (r, c))
                     except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "failed advanced feature extraction: %s", exc
-                        )
+                        logger.warning("failed advanced feature extraction: %s", exc)
                         feats = extract_features(board, r, c)
                 else:
                     feats = extract_features(board, r, c)
@@ -371,16 +402,13 @@ def predict_top_k(
     if enforce_unique:
         solutions = find_solutions(board, limit=k + 1)
         valid_coords = {
-            (int(r), int(c))
-            for sol in solutions
-            for r, c in np.argwhere(sol == target)
+            (int(r), int(c)) for sol in solutions for r, c in np.argwhere(sol == target)
         }
         if valid_coords:
             results = [p for p in results if (p["r"], p["c"]) in valid_coords]
             if not results:
                 results = [
-                    {"r": r, "c": c, "prob": 1.0}
-                    for r, c in sorted(valid_coords)
+                    {"r": r, "c": c, "prob": 1.0} for r, c in sorted(valid_coords)
                 ]
         else:
             results = []
@@ -425,9 +453,7 @@ def batch_predict(
         try:
             res = predict_top_k(model, board, target, k)
         except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "failed inference for %s: %s", data.get("__source__"), exc
-            )
+            logger.warning("failed inference for %s: %s", data.get("__source__"), exc)
             failures += 1
             res = {
                 "rows": board.shape[0],

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import joblib
+import lightgbm as lgb
+import numpy as np
+
+from rf_infer.core import _extract_features, _predict_proba_any
+
+MODELS_DIR = Path("models")
+
+
+def _dummy_board():
+    # 4x5 board with target=7
+    return (
+        np.array(
+            [
+                [1, -1, 3, 4, 5],
+                [6, -1, 8, 9, 10],
+                [11, 12, 13, 14, 15],
+                [16, 17, 18, 19, 20],
+            ],
+            dtype=int,
+        ),
+        7,
+    )
+
+
+def test_model_file_exists():
+    assert MODELS_DIR.exists(), "models/ 資料夾不存在"
+    files = (
+        list(MODELS_DIR.glob("*.pkl"))
+        + list(MODELS_DIR.glob("*.txt"))
+        + list(MODELS_DIR.glob("*.bin"))
+    )
+    assert files, "models/ 裡面找不到任何模型檔"
+
+
+def test_model_can_load_and_predict_proba():
+    board, target = _dummy_board()
+    X = _extract_features(board, target)
+
+    for f in MODELS_DIR.iterdir():
+        if f.suffix not in {".pkl", ".txt", ".bin"}:
+            continue
+        model = joblib.load(f) if f.suffix == ".pkl" else lgb.Booster(model_file=str(f))
+        probs = _predict_proba_any(model, X)
+        assert probs.shape[0] == X.shape[0], f"{f.name} 機率輸出筆數錯誤"
+        assert probs.shape[1] in (
+            2,
+            120,
+        ), f"{f.name} 機率輸出維度不合理: {probs.shape}"
+        assert np.all((probs >= 0) & (probs <= 1)), f"{f.name} 機率值超出 0~1"


### PR DESCRIPTION
## Summary
- support generic probability inference in `rf_infer.core`
- expose helper to produce feature matrix for any board
- verify LightGBM models under `models/` can load and predict

## Testing
- `isort rf_infer/core.py tests/test_model_loading.py --check`
- `black rf_infer/core.py tests/test_model_loading.py --check`
- `flake8 rf_infer/core.py tests/test_model_loading.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688179bd8de08324a79b848b7daa694e