### PR TITLE
Improve API logging

### DIFF
--- a/coco_service/main.py
+++ b/coco_service/main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
@@ -7,6 +8,9 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from rf_infer.core import infer_top3_for_target
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 async def initialize_resources() -> None:
@@ -57,9 +61,16 @@ async def root() -> Dict[str, str]:
 
 @app.post("/predict", response_model=List[Prediction])
 async def predict(req: PredictRequest) -> List[Prediction]:
+    logger.info(
+        "Received predict request: target=%s board=%dx%d",
+        req.target,
+        len(req.board),
+        len(req.board[0]) if req.board else 0,
+    )
     kwargs = req.kwargs or {}
     models_dir = kwargs.pop("models_dir", os.getenv("MODELS_DIR", "models"))
     predictions = _predict_lgbm(req.board, req.target, models_dir)
+    logger.info("Returning %d predictions", len(predictions))
     return [Prediction(**p) for p in predictions]
 
 

--- a/rf_infer/core.py
+++ b/rf_infer/core.py
@@ -465,7 +465,19 @@ def infer_top3_for_target(
 ) -> List[tuple[int, int]]:
     """Return the top-3 coordinates most likely to contain ``target``."""
     rows, cols = board.shape
+    logger.info(
+        "infer_top3_for_target: board=%dx%d target=%s",
+        rows,
+        cols,
+        target,
+    )
     model_path = _select_model(models_dir, rows, cols)
+    logger.info("Selected model path: %s", model_path)
     model = _load_model(model_path)
+    logger.info("Model loaded, running predict_top_k …")
     res = predict_top_k(model, board, target, 3)
+    logger.info(
+        "predict_top_k returned %d candidates",
+        len(res.get("predictions", [])),
+    )
     return [(p["r"], p["c"]) for p in res["predictions"]]

--- a/tests/test_infer_top3.py
+++ b/tests/test_infer_top3.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from rf_infer.core import predict_top_k
+from rf_infer import core
 
 
 class DummyModel:
@@ -15,6 +15,24 @@ class DummyModel:
 
 def test_binary_model_ok() -> None:
     board = np.array([[-1, -1], [-1, -1]])
-    res = predict_top_k(DummyModel(), board, target=1, k=3)
+    res = core.predict_top_k(DummyModel(), board, target=1, k=3)
     assert isinstance(res["predictions"], list)
     assert len(res["predictions"]) <= 3
+
+
+def test_infer_top3_logging(monkeypatch, caplog) -> None:
+    board = np.array([[-1, -1], [-1, -1]])
+
+    class _Dummy(DummyModel):
+        pass
+
+    monkeypatch.setattr(core, "_select_model", lambda d, r, c: "dummy")
+    monkeypatch.setattr(core, "_load_model", lambda p: _Dummy())
+
+    caplog.set_level("INFO")
+    res = core.infer_top3_for_target(board, 1, models_dir="m")
+    assert isinstance(res, list)
+    msgs = " ".join(r.message for r in caplog.records)
+    assert "infer_top3_for_target" in msgs
+    assert "Selected model path" in msgs
+    assert "predict_top_k returned" in msgs

--- a/tests/test_service/test_api.py
+++ b/tests/test_service/test_api.py
@@ -49,3 +49,17 @@ def test_root_endpoint():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World"}
+
+
+def test_predict_logging(tmp_path: Path, monkeypatch, caplog) -> None:
+    client = TestClient(app)
+    board_full = np.array([[1, 2], [3, 4]])
+    board_masked = np.array([[1, -1], [3, -1]])
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    joblib.dump(_train_simple_model(board_full, board_masked), model_dir / "2x2.pkl")
+    monkeypatch.setenv("MODELS_DIR", str(model_dir))
+
+    caplog.set_level("INFO")
+    client.post("/predict", json={"board": board_masked.tolist(), "target": 4})
+    assert any("Received predict request" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- configure logging for the FastAPI app
- record requests and response sizes
- validate log generation in API tests
- log model selection and inference steps in `infer_top3_for_target`
- check log generation for `infer_top3_for_target`

## Testing
- `black --check rf_infer/core.py tests/test_infer_top3.py tests/test_service/test_api.py coco_service/main.py`
- `isort --check rf_infer/core.py tests/test_infer_top3.py tests/test_service/test_api.py coco_service/main.py`
- `flake8 rf_infer/core.py tests/test_infer_top3.py tests/test_service/test_api.py coco_service/main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881b5ad84a083248ebe6bafac882a32