### PR TITLE
Improve API logging

### DIFF
--- a/coco_service/main.py
+++ b/coco_service/main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
@@ -7,6 +8,9 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from rf_infer.core import infer_top3_for_target
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 async def initialize_resources() -> None:
@@ -57,9 +61,16 @@ async def root() -> Dict[str, str]:
 
 @app.post("/predict", response_model=List[Prediction])
 async def predict(req: PredictRequest) -> List[Prediction]:
+    logger.info(
+        "Received predict request: target=%s board=%dx%d",
+        req.target,
+        len(req.board),
+        len(req.board[0]) if req.board else 0,
+    )
     kwargs = req.kwargs or {}
     models_dir = kwargs.pop("models_dir", os.getenv("MODELS_DIR", "models"))
     predictions = _predict_lgbm(req.board, req.target, models_dir)
+    logger.info("Returning %d predictions", len(predictions))
     return [Prediction(**p) for p in predictions]
 
 

--- a/tests/test_service/test_api.py
+++ b/tests/test_service/test_api.py
@@ -49,3 +49,17 @@ def test_root_endpoint():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World"}
+
+
+def test_predict_logging(tmp_path: Path, monkeypatch, caplog) -> None:
+    client = TestClient(app)
+    board_full = np.array([[1, 2], [3, 4]])
+    board_masked = np.array([[1, -1], [3, -1]])
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    joblib.dump(_train_simple_model(board_full, board_masked), model_dir / "2x2.pkl")
+    monkeypatch.setenv("MODELS_DIR", str(model_dir))
+
+    caplog.set_level("INFO")
+    client.post("/predict", json={"board": board_masked.tolist(), "target": 4})
+    assert any("Received predict request" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- configure logging for the FastAPI app
- record requests and response sizes
- validate log generation in API tests

## Testing
- `black --check coco_service/main.py tests/test_service/test_api.py`
- `isort --check coco_service/main.py tests/test_service/test_api.py`
- `flake8 coco_service/main.py tests/test_service/test_api.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b5ad84a083248ebe6bafac882a32