### PR TITLE
Add target handling to loader and dataset

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,5 +1,6 @@
-from typing import Dict
+from typing import Dict, List, Tuple
 
+import numpy as np
 import torch
 from torch.utils.data import Dataset
 
@@ -7,10 +8,20 @@ MASK_TOKEN_ID = 0
 
 
 class ScratchCardDataset(Dataset):
-    """Dataset that randomly masks board values for training."""
+    """Dataset that randomly masks board values for training.
 
-    def __init__(self, boards: list, mask_ratio: float = 0.6) -> None:
-        self.boards = boards
+    Parameters
+    ----------
+    boards : list of Tuple[np.ndarray, int]
+        List of ``(board, target)`` pairs.
+    mask_ratio : float, optional
+        Fraction of fields to mask, by default ``0.6``.
+    """
+
+    def __init__(
+        self, boards: List[Tuple[np.ndarray, int]], mask_ratio: float = 0.6
+    ) -> None:
+        self.boards, self.targets = zip(*boards)
         self.mask_ratio = mask_ratio
 
     def __len__(self) -> int:  # noqa: D401
@@ -18,9 +29,15 @@ class ScratchCardDataset(Dataset):
         return len(self.boards)
 
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
-        """Return masked input and original board for index ``idx``."""
+        """Return masked input, target and original board for ``idx``."""
         board = torch.from_numpy(self.boards[idx].flatten()).long()
+        target = torch.tensor(int(self.targets[idx])).long()
         mask = torch.rand(board.shape) < self.mask_ratio
         inp = board.clone()
         inp[mask] = MASK_TOKEN_ID
-        return {"input_vals": inp, "mask": mask, "orig_vals": board}
+        return {
+            "input_vals": inp,
+            "mask": mask,
+            "orig_vals": board,
+            "target": target,
+        }

--- a/model.py
+++ b/model.py
@@ -38,9 +38,7 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             self.value_embed = nn.Embedding(num_values + 1, d_model)
             self.field_embed = nn.Embedding(num_fields, d_model)
             # Use batch_first to support nested tensor optimization
-            encoder_layer = TransformerEncoderLayer(
-                d_model, nhead, batch_first=True
-            )
+            encoder_layer = TransformerEncoderLayer(d_model, nhead, batch_first=True)
             # Enable nested tensor for potential speed and memory benefits
             self.transformer = TransformerEncoder(
                 encoder_layer, num_layers=depth, enable_nested_tensor=True

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,10 +6,11 @@ from dataset import MASK_TOKEN_ID, ScratchCardDataset
 
 
 def test_dataset_mask_ratio() -> None:
-    boards = [np.arange(12).reshape(3, 4)]
+    data = [(np.arange(12).reshape(3, 4), 7)]
     torch.manual_seed(0)  # ensure deterministic mask
-    ds = ScratchCardDataset(boards, mask_ratio=0.6)
+    ds = ScratchCardDataset(data, mask_ratio=0.6)
     item = ds[0]
     mask = item["mask"].numpy()
     assert mask.mean() == pytest.approx(0.6, rel=0.3)
     assert (item["input_vals"][mask] == MASK_TOKEN_ID).all()
+    assert item["target"].item() == 7

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -10,12 +10,12 @@ from utils.io_utils import load_boards_from_archives
 def test_load_boards_from_archives(tmp_path: Path) -> None:
     board = np.arange(20).reshape(4, 5).tolist()
     json_path = tmp_path / "board.json"
-    json_path.write_text(json.dumps({"board": board}))
+    json_path.write_text(json.dumps({"board": board, "target": 3}))
 
     zip_path = tmp_path / "boards.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:
-        zf.writestr("a.json", json.dumps({"board": board}))
+        zf.writestr("a.json", json.dumps({"board": board, "target": 3}))
 
     boards = load_boards_from_archives(str(tmp_path))
     assert len(boards) == 2
-    assert all(isinstance(b, np.ndarray) for b in boards)
+    assert all(isinstance(b[0], np.ndarray) and isinstance(b[1], int) for b in boards)

--- a/tests/test_io_utils_multi_board.py
+++ b/tests/test_io_utils_multi_board.py
@@ -8,24 +8,24 @@ from utils.io_utils import load_boards_from_archives
 
 def test_load_boards_list_format(tmp_path: Path) -> None:
     data = [
-        [[1, 2], [3, 4]],
-        [[5, 6], [7, 8]],
+        {"board": [[1, 2], [3, 4]], "target": 1},
+        {"board": [[5, 6], [7, 8]], "target": 2},
     ]
     (tmp_path / "boards.json").write_text(json.dumps(data))
     boards = load_boards_from_archives(str(tmp_path))
     assert len(boards) == 2
-    assert all(isinstance(b, np.ndarray) for b in boards)
-    assert (boards[0] == np.array([[1, 2], [3, 4]])).all()
+    assert all(isinstance(b[0], np.ndarray) for b in boards)
+    assert (boards[0][0] == np.array([[1, 2], [3, 4]])).all()
 
 
 def test_load_boards_dict_list_format(tmp_path: Path) -> None:
     data = {
         "boards": [
-            [[9, 10], [11, 12]],
-            [[13, 14], [15, 16]],
+            {"board": [[9, 10], [11, 12]], "target": 3},
+            {"board": [[13, 14], [15, 16]], "target": 4},
         ]
     }
     (tmp_path / "boards2.json").write_text(json.dumps(data))
     boards = load_boards_from_archives(str(tmp_path))
     assert len(boards) == 2
-    assert (boards[1] == np.array([[13, 14], [15, 16]])).all()
+    assert (boards[1][0] == np.array([[13, 14], [15, 16]])).all()

--- a/tests/test_io_utils_recursive.py
+++ b/tests/test_io_utils_recursive.py
@@ -11,11 +11,11 @@ def test_recursive_loader(tmp_path: Path) -> None:
     sub = tmp_path / "sub" / "deep"
     sub.mkdir(parents=True)
     board = np.arange(4).reshape(2, 2).tolist()
-    (tmp_path / "a.json").write_text(json.dumps({"board": board}))
-    (sub / "b.json").write_text(json.dumps({"board": board}))
+    (tmp_path / "a.json").write_text(json.dumps({"board": board, "target": 1}))
+    (sub / "b.json").write_text(json.dumps({"board": board, "target": 1}))
     zpath = tmp_path / "c.zip"
     with zipfile.ZipFile(zpath, "w") as z:
-        z.writestr("inner.json", json.dumps({"board": board}))
+        z.writestr("inner.json", json.dumps({"board": board, "target": 1}))
     boards = load_boards_from_archives(str(tmp_path))
     assert len(boards) == 3
-    assert all(isinstance(b, np.ndarray) for b in boards)
+    assert all(isinstance(b[0], np.ndarray) and b[1] == 1 for b in boards)

--- a/train.py
+++ b/train.py
@@ -54,8 +54,8 @@ def main() -> None:
 
     # Group boards by shape
     shape_groups = {}
-    for b in boards:
-        shape_groups.setdefault(b.shape, []).append(b)
+    for board, target in boards:
+        shape_groups.setdefault(board.shape, []).append((board, target))
 
     logger = setup_logger()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -70,7 +70,9 @@ def main() -> None:
     for shape, group in shape_groups.items():
         rows, cols = shape
         model_name = f"{rows}x{cols}"
-        logger.info(f"Starting training for shape {model_name} with {len(group)} samples")
+        logger.info(
+            f"Starting training for shape {model_name} with {len(group)} samples"
+        )
 
         # Prepare model fields
         cfg["model"]["num_fields"] = rows * cols

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -1,13 +1,13 @@
 import json
 import os
 import zipfile
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 import numpy as np
 
 
-def _extract_boards(obj: object) -> Iterable[np.ndarray]:
-    """Yield ``numpy`` boards from ``obj``.
+def _extract_boards(obj: object) -> Iterable[Tuple[np.ndarray, int]]:
+    """Yield ``(board, target)`` pairs from ``obj``.
 
     Supported structures:
     - ``{"board": [...]}``
@@ -16,26 +16,27 @@ def _extract_boards(obj: object) -> Iterable[np.ndarray]:
     """
 
     if isinstance(obj, dict):
-        if "board" in obj:
-            yield np.array(obj["board"], dtype=int)
+        if "board" in obj and "target" in obj:
+            yield (np.array(obj["board"], dtype=int), int(obj["target"]))
         elif "boards" in obj:
-            for board in obj["boards"]:
-                yield np.array(board, dtype=int)
+            for item in obj["boards"]:
+                if isinstance(item, dict) and "board" in item and "target" in item:
+                    yield (np.array(item["board"], dtype=int), int(item["target"]))
     elif isinstance(obj, list):
-        if obj and isinstance(obj[0], list) and obj[0] and isinstance(obj[0][0], list):
-            for board in obj:
-                yield np.array(board, dtype=int)
+        for item in obj:
+            if isinstance(item, dict) and "board" in item and "target" in item:
+                yield (np.array(item["board"], dtype=int), int(item["target"]))
 
 
-def load_boards_from_archives(data_dir: str) -> List[np.ndarray]:
-    """Recursively load boards from ``data_dir``.
+def load_boards_from_archives(data_dir: str) -> List[Tuple[np.ndarray, int]]:
+    """Recursively load boards and targets from ``data_dir``.
 
     All ``.json`` files and JSON files inside ``.zip`` archives are read and
     converted to ``numpy`` arrays. Files may contain a single object with a
     ``board`` field or a list of boards.
     """
 
-    boards: List[np.ndarray] = []
+    boards: List[Tuple[np.ndarray, int]] = []
     for root, _, files in os.walk(data_dir):
         for fname in files:
             path = os.path.join(root, fname)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,13 +1,13 @@
 import logging
 from pathlib import Path
+
 import torch
 
 
 def setup_logger() -> logging.Logger:
     """Configure and return a simple logger."""
     logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s: %(message)s"
+        level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
     )
     return logging.getLogger("scratch")
 
@@ -17,7 +17,7 @@ def save_checkpoint(
     optimizer: torch.optim.Optimizer,
     epoch: int,
     directory: str = "checkpoints",
-    prefix: str = ""
+    prefix: str = "",
 ) -> None:
     """Save model checkpoint, optionally with a filename prefix."""
     # Ensure the directory exists


### PR DESCRIPTION
## Summary
- extend `load_boards_from_archives` to read `(board, target)` pairs
- update `ScratchCardDataset` to store targets and return them from `__getitem__`
- adapt training script for new loader output
- adjust tests for dataset and I/O utilities
- run `black`/`isort` on affected files

## Testing
- `black --check . && isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fc326ea08324b1d8124d56635626