### PR TITLE
Add solver endpoint and tools

### DIFF
--- a/agent_demo.py
+++ b/agent_demo.py
@@ -1,26 +1,32 @@
 """CLI demo for CSP solver agent."""
 
+from __future__ import annotations
+
+import argparse
 import json
+import pathlib
 
 import numpy as np
 
 from agents.csp_solver_agent import predict, solve
 
 
-def main() -> None:
-    board = np.array(
-        [
-            [1, -1, -1, 4],
-            [-1, 4, 1, -1],
-            [-1, 1, 4, -1],
-            [4, -1, -1, 1],
-        ]
-    )
-    target = 3
+def _load(path: pathlib.Path) -> np.ndarray:
+    data = [list(map(int, line.split())) for line in path.read_text().splitlines()]
+    return np.array(data, dtype=int)
+
+
+def main(argv: list[str] | None = None) -> None:
+    pa = argparse.ArgumentParser()
+    pa.add_argument("board", type=pathlib.Path)
+    pa.add_argument("-t", "--target", type=int, required=True)
+    args = pa.parse_args(argv)
+
+    board = _load(args.board)
     solution = solve(board)
     print("Solved board:\n", solution)
-    preds = predict(board, target)
-    print("Predictions for", target)
+    preds = predict(board, args.target)
+    print("Predictions for", args.target)
     print(json.dumps(preds, indent=2))
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from agents.csp_solver_agent import predict as solver_predict
+from agents.csp_solver_agent import solve
 from agents.hint_agent import predict as hint_predict
 
 app = FastAPI(title="CSP Solver Service", version="0.2.0")
@@ -17,6 +18,10 @@ app = FastAPI(title="CSP Solver Service", version="0.2.0")
 class PredictRequest(BaseModel):
     board: List[List[int]] = Field(..., min_items=1)
     target: int
+
+
+class SolveRequest(BaseModel):
+    board: List[List[int]] = Field(..., min_items=1)
 
 
 @app.post("/predict")
@@ -39,3 +44,17 @@ def hints_endpoint(req: PredictRequest):
     if board.ndim != 2 or board.shape[0] != board.shape[1]:
         raise HTTPException(status_code=400, detail="board must be square")
     return {"hints": hint_predict(board, req.target)}
+
+
+@app.post("/solve")
+def solve_endpoint(req: SolveRequest):
+    try:
+        board = np.asarray(req.board, dtype=int)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail=f"bad board: {exc}") from exc
+    if board.ndim != 2 or board.shape[0] != board.shape[1]:
+        raise HTTPException(status_code=400, detail="board must be square")
+    solved = solve(board)
+    if solved is None:
+        raise HTTPException(status_code=400, detail="puzzle has no solution")
+    return {"solution": solved.tolist()}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 # Formatting
 black>=24.4
 isort>=5.13
-httpx>=0.27
+httpx>=0.23,<0.24
+
 # Lint / Type / Security
 flake8>=7.0
 mypy>=1.10
@@ -13,10 +14,12 @@ pytest>=8.2
 hypothesis>=6.100
 pytest-xdist>=3.5
 scipy>=1.8.0
+
 # Core
 numpy==1.26.4
 fastapi==0.110.0
 uvicorn==0.29.0
+
 # Optional coverage
 openpyxl
 pytest-cov>=5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,10 +13,13 @@ pytest>=8.2
 hypothesis>=6.100
 pytest-xdist>=3.5
 scipy>=1.8.0
+# Core
+numpy==1.26.4
+fastapi==0.110.0
+uvicorn==0.29.0
 # Optional coverage
 openpyxl
 pytest-cov>=5.0
 orjson>=3.10.0
 ortools>=9.0.0
 scipy
-fastapi>=0.110

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Formatting
 black>=24.4
 isort>=5.13
-httpx>=0.27
+httpx>=0.23,<0.24
+
 # Lint / Type / Security
 flake8>=7.0
 mypy>=1.10
@@ -13,10 +14,12 @@ pytest>=8.2
 hypothesis>=6.100
 pytest-xdist>=3.5
 scipy>=1.8.0
+
 # Core
 numpy==1.26.4
 fastapi==0.110.0
 uvicorn==0.29.0
+
 # Optional coverage
 openpyxl
 pytest-cov>=5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,13 @@ pytest>=8.2
 hypothesis>=6.100
 pytest-xdist>=3.5
 scipy>=1.8.0
+# Core
+numpy==1.26.4
+fastapi==0.110.0
+uvicorn==0.29.0
 # Optional coverage
 openpyxl
 pytest-cov>=5.0
 orjson>=3.10.0
 ortools>=9.0.0
 scipy
-fastapi>=0.110

--- a/scripts/sudoku_generator.py
+++ b/scripts/sudoku_generator.py
@@ -1,0 +1,70 @@
+"""Generate random Sudoku puzzles and solutions."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+import numpy as np
+
+
+def _pattern(r: int, c: int, sub: int, n: int) -> int:
+    return (sub * (r % sub) + r // sub + c) % n
+
+
+def _shuffle(seq: list[int], rng: np.random.Generator) -> list[int]:
+    arr = np.array(seq)
+    rng.shuffle(arr)
+    return arr.tolist()
+
+
+def generate(
+    n: int, blanks: int, rng: np.random.Generator | None = None
+) -> tuple[np.ndarray, np.ndarray]:
+    if n not in (4, 9):
+        raise ValueError("only 4x4 or 9x9 supported")
+    rng = rng or np.random.default_rng()
+    sub = int(n**0.5)
+    rows = [
+        g * sub + r
+        for g in _shuffle(list(range(sub)), rng)
+        for r in _shuffle(list(range(sub)), rng)
+    ]
+    cols = [
+        g * sub + c
+        for g in _shuffle(list(range(sub)), rng)
+        for c in _shuffle(list(range(sub)), rng)
+    ]
+    nums = _shuffle(list(range(1, n + 1)), rng)
+    board = np.array([[nums[_pattern(r, c, sub, n)] for c in cols] for r in rows])
+    puzzle = board.copy()
+    blanks = min(blanks, n * n)
+    idx = rng.choice(n * n, blanks, replace=False)
+    puzzle[np.unravel_index(idx, puzzle.shape)] = -1
+    return puzzle, board
+
+
+def main(argv: list[str] | None = None) -> None:
+    pa = argparse.ArgumentParser()
+    pa.add_argument("-n", type=int, choices=[4, 9], default=9)
+    pa.add_argument("-b", "--blanks", type=int, default=None)
+    pa.add_argument("-o", "--output", type=pathlib.Path)
+    args = pa.parse_args(argv)
+
+    blanks = args.blanks if args.blanks is not None else args.n * args.n // 3
+    puzzle, solution = generate(args.n, blanks)
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        (args.output / "board.txt").write_text(
+            "\n".join(" ".join(map(str, row)) for row in puzzle)
+        )
+        (args.output / "solution.txt").write_text(
+            "\n".join(" ".join(map(str, row)) for row in solution)
+        )
+    else:
+        print("Puzzle:\n", puzzle)
+        print("Solution:\n", solution)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,3 +32,17 @@ def test_hints_endpoint():
     data = res.json()
     assert "hints" in data
     assert isinstance(data["hints"], list)
+
+
+def test_solve_endpoint():
+    board = [
+        [1, -1, -1, 4],
+        [-1, 4, 1, -1],
+        [-1, 1, 4, -1],
+        [4, -1, -1, 1],
+    ]
+    res = client.post("/solve", json={"board": board})
+    assert res.status_code == 200
+    data = res.json()
+    assert "solution" in data
+    assert isinstance(data["solution"], list)


### PR DESCRIPTION
## Summary
- update CLI demo to load a board from file
- expose `/solve` endpoint in FastAPI app
- pin numpy, fastapi and uvicorn dependencies
- add Sudoku puzzle generator script
- test the new API route

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838f0b987883248b2dbf6ccad29288