### PR TITLE
Enhance app torch fallback and add health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT:-80}"]

--- a/app.py
+++ b/app.py
@@ -1,13 +1,29 @@
 import os
 
 import numpy as np
-import torch
+
+try:
+    import torch
+except Exception:  # torch may be unavailable in minimal runtimes
+    torch = None  # type: ignore[assignment]
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 from model import DynamicMET
 
 app = FastAPI()
+
+
+@app.get("/health")
+def health():
+    """Simple readiness/liveness probe.
+
+    Returns the loaded model shapes so ops can verify startup state.
+    """
+    return {
+        "status": "ok",
+        "models": [{"rows": r, "cols": c} for (r, c) in models.keys()],
+    }
 
 
 class BoardInput(BaseModel):

--- a/tests/test_app_fallback.py
+++ b/tests/test_app_fallback.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import sys
+import types
 
 import numpy as np
 
@@ -10,14 +11,14 @@ import model
 
 def test_app_predict_numpy(monkeypatch):
     orig_torch = sys.modules.get("torch")
+    # Simulate environment without torch *before* importing modules that depend on it.
     monkeypatch.setitem(sys.modules, "torch", None)
-    model_no_torch = importlib.reload(model)
-    monkeypatch.setattr(appmod, "torch", None, raising=False)
-    monkeypatch.setattr(appmod, "DynamicMET", model_no_torch.DynamicMET, raising=False)
+    importlib.reload(model)
+    importlib.reload(appmod)
     appmod.models.clear()
-    appmod.models[(2, 2)] = model_no_torch.DynamicMET(4, 5)
+    appmod.models[(2, 2)] = model.DynamicMET(4, 5)
     board = np.array([[1, 2], [3, -1]]).tolist()
-    payload = appmod.BoardInput(board=board, target_value=1)
+    payload = types.SimpleNamespace(board=board, target_value=1)
     result = asyncio.get_event_loop().run_until_complete(appmod.predict(payload))
     assert isinstance(result, list) and len(result) == 3
     for item in result:


### PR DESCRIPTION
## Summary
- gracefully handle missing `torch` module
- expose `/health` API route
- adapt fallback test to reload modules without `torch`
- allow dynamic PORT in Dockerfile command

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check $(git ls-files '*.py')`
- `isort --check $(git ls-files '*.py')`
- `flake8 $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c0b251d883249359709f4c3864a0