### PR TITLE
Update API to use 1-based positions

### DIFF
--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -64,4 +64,8 @@ def predict(
     for idx in top_indices:
         r, c = index_to_coord(int(idx), board.shape)
         results.append({"row": r, "col": c, "score": float(scores_all[idx])})
-    return ensure_only_blank(board, results, BLANK_VALUE)
+    results = ensure_only_blank(board, results, BLANK_VALUE)
+    for item in results:
+        item["row"] += 1
+        item["col"] += 1
+    return results

--- a/app.py
+++ b/app.py
@@ -287,4 +287,8 @@ def predict(req: PredictRequest):
                 cell_value=int(flat[idx]),
             )
         )
-    return ensure_only_blank(board, raw, BLANK_VALUE)
+    validated = ensure_only_blank(board, raw, BLANK_VALUE)
+    for item in validated:
+        item.row += 1
+        item.col += 1
+    return validated

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -40,4 +40,5 @@ def test_met_agent_only_returns_blank() -> None:
     res = predict(board.copy(), target=target, model=model, topk=3)
     assert len(res) <= 3
     for item in res:
-        assert board[item["row"], item["col"]] == BLANK_VALUE
+        r0, c0 = item["row"] - 1, item["col"] - 1
+        assert board[r0, c0] == BLANK_VALUE

--- a/tests/test_api_only_blank.py
+++ b/tests/test_api_only_blank.py
@@ -19,7 +19,7 @@ def test_api_predict_only_blank() -> None:
     # 應至少回傳一筆
     assert isinstance(data, list) and len(data) > 0
     for item in data:
-        r0, c0 = item["row"], item["col"]
+        r0, c0 = item["row"] - 1, item["col"] - 1
         assert board[r0][c0] == BLANK_VALUE
         # 驗證 debug 欄位
         assert item.get("idx") is not None

--- a/tests/test_blank_top3.py
+++ b/tests/test_blank_top3.py
@@ -13,5 +13,5 @@ def test_predict_only_blank_top3():
     payload = appmod.PredictRequest(board=board, target=1)
     result = appmod.predict(payload)
     assert len(result) == 2
-    blank_positions = {(0, 1), (1, 0)}
+    blank_positions = {(1, 2), (2, 1)}
     assert all((item.row, item.col) in blank_positions for item in result)


### PR DESCRIPTION
## Summary
- shift returned coordinates to 1-based indexing in `app.py`
- adjust `met_agent.predict` to output 1-based rows/cols
- update unit tests expecting 1-based indices

## Testing
- `isort --check --diff .`
- `black --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c269274083249926bfacf847ebcc