### PR TITLE
Handle binary model probabilities

### DIFF
--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -349,22 +349,32 @@ def predict_top_k(
             "num_solutions": num_solutions,
             "status": status,
         }
+    # ――― 推理 ―――――――――――――――――――――――――――――――――――――――――――――――――
     X = np.vstack(feats_list)
-    probs = model.predict_proba(X)
-    try:
-        idx = list(model.classes_).index(target)
-    except ValueError:
-        logger.warning("target %s not in model classes", target)
-        return {
-            "rows": rows,
-            "cols": cols,
-            "target": target,
-            "predictions": [],
-            "unique": num_solutions == 1,
-            "num_solutions": num_solutions,
-            "status": "no_valid_solution",
-        }
-    target_probs = probs[:, idx]
+    probs = model.predict_proba(X)  # shape (n, C) or (n,)
+
+    # 1）多類模型: 機率列數與 classes_ 一致
+    if probs.ndim == 2 and probs.shape[1] == len(getattr(model, "classes_", [])):
+        try:
+            idx = list(model.classes_).index(target)
+            target_probs = probs[:, idx]
+        except ValueError:
+            logger.warning("target %s not in model classes", target)
+            return {
+                "rows": rows,
+                "cols": cols,
+                "target": target,
+                "predictions": [],
+                "unique": num_solutions == 1,
+                "num_solutions": num_solutions,
+                "status": status,
+            }
+    # 2）二元(OVA)或 shape 不相符: 取最後一欄/一維向量當正類機率
+    else:
+        if probs.ndim == 1:
+            target_probs = probs
+        else:
+            target_probs = probs[:, -1]
     top_idx = np.argsort(target_probs)[-k:][::-1]
     results = [
         {

--- a/tests/test_infer_top3.py
+++ b/tests/test_infer_top3.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from rf_infer.core import predict_top_k
+
+
+class DummyModel:
+    classes_ = [0, 1]
+    n_features_in_ = 4
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        pos = (X[:, 0] + X[:, 1]) / 10.0
+        neg = 1 - pos
+        return np.vstack([neg, pos]).T
+
+
+def test_binary_model_ok() -> None:
+    board = np.array([[-1, -1], [-1, -1]])
+    res = predict_top_k(DummyModel(), board, target=1, k=3)
+    assert isinstance(res["predictions"], list)
+    assert len(res["predictions"]) <= 3


### PR DESCRIPTION
## Summary
- fix inference for binary classifier outputs by handling 1D or mismatched probability shapes
- add basic test for DummyModel binary inference

## Testing
- `black --check rf_infer/core.py tests/test_infer_top3.py`
- `isort --check rf_infer/core.py tests/test_infer_top3.py`
- `flake8 rf_infer/core.py tests/test_infer_top3.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a596e24c8324b25b1ea036fd7aa9