### PR TITLE
Handle blank cells using -1

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ except Exception:  # torch may be unavailable in minimal runtimes
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
+from dataset import BLANK_VALUE
 from model import DynamicMET
 
 logging.basicConfig(
@@ -42,7 +43,9 @@ def health():
 
 
 class PredictRequest(BaseModel):
-    board: List[List[int]] = Field(..., description="2D grid, blanks use -1.")
+    board: List[List[int]] = Field(
+        ..., description=f"2D grid, blanks use {BLANK_VALUE}."
+    )
     # 兩個欄位都接受，擇一或兩者皆送都行
     target: Optional[int] = Field(None, description="Preferred. Target number.")
     target_value: Optional[int] = Field(
@@ -146,9 +149,9 @@ def predict(req: PredictRequest):
     flat_all = board.flatten()
     valid_values = set(range(1, n + 1))
     for v in flat_all:
-        if v != -1 and v not in valid_values:
+        if v != BLANK_VALUE and v not in valid_values:
             raise HTTPException(status_code=422, detail="board values out of range")
-    non_blank = flat_all[flat_all != -1]
+    non_blank = flat_all[flat_all != BLANK_VALUE]
     if non_blank.size != len(set(non_blank.tolist())):
         raise HTTPException(status_code=422, detail="board has duplicate numbers")
     target = req.target
@@ -163,9 +166,11 @@ def predict(req: PredictRequest):
     )  # 中文log：記錄盤面大小與目標數字
 
     flat = board.flatten()
-    mask_pos = np.where(flat == -1)[0]
+    mask_pos = np.where(flat == BLANK_VALUE)[0]
     if mask_pos.size == 0:
-        raise HTTPException(status_code=422, detail="no blank cells (-1) to predict")
+        raise HTTPException(
+            status_code=422, detail=f"no blank cells ({BLANK_VALUE}) to predict"
+        )
 
     # ensure contiguous int64 array to avoid torch dtype inference errors
     flat_input = np.where(flat < 0, 0, flat).astype(np.int64, copy=False)

--- a/dataset.py
+++ b/dataset.py
@@ -13,6 +13,24 @@ except Exception:  # pragma: no cover - torch missing
     TORCH_AVAILABLE = False
 
 MASK_TOKEN_ID = 0
+BLANK_VALUE = -1
+
+
+def validate_board(board: np.ndarray) -> None:
+    """Validate board contents.
+
+    Ensures numbers are unique and within ``1..N`` where ``N`` is the board
+    size. ``BLANK_VALUE`` (-1) is allowed to denote empty cells.
+    """
+    n = board.size
+    valid_values = set(range(1, n + 1))
+    flat = board.ravel()
+    for v in flat:
+        if v != BLANK_VALUE and v not in valid_values:
+            raise ValueError("board values out of range")
+    non_blank = flat[flat != BLANK_VALUE]
+    if non_blank.size != len(set(non_blank.tolist())):
+        raise ValueError("board has duplicate numbers")
 
 
 class ScratchCardDataset(Dataset):
@@ -30,6 +48,8 @@ class ScratchCardDataset(Dataset):
         self, boards: List[Tuple[np.ndarray, int]], mask_ratio: float = 0.6
     ) -> None:
         self.boards, self.targets = zip(*boards)
+        for b in self.boards:
+            validate_board(np.asarray(b))
         self.mask_ratio = mask_ratio
 
     def __len__(self) -> int:  # noqa: D401
@@ -41,14 +61,17 @@ class ScratchCardDataset(Dataset):
         if not TORCH_AVAILABLE:
             raise RuntimeError("Torch is required for ScratchCardDataset")
 
-        board = torch.from_numpy(self.boards[idx].flatten()).long()
+        board_arr = self.boards[idx].flatten()
+        board = torch.from_numpy(board_arr).long()
         target = torch.tensor(int(self.targets[idx])).long()
         mask = torch.rand(board.shape) < self.mask_ratio
+        mask |= board == BLANK_VALUE
         inp = board.clone()
         inp[mask] = MASK_TOKEN_ID
+        orig = torch.where(board == BLANK_VALUE, MASK_TOKEN_ID, board)
         return {
             "input_vals": inp,
             "mask": mask,
-            "orig_vals": board,
+            "orig_vals": orig,
             "target": target,
         }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,13 +1,14 @@
 import numpy as np
 import pytest
 
-from dataset import MASK_TOKEN_ID, ScratchCardDataset
+from dataset import BLANK_VALUE, MASK_TOKEN_ID  # isort: split
+from dataset import ScratchCardDataset, validate_board
 
 torch = pytest.importorskip("torch")
 
 
 def test_dataset_mask_ratio() -> None:
-    data = [(np.arange(12).reshape(3, 4), 7)]
+    data = [(np.arange(1, 13).reshape(3, 4), 7)]
     torch.manual_seed(0)  # ensure deterministic mask
     ds = ScratchCardDataset(data, mask_ratio=0.6)
     item = ds[0]
@@ -15,3 +16,15 @@ def test_dataset_mask_ratio() -> None:
     assert mask.mean() == pytest.approx(0.6, rel=0.3)
     assert (item["input_vals"][mask] == MASK_TOKEN_ID).all()
     assert item["target"].item() == 7
+
+
+def test_dataset_validation_duplicate() -> None:
+    board = np.array([[1, 2], [2, BLANK_VALUE]])
+    with pytest.raises(ValueError):
+        ScratchCardDataset([(board, 1)])
+
+
+def test_dataset_validation_range() -> None:
+    board = np.array([[0, 1], [2, BLANK_VALUE]])
+    with pytest.raises(ValueError):
+        validate_board(board)

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ import yaml
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from dataset import MASK_TOKEN_ID, ScratchCardDataset
+from dataset import MASK_TOKEN_ID, ScratchCardDataset, validate_board
 from model import DynamicMET
 from utils.io_utils import load_boards_from_archives
 from utils.logger import save_checkpoint, setup_logger
@@ -51,6 +51,8 @@ def main() -> None:
     boards = load_boards_from_archives(cfg["data"]["data_dir"])
     if not boards:
         raise ValueError("No boards loaded from data_dir")
+    for b, _ in boards:
+        validate_board(b)
 
     # Group boards by shape
     shape_groups = {}


### PR DESCRIPTION
## Summary
- centralize blank token constant and validation logic
- validate boards during training
- adjust API to use BLANK_VALUE constant
- test dataset validation for duplicates and range

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688630bf3a1c83248eef6189806911d9