### PR TITLE
Implement guard for blank-only predictions

### DIFF
--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -21,29 +21,36 @@ def predict(
     board: np.ndarray, *, target: int, model: DynamicMET, topk: int = 3
 ) -> List[Dict[str, Any]]:
     """Predict top-k blank positions for ``target`` using ``model``."""
-
-    shape = board.shape
+    rows, cols = board.shape
     flat = board.flatten()
 
     mask_pos = np.where(flat == BLANK_VALUE)[0]
     if mask_pos.size == 0:
         return []
 
+    arr_inp = np.where(flat < 0, 0, flat)
+
     if TORCH_AVAILABLE and isinstance(model, torch.nn.Module):
-        inp = torch.as_tensor(np.where(flat < 0, 0, flat), dtype=torch.long).unsqueeze(
-            0
-        )
+        inp = torch.as_tensor(arr_inp, dtype=torch.long).unsqueeze(0)
         logits = model(inp)
         probs = torch.softmax(logits, dim=-1)
         V = probs.shape[-1]
         target_idx = target if V == flat.size + 1 else target - 1
+        if not (0 <= target_idx < V):
+            raise RuntimeError(
+                f"target_idx out of range: target={target} -> {target_idx}, V={V}"
+            )
         scores_all = probs[0, :, target_idx].detach().cpu().numpy()
     else:
-        inp = np.where(flat < 0, 0, flat).reshape(1, -1).astype(np.int64, copy=False)
+        inp = arr_inp.reshape(1, -1).astype(np.int64, copy=False)
         logits = model(inp)
         arr = np.asarray(logits)
         V = arr.shape[-1]
         target_idx = target if V == flat.size + 1 else target - 1
+        if not (0 <= target_idx < V):
+            raise RuntimeError(
+                f"target_idx out of range: target={target} -> {target_idx}, V={V}"
+            )
         scores_all = arr[0, :, target_idx]
 
     cand_scores = scores_all[mask_pos]
@@ -55,6 +62,6 @@ def predict(
 
     results: List[Dict[str, Any]] = []
     for idx in top_indices:
-        r, c = divmod(int(idx), shape[1])
+        r, c = divmod(int(idx), cols)
         results.append({"row": r, "col": c, "score": float(scores_all[idx])})
     return ensure_only_blank(board, results, BLANK_VALUE)

--- a/app.py
+++ b/app.py
@@ -247,6 +247,13 @@ def predict(req: PredictRequest):
     top_indices = mask_pos[topk_local]
     logger.info("[CHK] top_indices=%s", top_indices.tolist())
 
+    picked_vals = [int(flat[idx]) for idx in top_indices]
+    logger.info(
+        "[CHK] picked vals=%s (should all be BLANK_VALUE=%s)",
+        picked_vals,
+        BLANK_VALUE,
+    )
+
     raw = [
         Prediction(
             row=int(idx // cols), col=int(idx % cols), score=float(scores_np[idx])

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from agents.met_agent import predict
+from dataset import BLANK_VALUE
 from model import DynamicMET
 
 
@@ -11,8 +12,8 @@ def test_met_agent_predict_on_10x12() -> None:
     blank_indices = rng.choice(rows * cols, size=rng.integers(15, 26), replace=False)
     for idx in blank_indices:
         r, c = divmod(idx, cols)
-        grid[r, c] = -1
-    non_blanks = np.argwhere(grid != -1)
+        grid[r, c] = BLANK_VALUE
+    non_blanks = np.argwhere(grid != BLANK_VALUE)
     target_r, target_c = non_blanks[rng.integers(len(non_blanks))]
     target = int(grid[target_r, target_c])
     model = DynamicMET(rows * cols, 100)
@@ -28,10 +29,10 @@ def test_met_agent_only_returns_blank() -> None:
     rows, cols = 4, 5
     board = np.array(
         [
-            [1, -1, 3, 4, 5],
-            [6, 7, -1, 9, 10],
-            [11, 12, 13, -1, 15],
-            [16, -1, 18, 19, 20],
+            [1, BLANK_VALUE, 3, 4, 5],
+            [6, 7, BLANK_VALUE, 9, 10],
+            [11, 12, 13, BLANK_VALUE, 15],
+            [16, BLANK_VALUE, 18, 19, 20],
         ]
     )
     model = DynamicMET(rows * cols, rows * cols + 1)
@@ -39,4 +40,4 @@ def test_met_agent_only_returns_blank() -> None:
     res = predict(board.copy(), target=target, model=model, topk=3)
     assert len(res) <= 3
     for item in res:
-        assert board[item["row"], item["col"]] == -1
+        assert board[item["row"], item["col"]] == BLANK_VALUE

--- a/tests/test_api_only_blank.py
+++ b/tests/test_api_only_blank.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from app import app
+from dataset import BLANK_VALUE
+
+client = TestClient(app)
+
+
+def test_api_predict_only_blank():
+    board = [
+        [1, BLANK_VALUE, 3, 4, 5],
+        [6, 7, BLANK_VALUE, 9, 10],
+        [11, 12, 13, BLANK_VALUE, 15],
+        [16, BLANK_VALUE, 18, 19, 20],
+    ]
+    response = client.post("/predict", json={"board": board, "target": 15})
+    assert response.status_code == 200
+    data = response.json()
+    for item in data:
+        r0, c0 = item["row"], item["col"]
+        assert board[r0][c0] == BLANK_VALUE

--- a/utils/guard.py
+++ b/utils/guard.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterable
+from typing import Any, Iterable, List, Sequence
 
 import numpy as np
 
+from dataset import BLANK_VALUE
 
-def ensure_only_blank(board: np.ndarray, preds: Iterable[Any], blank_value: int = -1):
+
+def ensure_only_blank(
+    board: np.ndarray, preds: Iterable[Any], blank_value: int = BLANK_VALUE
+) -> List[Any]:
     """Filter predictions to ensure returned positions are blank."""
     rows, cols = board.shape
     flat = board.ravel()
-    out = []
-    bad = []
+    out: List[Any] = []
+    bad: List[Sequence[int]] = []
     for p in preds:
         r = p["row"] if isinstance(p, dict) else getattr(p, "row")
         c = p["col"] if isinstance(p, dict) else getattr(p, "col")
@@ -23,5 +27,9 @@ def ensure_only_blank(board: np.ndarray, preds: Iterable[Any], blank_value: int 
         else:
             bad.append((r, c))
     if bad:
-        logging.getLogger(__name__).error("[GUARD] filtered non-blank cells: %s", bad)
+        logging.getLogger(__name__).error(
+            "[GUARD] filtered non-blank cells: %s values=%s",
+            bad,
+            [int(flat[r * cols + c]) for (r, c) in bad],
+        )
     return out


### PR DESCRIPTION
## Summary
- tighten guard by defaulting to `BLANK_VALUE` and logging filtered cells
- verify target index range in MET agent and use blank mask on input
- expose picked cell values from API for observability
- update tests to rely on `BLANK_VALUE`
- add API test ensuring only blank cells returned

## Testing
- `isort --check --diff .`
- `black --check agents/met_agent.py app.py utils/guard.py tests/test_agents/test_met_agent.py tests/test_api_only_blank.py`
- `flake8 agents/met_agent.py app.py utils/guard.py tests/test_agents/test_met_agent.py tests/test_api_only_blank.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68864eb02b408324bf14e04bb57883b0