### PR TITLE
Implement scratch solver agent and API update

### DIFF
--- a/agents/scratch_solver_agent.py
+++ b/agents/scratch_solver_agent.py
@@ -1,0 +1,55 @@
+"""Scratch-card solver agent with simple heuristics.
+
+This agent assumes numbers on the board are unique within the range
+1..N*M (where ``N`` and ``M`` are board dimensions). Blank cells are
+represented by ``-1``. The agent predicts positions of a target number
+by assigning equal score to all blank cells when the target is hidden
+or returning the revealed location when the target is already visible.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+
+
+def predict(board: np.ndarray, target: int, **_: Any) -> List[Dict[str, Any]]:
+    """Predict candidate positions for ``target``.
+
+    Parameters
+    ----------
+    board:
+        2D numpy array with ``-1`` for hidden cells. Values must be unique
+        and in the range ``1`` .. ``rows*cols``.
+    target:
+        The number to locate.
+
+    Returns
+    -------
+    list of dict
+        Each dict contains ``row``, ``col`` and ``score`` keys.
+    """
+    if board.ndim != 2:
+        raise ValueError("board must be 2D")
+
+    rows, cols = board.shape
+    max_val = rows * cols
+
+    numbers = board[board != -1]
+    if numbers.size != len(np.unique(numbers)):
+        raise ValueError("board numbers must be unique")
+    if numbers.size and (numbers.min() < 1 or numbers.max() > max_val):
+        raise ValueError("board numbers out of range")
+
+    # target already revealed
+    locations = np.argwhere(board == target)
+    if locations.size:
+        return [{"row": int(r), "col": int(c), "score": 1.0} for r, c in locations]
+
+    blanks = np.argwhere(board == -1)
+    if blanks.size == 0:
+        return []
+
+    score = 1.0 / len(blanks)
+    return [{"row": int(r), "col": int(c), "score": float(score)} for r, c in blanks]

--- a/api/main.py
+++ b/api/main.py
@@ -8,9 +8,9 @@ import numpy as np
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from agents.csp_solver_agent import predict as solver_predict
 from agents.csp_solver_agent import solve
 from agents.hint_agent import predict as hint_predict
+from agents.scratch_solver_agent import predict as scratch_predict
 
 app = FastAPI(title="CSP Solver Service", version="0.2.0")
 
@@ -30,9 +30,22 @@ def predict_endpoint(req: PredictRequest):
         board = np.asarray(req.board, dtype=int)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=400, detail=f"bad board: {exc}") from exc
-    if board.ndim != 2 or board.shape[0] != board.shape[1]:
-        raise HTTPException(status_code=400, detail="board must be square")
-    return {"predictions": solver_predict(board, req.target)}
+
+    if board.ndim != 2:
+        raise HTTPException(status_code=400, detail="board must be 2D")
+
+    rows, cols = board.shape
+    numbers = board[board != -1]
+    if numbers.size != len(np.unique(numbers)):
+        raise HTTPException(status_code=400, detail="duplicate numbers found")
+    if numbers.size and (numbers.min() < 1 or numbers.max() > rows * cols):
+        raise HTTPException(status_code=400, detail="numbers out of range")
+    if not (1 <= req.target <= rows * cols):
+        raise HTTPException(status_code=400, detail="target out of range")
+
+    preds = scratch_predict(board, req.target)
+    top3 = sorted(preds, key=lambda x: x["score"], reverse=True)[:3]
+    return {"predictions": top3}
 
 
 @app.post("/hints")

--- a/tests/test_agents/test_scratch_solver_agent.py
+++ b/tests/test_agents/test_scratch_solver_agent.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from agents.scratch_solver_agent import predict
+
+
+def _make_unique_board(rows: int, cols: int, blanks: int, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    numbers = np.arange(1, rows * cols + 1)
+    rng.shuffle(numbers)
+    board = numbers.reshape(rows, cols)
+    blank_indices = rng.choice(rows * cols, size=blanks, replace=False)
+    for idx in blank_indices:
+        r, c = divmod(idx, cols)
+        board[r, c] = -1
+    return board
+
+
+def test_predict_interface():
+    board = _make_unique_board(4, 5, blanks=6, seed=42)
+    target = 3
+    result = predict(board.copy(), target=target)
+    assert isinstance(result, list)
+    for item in result:
+        assert isinstance(item, dict)
+        assert {"row", "col", "score"} <= item.keys()
+        assert (
+            board[item["row"], item["col"]] == -1
+            or board[item["row"], item["col"]] == target
+        )
+
+
+def test_duplicate_numbers_error():
+    board = np.array([[1, 2], [2, -1]])
+    with pytest.raises(ValueError):
+        predict(board, target=1)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,17 +7,23 @@ client = TestClient(app)
 
 def test_predict_endpoint():
     board = [
-        [1, -1, -1, 4],
-        [-1, 4, 1, -1],
-        [-1, 1, 4, -1],
-        [4, -1, -1, 1],
+        [1, 2, -1, 4],
+        [5, -1, -1, 8],
+        [9, -1, -1, 12],
+        [13, 14, 15, -1],
     ]
     response = client.post("/predict", json={"board": board, "target": 3})
     assert response.status_code == 200
     data = response.json()
     assert "predictions" in data
     assert isinstance(data["predictions"], list)
-    assert len(data["predictions"]) == 4
+    assert len(data["predictions"]) == 3
+
+
+def test_predict_invalid_board():
+    board = [[1, 1], [-1, 2]]
+    res = client.post("/predict", json={"board": board, "target": 3})
+    assert res.status_code == 400
 
 
 def test_hints_endpoint():


### PR DESCRIPTION
## Summary
- add new `scratch_solver_agent` for unique-number scratch grids
- update `/predict` endpoint to use scratch solver with validation and top-3 results
- ensure board validation on API side
- add unit tests for the new agent and updated API behavior

## Testing
- `isort . --check-only`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a6d257a48324b98de88dddfb35bc