### PR TITLE
Update model head and prediction scoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,7 @@
+import glob
 import os
+import re
+from typing import Dict, Tuple
 
 import numpy as np
 
@@ -28,45 +31,90 @@ def health():
 
 class BoardInput(BaseModel):
     board: list[list[int]]
-    target_value: int
+    target_value: int  # 1..N (N=rows*cols)
 
 
-models: dict[tuple[int, int], DynamicMET] = {}
+MODEL_GLOB = os.environ.get("MODEL_GLOB", "met_*x*.pth")
+_PATTERN = re.compile(r"met_(\d+)x(\d+)\.pth$")
+models: Dict[Tuple[int, int], DynamicMET] = {}
+
+
+def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
+    n = rows * cols
+    model = DynamicMET(n, n)
+    if torch is not None and os.path.exists(path):
+        ckpt = torch.load(path, map_location="cpu")
+        state = ckpt.get("model", ckpt)
+        model.load_state_dict(state, strict=False)
+        if hasattr(model, "eval"):
+            model.eval()
+    return model
+
+
+def _discover_models() -> None:
+    found = False
+    for path in glob.glob(MODEL_GLOB):
+        m = _PATTERN.match(os.path.basename(path))
+        if not m:
+            continue
+        r, c = int(m.group(1)), int(m.group(2))
+        models[(r, c)] = _load_one(path, r, c)
+        found = True
+    if not found:
+        r, c = 8, 10
+        models[(r, c)] = DynamicMET(r * c, r * c)
+        if hasattr(models[(r, c)], "eval"):
+            models[(r, c)].eval()
 
 
 @app.on_event("startup")
 def load_models() -> None:
-    """Load pretrained models if available, else use fallback."""
-    for rows, cols, path in [(8, 10, "met_8x10.pth")]:
-        model = DynamicMET(rows * cols, 80)
-        if torch is not None and os.path.exists(path):
-            ckpt = torch.load(path, map_location="cpu")
-            model.load_state_dict(ckpt["model"])  # type: ignore[arg-type]
-            if hasattr(model, "eval"):
-                model.eval()
-        models[(rows, cols)] = model
+    """Search and load checkpoints following pattern met_{R}x{C}.pth."""
+    _discover_models()
 
 
 @app.post("/predict")
 async def predict(input: BoardInput):
     board = np.array(input.board)
     rows, cols = board.shape
+    n = rows * cols
+    if not (1 <= input.target_value <= n):
+        return {"error": f"target_value must be in [1, {n}], got {input.target_value}"}
+
     flat = board.flatten()
-    flat = np.where(flat < 0, 0, flat)
-    model = models[(rows, cols)]
+    mask_pos = np.where(flat == -1)[0]
+    if mask_pos.size == 0:
+        return {"error": "no blank cells (-1) to predict"}
+
+    flat_input = np.where(flat < 0, 0, flat)
+
+    model = models.get((rows, cols))
+    if model is None:
+        model = DynamicMET(n, n)
+        if hasattr(model, "eval"):
+            model.eval()
+        models[(rows, cols)] = model
+
     if torch is not None:
-        inp = torch.tensor(flat).long().unsqueeze(0)
+        inp = torch.tensor(flat_input).long().unsqueeze(0)
         logits = model(inp)  # type: ignore[misc]
         probs = torch.softmax(logits, dim=-1)
-        scores = probs[0, :, input.target_value]
-        topk = torch.topk(scores, k=3).indices.tolist()
-        scores_np = scores.detach().cpu().numpy()
+        scores_all = probs[0, :, input.target_value]
+        scores_np = scores_all.detach().cpu().numpy()
     else:
-        inp = flat.reshape(1, -1)
+        inp = flat_input.reshape(1, -1)
         logits = model(inp)
         scores_np = logits[0, :, input.target_value]
-        topk = np.argsort(scores_np)[-3:][::-1].tolist()
+
+    candidate_scores = scores_np[mask_pos]
+    topk_local = np.argsort(candidate_scores)[-min(3, len(candidate_scores)) :][::-1]
+    top_indices = mask_pos[topk_local]
+
     return [
-        {"row": idx // cols, "col": idx % cols, "score": float(scores_np[idx])}
-        for idx in topk
+        {
+            "row": int(idx // cols),
+            "col": int(idx % cols),
+            "score": float(scores_np[idx]),
+        }
+        for idx in top_indices
     ]

--- a/model.py
+++ b/model.py
@@ -14,8 +14,10 @@ except Exception:  # pragma: no cover - torch missing
 class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
     """Dynamic Masked Encoding Transformer for scratch-card boards.
 
-    If ``torch`` is unavailable, operations fall back to NumPy and return
-    zeros so that dependent services remain functional.
+    類別索引規則：
+    - 0 = MASK（保留，不作為實際數字）
+    - 1..N = 盤面實際數字（唯一）
+    因此輸出維度為 N+1，訓緻時使用 ``ignore_index=0``。
     """
 
     def __init__(
@@ -26,6 +28,8 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
         nhead: int = 4,
         depth: int = 6,
     ) -> None:
+        # num_values = N (R*C)
+        # logits dimension is N+1 with class 0 reserved for MASK
         self.num_fields = num_fields
         self.num_values = num_values
         if TORCH_AVAILABLE:
@@ -34,10 +38,10 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             self.field_embed = nn.Embedding(num_fields, d_model)
             encoder_layer = TransformerEncoderLayer(d_model, nhead)
             self.transformer = TransformerEncoder(encoder_layer, num_layers=depth)
-            self.head = nn.Linear(d_model, num_values)
+            self.head = nn.Linear(d_model, num_values + 1)
 
-    def __call__(self, input_vals):
-        """Return logits for each position with optional NumPy fallback."""
+    def forward(self, input_vals):  # type: ignore[override]
+        """Forward pass returning logits for each position."""
         if TORCH_AVAILABLE:
             assert isinstance(input_vals, torch.Tensor)
             bsz, fields = input_vals.shape
@@ -51,8 +55,6 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
         import numpy as np
 
         bsz, fields = input_vals.shape
-        return np.zeros((bsz, fields, self.num_values), dtype=float)
+        return np.zeros((bsz, fields, self.num_values + 1), dtype=float)
 
-    # retain PyTorch-style API when torch is missing
-    def eval(self):  # type: ignore[override]
-        return self
+    __call__ = forward

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,8 @@ flake8>=7.0
 mypy>=1.10
 bandit>=1.7
 pip-audit>=2.7
-
+numpy
+pydantic
 # Testing
 pytest>=8.2
 hypothesis>=6.100

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ flake8>=7.0
 mypy>=1.10
 bandit>=1.7
 pip-audit>=2.7
-
+numpy
+pydantic
 # Testing
 pytest>=8.2
 hypothesis>=6.100

--- a/tests/test_app_fallback.py
+++ b/tests/test_app_fallback.py
@@ -20,7 +20,7 @@ def test_app_predict_numpy(monkeypatch):
     board = np.array([[1, 2], [3, -1]]).tolist()
     payload = types.SimpleNamespace(board=board, target_value=1)
     result = asyncio.get_event_loop().run_until_complete(appmod.predict(payload))
-    assert isinstance(result, list) and len(result) == 3
+    assert isinstance(result, list) and len(result) == 1
     for item in result:
         assert {"row", "col", "score"} <= set(item.keys())
     monkeypatch.setitem(sys.modules, "torch", orig_torch)

--- a/tests/test_blank_top3.py
+++ b/tests/test_blank_top3.py
@@ -1,0 +1,18 @@
+import asyncio
+import importlib
+
+import numpy as np
+
+import app as appmod
+
+
+def test_predict_only_blank_top3():
+    importlib.reload(appmod)
+    appmod.models.clear()
+    appmod.models[(2, 3)] = appmod.DynamicMET(6, 6)
+    board = np.array([[1, -1, 2], [-1, 3, 4]]).tolist()
+    payload = appmod.BoardInput(board=board, target_value=1)
+    result = asyncio.get_event_loop().run_until_complete(appmod.predict(payload))
+    assert len(result) == 2
+    blank_positions = {(0, 1), (1, 0)}
+    assert all((item["row"], item["col"]) in blank_positions for item in result)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,6 @@ from model import DynamicMET
 
 def test_dynamic_met_forward() -> None:
     model = DynamicMET(num_fields=20, num_values=10)
-    x = torch.randint(0, 10, (2, 20))
+    x = torch.randint(0, 11, (2, 20))
     out = model(x)
-    assert out.shape == (2, 20, 10)
+    assert out.shape == (2, 20, 11)

--- a/train.py
+++ b/train.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pathlib import Path
 
 import torch
 import yaml
@@ -24,6 +25,7 @@ def train_epoch(
         inp = batch["input_vals"].to(device)
         orig = batch["orig_vals"].to(device)
         logits = model(inp)
+        # logits: (B, F, N+1); labels: (B, F) with 0 as mask
         loss = torch.nn.functional.cross_entropy(
             logits.permute(0, 2, 1), orig, ignore_index=MASK_TOKEN_ID
         )
@@ -45,13 +47,11 @@ def main() -> None:
     if args.epochs:
         cfg["training"]["epochs"] = args.epochs
 
-    rows_env = os.environ.get("BOARD_ROWS")
-    cols_env = os.environ.get("BOARD_COLS")
-    max_val_env = os.environ.get("MAX_VALUE")
-    if rows_env and cols_env:
-        cfg["model"]["num_fields"] = int(rows_env) * int(cols_env)
-    if max_val_env:
-        cfg["model"]["num_values"] = int(max_val_env)
+    rows = int(os.environ.get("BOARD_ROWS", 0))
+    cols = int(os.environ.get("BOARD_COLS", 0))
+    if rows and cols:
+        cfg["model"]["num_fields"] = rows * cols
+        cfg["model"]["num_values"] = rows * cols
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     boards = load_boards_from_archives(cfg["data"]["data_dir"])
@@ -76,6 +76,21 @@ def main() -> None:
         loss = train_epoch(model, loader, optimizer, device)
         logger.info("Epoch %s: loss=%.4f", epoch, loss)
         save_checkpoint(model, optimizer, epoch)
+
+    out_dir = Path("checkpoints")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    final_path = out_dir / f"met_{rows}x{cols}.pth"
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+            "epoch": cfg["training"]["epochs"],
+            "rows": rows,
+            "cols": cols,
+        },
+        final_path,
+    )
+    logger.info("Saved final checkpoint to %s", final_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- adjust `DynamicMET` outputs to be `num_values + 1`
- load MET checkpoints dynamically on startup and validate input
- score only blank cells when predicting and restrict target value range
- train script saves final checkpoint as `met_{R}x{C}.pth`
- update tests and add new case for blank-cell scoring

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ca97b4b88324bbcac4c2e07a4597