### PR TITLE
Implement CSP solver agent with API

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,4 +1,3 @@
-# deployment.yml (GitHub Actions)
 name: Deploy to Azure
 
 on:
@@ -9,22 +8,34 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install numpy scipy pandas openpyxl fastapi uvicorn aiofiles
+        pip install -r requirements.txt || true
+        pip install -r requirements-dev.txt || true
+
+    - name: Run tests
+      run: |
+        PYTHONPATH=. pytest -q -m 'not slow' --maxfail=1 --disable-warnings
+
     - name: Azure Login
       uses: azure/login@v2
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
     - name: Deploy to Azure Web App
       uses: azure/webapps-deploy@v3
       with:

--- a/agent_demo.py
+++ b/agent_demo.py
@@ -1,0 +1,28 @@
+"""CLI demo for CSP solver agent."""
+
+import json
+
+import numpy as np
+
+from agents.csp_solver_agent import predict, solve
+
+
+def main() -> None:
+    board = np.array(
+        [
+            [1, -1, -1, 4],
+            [-1, 4, 1, -1],
+            [-1, 1, 4, -1],
+            [4, -1, -1, 1],
+        ]
+    )
+    target = 3
+    solution = solve(board)
+    print("Solved board:\n", solution)
+    preds = predict(board, target)
+    print("Predictions for", target)
+    print(json.dumps(preds, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/csp_solver_agent.py
+++ b/agents/csp_solver_agent.py
@@ -1,0 +1,184 @@
+"""CSP-based Sudoku solver agent.
+
+This module provides a CSP solver using AC-3, MRV, Forward Checking,
+and Backtracking to solve Sudoku-like puzzles.
+
+The ``predict`` function conforms to the interface described in AGENTS.md.
+It returns positions likely containing the target number after solving the
+puzzle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Cell:
+    row: int
+    col: int
+
+
+def _get_subgrid_size(n: int) -> int:
+    size = int(np.sqrt(n))
+    if size * size != n:
+        raise ValueError(f"Board size {n} is not a perfect square")
+    return size
+
+
+def _peers(n: int) -> Dict[Tuple[int, int], List[Tuple[int, int]]]:
+    sub = _get_subgrid_size(n)
+    peers: Dict[Tuple[int, int], List[Tuple[int, int]]] = {}
+    for r in range(n):
+        for c in range(n):
+            peer_set = set()
+            # row and column
+            peer_set.update(((r, j) for j in range(n) if j != c))
+            peer_set.update(((i, c) for i in range(n) if i != r))
+            # subgrid
+            sg_r, sg_c = (r // sub) * sub, (c // sub) * sub
+            for i in range(sg_r, sg_r + sub):
+                for j in range(sg_c, sg_c + sub):
+                    if i == r and j == c:
+                        continue
+                    peer_set.add((i, j))
+            peers[(r, c)] = list(peer_set)
+    return peers
+
+
+def _ac3(
+    domains: Dict[Tuple[int, int], set],
+    peers: Dict[Tuple[int, int], List[Tuple[int, int]]],
+) -> bool:
+    queue = [(xi, xj) for xi in domains for xj in peers[xi]]
+    while queue:
+        xi, xj = queue.pop(0)
+        if _revise(domains, xi, xj):
+            if not domains[xi]:
+                return False
+            for xk in peers[xi]:
+                if xk != xj:
+                    queue.append((xk, xi))
+    return True
+
+
+def _revise(
+    domains: Dict[Tuple[int, int], set], xi: Tuple[int, int], xj: Tuple[int, int]
+) -> bool:
+    revised = False
+    for x in set(domains[xi]):
+        if all(x == y for y in domains[xj]):
+            domains[xi].remove(x)
+            revised = True
+    return revised
+
+
+def _select_unassigned_variable(
+    domains: Dict[Tuple[int, int], set],
+) -> Optional[Tuple[int, int]]:
+    candidates = [
+        (len(values), cell) for cell, values in domains.items() if len(values) > 1
+    ]
+    return min(candidates, default=(None, None))[1] if candidates else None
+
+
+def _forward_check(
+    domains: Dict[Tuple[int, int], set],
+    peers: Dict[Tuple[int, int], List[Tuple[int, int]]],
+    cell: Tuple[int, int],
+    value: int,
+) -> Dict[Tuple[int, int], set]:
+    removed: Dict[Tuple[int, int], set] = {}
+    for peer in peers[cell]:
+        if value in domains[peer]:
+            domains[peer].remove(value)
+            removed.setdefault(peer, set()).add(value)
+    return removed
+
+
+def _restore(
+    domains: Dict[Tuple[int, int], set], removed: Dict[Tuple[int, int], set]
+) -> None:
+    for cell, values in removed.items():
+        domains[cell].update(values)
+
+
+def _backtrack(
+    domains: Dict[Tuple[int, int], set],
+    peers: Dict[Tuple[int, int], List[Tuple[int, int]]],
+) -> Optional[Dict[Tuple[int, int], int]]:
+    if all(len(v) == 1 for v in domains.values()):
+        return {cell: next(iter(values)) for cell, values in domains.items()}
+
+    cell = _select_unassigned_variable(domains)
+    if cell is None:
+        return None
+
+    for value in list(domains[cell]):
+        removed = _forward_check(domains, peers, cell, value)
+        domains[cell] = {value}
+        if _ac3(domains, peers):
+            result = _backtrack(domains, peers)
+            if result:
+                return result
+        _restore(domains, removed)
+        domains[cell].add(value)
+    return None
+
+
+def solve(board: np.ndarray) -> Optional[np.ndarray]:
+    """Solve the given Sudoku puzzle.
+
+    Parameters
+    ----------
+    board: np.ndarray
+        ``n x n`` array with ``-1`` for blanks.
+
+    Returns
+    -------
+    np.ndarray or None
+        Solved board or ``None`` if no solution exists.
+    """
+    n = board.shape[0]
+    if board.shape[0] != board.shape[1]:
+        raise ValueError("Board must be square")
+
+    digits = set(range(1, n + 1))
+    peers = _peers(n)
+    domains: Dict[Tuple[int, int], set] = {}
+    for r in range(n):
+        for c in range(n):
+            value = board[r, c]
+            if value == -1:
+                domains[(r, c)] = digits.copy()
+            else:
+                domains[(r, c)] = {int(value)}
+
+    if not _ac3(domains, peers):
+        return None
+    result = _backtrack(domains, peers)
+    if result is None:
+        return None
+    solved = np.full_like(board, -1)
+    for (r, c), val in result.items():
+        solved[r, c] = val
+    return solved
+
+
+def predict(board: np.ndarray, target: int, **kwargs: Any) -> List[Dict[str, Any]]:
+    """Predict positions of ``target`` using CSP solving.
+
+    Returns a list of dictionaries ``{"row": int, "col": int, "score": float}``.
+    Score is ``1.0`` for deterministic predictions.
+    """
+    solved = solve(board.copy())
+    predictions: List[Dict[str, Any]] = []
+    if solved is None:
+        return predictions
+    rows, cols = np.where(solved == target)
+    for r, c in zip(rows, cols):
+        predictions.append({"row": int(r), "col": int(c), "score": 1.0})
+    return predictions

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+"""FastAPI entry point for CSP solver agent."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from agents.csp_solver_agent import predict
+
+app = FastAPI()
+
+
+class PredictRequest(BaseModel):
+    board: List[List[int]]
+    target: int
+
+
+@app.post("/predict")
+def predict_endpoint(request: PredictRequest) -> List[Dict[str, Any]]:
+    board = np.array(request.board, dtype=int)
+    return predict(board, target=request.target)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ pytest-cov>=5.0
 orjson>=3.10.0
 ortools>=9.0.0
 scipy
+fastapi>=0.110

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pytest-cov>=5.0
 orjson>=3.10.0
 ortools>=9.0.0
 scipy
+fastapi>=0.110

--- a/tests/test_agents/test_csp_solver_agent.py
+++ b/tests/test_agents/test_csp_solver_agent.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from agents.csp_solver_agent import predict, solve
+
+
+def _is_valid(board: np.ndarray) -> bool:
+    n = board.shape[0]
+    digits = set(range(1, n + 1))
+    for i in range(n):
+        if set(board[i]) != digits:
+            return False
+        if set(board[:, i]) != digits:
+            return False
+    return True
+
+
+def test_csp_solver_on_simple_board():
+    board = np.array(
+        [
+            [1, -1, -1, 4],
+            [-1, 4, 1, -1],
+            [-1, 1, 4, -1],
+            [4, -1, -1, 1],
+        ]
+    )
+    solved = solve(board)
+    assert solved is not None
+    assert _is_valid(solved)
+    preds = predict(board, target=3)
+    solved_positions = set(zip(*np.where(solved == 3)))
+    assert {(p["row"], p["col"]) for p in preds} == solved_positions
+
+
+def test_csp_solver_predict_interface():
+    rng = np.random.default_rng(42)
+    rows, cols = 4, 4
+    board = rng.integers(1, 5, size=(rows, cols))
+    blank_indices = rng.choice(rows * cols, size=5, replace=False)
+    for idx in blank_indices:
+        r, c = divmod(idx, cols)
+        board[r, c] = -1
+    non_blanks = np.argwhere(board != -1)
+    target_r, target_c = non_blanks[rng.integers(len(non_blanks))]
+    target = board[target_r, target_c]
+    result = predict(board.copy(), target=target)
+    assert isinstance(result, list)
+    for item in result:
+        assert isinstance(item, dict)
+        assert "row" in item and "col" in item and "score" in item

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_predict_endpoint():
+    board = [
+        [1, -1, -1, 4],
+        [-1, 4, 1, -1],
+        [-1, 1, 4, -1],
+        [4, -1, -1, 1],
+    ]
+    response = client.post("/predict", json={"board": board, "target": 3})
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 4


### PR DESCRIPTION
## Summary
- implement CSP-based Sudoku solver agent
- expose `/predict` FastAPI endpoint
- add CLI demo
- add tests for solver and API
- require FastAPI in requirements

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(find . -name '*.py' -not -path './.venv/*')`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688372e5b6808324a4f376da89778174