### PR TITLE
Fix MET agent blank filtering

### DIFF
--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -12,53 +12,49 @@ except Exception:  # pragma: no cover - torch missing
     torch = None  # type: ignore[assignment]
     TORCH_AVAILABLE = False
 
+from dataset import BLANK_VALUE
 from model import DynamicMET
+from utils import ensure_only_blank
 
 
 def predict(
-    board: np.ndarray, target: int, *, model: DynamicMET, topk: int = 3
+    board: np.ndarray, *, target: int, model: DynamicMET, topk: int = 3
 ) -> List[Dict[str, Any]]:
-    """Predict top-k positions for ``target`` using ``model``.
-
-    Parameters
-    ----------
-    board : np.ndarray
-        Board array containing integers. ``-1`` denotes empty cells.
-    target : int
-        Target value to locate.
-    model : DynamicMET
-        Pretrained model used for prediction.
-    topk : int, optional
-        Number of positions to return, by default ``3``.
-
-    Returns
-    -------
-    List[Dict[str, Any]]
-        Each dictionary contains ``row``, ``col`` and ``score`` fields.
-    """
+    """Predict top-k blank positions for ``target`` using ``model``."""
 
     shape = board.shape
-    board_proc = np.where(board < 0, 0, board).astype(int)
+    flat = board.flatten()
 
-    if TORCH_AVAILABLE:
-        inp = torch.tensor(board_proc.flatten()).long().unsqueeze(0)
-        if hasattr(model, "eval"):
-            model.eval()
-        with torch.no_grad():
-            logits = model(inp)
-            probs = torch.softmax(logits, dim=-1)[0, :, target]
-            scores, indices = torch.topk(probs, k=topk)
-        scores_list = scores.tolist()
-        indices_list = indices.tolist()
-    else:
-        inp = board_proc.flatten().reshape(1, -1)
+    mask_pos = np.where(flat == BLANK_VALUE)[0]
+    if mask_pos.size == 0:
+        return []
+
+    if TORCH_AVAILABLE and isinstance(model, torch.nn.Module):
+        inp = torch.as_tensor(np.where(flat < 0, 0, flat), dtype=torch.long).unsqueeze(
+            0
+        )
         logits = model(inp)
-        probs = np.asarray(logits)[0, :, target]
-        indices_list = np.argsort(probs)[-topk:][::-1].tolist()
-        scores_list = probs[indices_list].tolist()
+        probs = torch.softmax(logits, dim=-1)
+        V = probs.shape[-1]
+        target_idx = target if V == flat.size + 1 else target - 1
+        scores_all = probs[0, :, target_idx].detach().cpu().numpy()
+    else:
+        inp = np.where(flat < 0, 0, flat).reshape(1, -1).astype(np.int64, copy=False)
+        logits = model(inp)
+        arr = np.asarray(logits)
+        V = arr.shape[-1]
+        target_idx = target if V == flat.size + 1 else target - 1
+        scores_all = arr[0, :, target_idx]
+
+    cand_scores = scores_all[mask_pos]
+    k = min(topk, cand_scores.size)
+    if k == 0:
+        return []
+    local_idx = np.argsort(cand_scores)[-k:][::-1]
+    top_indices = mask_pos[local_idx]
 
     results: List[Dict[str, Any]] = []
-    for score, idx in zip(scores_list, indices_list):
+    for idx in top_indices:
         r, c = divmod(int(idx), shape[1])
-        results.append({"row": r, "col": c, "score": float(score)})
-    return results
+        results.append({"row": r, "col": c, "score": float(scores_all[idx])})
+    return ensure_only_blank(board, results, BLANK_VALUE)

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from dataset import BLANK_VALUE
 from model import DynamicMET
+from utils import ensure_only_blank
 
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO"),
@@ -144,6 +145,10 @@ def predict(req: PredictRequest):
         )
 
     board = np.asarray(req.board, dtype=int)
+    uniq, cnt = np.unique(board, return_counts=True)
+    logger.info(
+        "[CHK] uniq=%s cnt=%s BLANK_VALUE=%s", uniq.tolist(), cnt.tolist(), BLANK_VALUE
+    )
     rows, cols = board.shape
     n = rows * cols
     flat_all = board.flatten()
@@ -171,6 +176,7 @@ def predict(req: PredictRequest):
         raise HTTPException(
             status_code=422, detail=f"no blank cells ({BLANK_VALUE}) to predict"
         )
+    logger.info("[CHK] mask_pos=%s", mask_pos.tolist())
 
     # ensure contiguous int64 array to avoid torch dtype inference errors
     flat_input = np.where(flat < 0, 0, flat).astype(np.int64, copy=False)
@@ -239,10 +245,12 @@ def predict(req: PredictRequest):
         "從 %s 個候選格中挑選前 %s 名", len(candidate_scores), len(topk_local)
     )  # 中文log：候選格與返回數量
     top_indices = mask_pos[topk_local]
+    logger.info("[CHK] top_indices=%s", top_indices.tolist())
 
-    return [
+    raw = [
         Prediction(
             row=int(idx // cols), col=int(idx % cols), score=float(scores_np[idx])
         )
         for idx in top_indices
     ]
+    return ensure_only_blank(board, raw, BLANK_VALUE)

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -22,3 +22,21 @@ def test_met_agent_predict_on_10x12() -> None:
     for item in result:
         assert isinstance(item, dict)
         assert "row" in item and "col" in item and "score" in item
+
+
+def test_met_agent_only_returns_blank() -> None:
+    rows, cols = 4, 5
+    board = np.array(
+        [
+            [1, -1, 3, 4, 5],
+            [6, 7, -1, 9, 10],
+            [11, 12, 13, -1, 15],
+            [16, -1, 18, 19, 20],
+        ]
+    )
+    model = DynamicMET(rows * cols, rows * cols + 1)
+    target = 15
+    res = predict(board.copy(), target=target, model=model, topk=3)
+    assert len(res) <= 3
+    for item in res:
+        assert board[item["row"], item["col"]] == -1

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+from .guard import ensure_only_blank
+
+__all__ = ["ensure_only_blank"]

--- a/utils/guard.py
+++ b/utils/guard.py
@@ -1,0 +1,27 @@
+"""Guard helpers for scratch card predictions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+import numpy as np
+
+
+def ensure_only_blank(board: np.ndarray, preds: Iterable[Any], blank_value: int = -1):
+    """Filter predictions to ensure returned positions are blank."""
+    rows, cols = board.shape
+    flat = board.ravel()
+    out = []
+    bad = []
+    for p in preds:
+        r = p["row"] if isinstance(p, dict) else getattr(p, "row")
+        c = p["col"] if isinstance(p, dict) else getattr(p, "col")
+        idx = r * cols + c
+        if 0 <= idx < flat.size and flat[idx] == blank_value:
+            out.append(p)
+        else:
+            bad.append((r, c))
+    if bad:
+        logging.getLogger(__name__).error("[GUARD] filtered non-blank cells: %s", bad)
+    return out


### PR DESCRIPTION
## Summary
- ensure all predictions refer to blank cells only
- add guard utility and integrate with API
- log candidate and final indices
- test MET agent returns only blanks

## Testing
- `black . --check`
- `isort . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688644cc14888324908e3baf850bd78a