### PR TITLE
Upgrade model skeleton with RoPE blocks

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,24 +1,18 @@
 try:
     import torch
     import torch.nn as nn
-    from torch.nn import TransformerEncoder, TransformerEncoderLayer
 
     TORCH_AVAILABLE = True
 except Exception:  # pragma: no cover - torch missing
-    torch = None
-    nn = None  # type: ignore
-    TransformerEncoder = TransformerEncoderLayer = None  # type: ignore
+    torch = None  # type: ignore[assignment]
+    nn = object  # type: ignore[misc]
     TORCH_AVAILABLE = False
+
+from models.blocks import TransformerBlock
 
 
 class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
-    """Dynamic Masked Encoding Transformer for scratch-card boards.
-
-    類別索引規則：
-    - 0 = MASK（保留，不作為實際數字）
-    - 1..N = 盤面實際數字（唯一）
-    因此輸出維度為 N+1，訓緻時使用 ``ignore_index=0``。
-    """
+    """Simple transformer-like model for tabular scratch card prediction."""
 
     def __init__(
         self,
@@ -27,40 +21,42 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
         d_model: int = 128,
         nhead: int = 4,
         depth: int = 6,
+        dropout: float = 0.0,
+        use_flash: bool = False,
     ) -> None:
-        # num_values = N (R*C)
-        # logits dimension is N+1 with class 0 reserved for MASK
-        self.num_fields = num_fields
-        self.num_values = num_values
+        self.num_fields = int(num_fields)
+        self.num_values = int(num_values)
+        self.d_model = int(d_model)
         if TORCH_AVAILABLE:
             super().__init__()  # type: ignore[misc]
-            # Embeddings for values and positions
-            self.value_embed = nn.Embedding(num_values + 1, d_model)
-            self.field_embed = nn.Embedding(num_fields, d_model)
-            # Use batch_first to support nested tensor optimization
-            encoder_layer = TransformerEncoderLayer(d_model, nhead, batch_first=True)
-            # Enable nested tensor for potential speed and memory benefits
-            self.transformer = TransformerEncoder(
-                encoder_layer, num_layers=depth, enable_nested_tensor=True
+            self.token_emb = nn.Embedding(num_values + 1, d_model)
+            self.blocks = nn.ModuleList(
+                [
+                    TransformerBlock(
+                        d_model,
+                        nhead,
+                        dropout=dropout,
+                        hidden_mult=2.0,
+                        use_flash=use_flash,
+                    )
+                    for _ in range(depth)
+                ]
             )
+            self.norm_out = nn.LayerNorm(d_model)
             self.head = nn.Linear(d_model, num_values + 1)
 
-    def forward(self, input_vals):  # type: ignore[override]
-        """Forward pass returning logits for each position."""
+    def forward(self, x: "torch.Tensor") -> "torch.Tensor":  # type: ignore[override]
         if TORCH_AVAILABLE:
-            assert isinstance(input_vals, torch.Tensor)
-            bsz, fields = input_vals.shape
-            # value embedding + positional embedding
-            x = self.value_embed(input_vals)
-            pos = self.field_embed(torch.arange(fields, device=x.device))
-            x = x + pos.unsqueeze(0)
-            # Transformer expects (batch, seq, dim) with batch_first
-            z = self.transformer(x)
-            return self.head(z)
+            tok = self.token_emb(x)
+            h = tok
+            for blk in self.blocks:
+                h = blk(h, attn_mask=None)
+            h = self.norm_out(h)
+            logits = self.head(h)
+            return logits
         import numpy as np
 
-        # Fallback: return zeros
-        bsz, fields = input_vals.shape
+        bsz, fields = x.shape
         return np.zeros((bsz, fields, self.num_values + 1), dtype=float)
 
     __call__ = forward

--- a/models/blocks.py
+++ b/models/blocks.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+
+    TORCH_AVAILABLE = True
+except Exception:  # pragma: no cover - torch missing
+    torch = None  # type: ignore[assignment]
+    nn = object  # type: ignore[misc]
+    F = None  # type: ignore[assignment]
+    TORCH_AVAILABLE = False
+
+try:
+    from flash_attn import flash_attn_func  # type: ignore
+
+    HAS_FLASH = True
+except Exception:  # pragma: no cover
+    HAS_FLASH = False
+
+from utils.rope import apply_rope, build_rope_cache
+
+if not TORCH_AVAILABLE:
+
+    class RMSNorm:  # type: ignore[misc]
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("torch is required for RMSNorm")
+
+    class SwiGLU:  # type: ignore[misc]
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("torch is required for SwiGLU")
+
+    @dataclass
+    class AttnConfig:
+        dim: int
+        n_heads: int
+        dropout: float = 0.0
+        rope_base: float = 10_000.0
+        use_flash: bool = False
+
+    class RoPEAttention:  # type: ignore[misc]
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("torch is required for RoPEAttention")
+
+    class TransformerBlock:  # type: ignore[misc]
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("torch is required for TransformerBlock")
+
+else:
+
+    class RMSNorm(nn.Module):
+        """RMSNorm，較 LayerNorm 穩定、便宜。"""
+
+        def __init__(self, dim: int, eps: float = 1e-6):
+            super().__init__()
+            self.eps = eps
+            self.weight = nn.Parameter(torch.ones(dim))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+            rms = x.pow(2).mean(dim=-1, keepdim=True).add(self.eps).rsqrt()
+            return self.weight * x * rms
+
+    class SwiGLU(nn.Module):
+        """SwiGLU 前饋，提升表示力與穩定性。"""
+
+        def __init__(self, dim: int, hidden_mult: float = 2.0, dropout: float = 0.0):
+            super().__init__()
+            hidden = int(dim * hidden_mult)
+            self.w1 = nn.Linear(dim, hidden, bias=False)
+            self.w2 = nn.Linear(dim, hidden, bias=False)
+            self.proj = nn.Linear(hidden, dim, bias=False)
+            self.dropout = nn.Dropout(dropout)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+            a = self.w1(x)
+            b = self.w2(x)
+            x = F.silu(a) * b
+            x = self.proj(x)
+            return self.dropout(x)
+
+    @dataclass
+    class AttnConfig:
+        dim: int
+        n_heads: int
+        dropout: float = 0.0
+        rope_base: float = 10_000.0
+        use_flash: bool = False
+
+    class RoPEAttention(nn.Module):
+        """多頭注意力，內建 RoPE，可選 FlashAttention-2。"""
+
+        def __init__(self, cfg: AttnConfig):
+            super().__init__()
+            assert cfg.dim % cfg.n_heads == 0, "dim must be divisible by n_heads"
+            self.cfg = cfg
+            self.head_dim = cfg.dim // cfg.n_heads
+            self.qkv = nn.Linear(cfg.dim, cfg.dim * 3, bias=False)
+            self.out = nn.Linear(cfg.dim, cfg.dim, bias=False)
+            self.attn_dropout = nn.Dropout(cfg.dropout)
+            self.resid_dropout = nn.Dropout(cfg.dropout)
+            self.register_buffer("_cos", torch.empty(0), persistent=False)
+            self.register_buffer("_sin", torch.empty(0), persistent=False)
+
+        def _rope_cache(
+            self, seq_len: int, device: torch.device
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
+            if (
+                self._cos.numel() == 0
+                or self._cos.size(0) < seq_len
+                or self._cos.device != device
+            ):
+                cos, sin = build_rope_cache(
+                    seq_len, self.head_dim, base=self.cfg.rope_base, device=device
+                )
+                self._cos = cos
+                self._sin = sin
+            return self._cos[:seq_len], self._sin[:seq_len]
+
+        def forward(
+            self, x: torch.Tensor, attn_mask: Optional[torch.Tensor] = None
+        ) -> torch.Tensor:
+            B, N, D = x.shape
+            qkv = self.qkv(x)
+            q, k, v = qkv.chunk(3, dim=-1)
+            H = self.cfg.n_heads
+            q = q.view(B, N, H, self.head_dim).transpose(1, 2)
+            k = k.view(B, N, H, self.head_dim).transpose(1, 2)
+            v = v.view(B, N, H, self.head_dim).transpose(1, 2)
+
+            cos, sin = self._rope_cache(N, x.device)
+            q, k = apply_rope(q, k, cos, sin)
+
+            if self.cfg.use_flash and HAS_FLASH and x.is_cuda:
+                q_f = q.transpose(1, 2)
+                k_f = k.transpose(1, 2)
+                v_f = v.transpose(1, 2)
+                out = flash_attn_func(
+                    q_f,
+                    k_f,
+                    v_f,
+                    dropout_p=self.cfg.dropout if self.training else 0.0,
+                    softmax_scale=None,
+                    causal=False,
+                )
+                out = out.transpose(1, 2).contiguous()
+            else:
+                att = torch.matmul(q, k.transpose(-2, -1)) / (self.head_dim**0.5)
+                if attn_mask is not None:
+                    att = att.masked_fill(attn_mask == 0, float("-inf"))
+                att = torch.softmax(att, dim=-1)
+                att = self.attn_dropout(att)
+                out = torch.matmul(att, v)
+
+            out = out.transpose(1, 2).contiguous().view(B, N, D)
+            out = self.out(out)
+            return self.resid_dropout(out)
+
+    class TransformerBlock(nn.Module):
+        def __init__(
+            self,
+            dim: int,
+            n_heads: int,
+            dropout: float = 0.0,
+            hidden_mult: float = 2.0,
+            use_flash: bool = False,
+        ):
+            super().__init__()
+            self.norm1 = RMSNorm(dim)
+            self.attn = RoPEAttention(
+                AttnConfig(
+                    dim=dim, n_heads=n_heads, dropout=dropout, use_flash=use_flash
+                )
+            )
+            self.norm2 = RMSNorm(dim)
+            self.ff = SwiGLU(dim, hidden_mult=hidden_mult, dropout=dropout)
+
+        def forward(
+            self, x: torch.Tensor, attn_mask: Optional[torch.Tensor] = None
+        ) -> torch.Tensor:  # noqa: D401
+            x = x + self.attn(self.norm1(x), attn_mask)
+            x = x + self.ff(self.norm2(x))
+            return x

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,4 @@
 from .guard import ensure_only_blank, index_to_coord
+from .rope import apply_rope, build_rope_cache
 
-__all__ = ["ensure_only_blank", "index_to_coord"]
+__all__ = ["ensure_only_blank", "index_to_coord", "build_rope_cache", "apply_rope"]

--- a/utils/rope.py
+++ b/utils/rope.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except Exception:  # pragma: no cover - torch missing
+    torch = None  # type: ignore[assignment]
+    TORCH_AVAILABLE = False
+
+
+def build_rope_cache(
+    seq_len: int, dim: int, base: float = 10_000.0, device: torch.device | None = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    建立 RoPE 需要的 cos/sin 快取。
+    dim 需為偶數（對偶維度旋轉），若為奇數會自動補到偶數最後一維不旋轉。
+    回傳張量 shape: (seq_len, dim)
+    """
+    half = dim // 2
+    theta = torch.arange(half, device=device, dtype=torch.float32)
+    theta = 1.0 / (base ** (theta / half))
+    pos = torch.arange(seq_len, device=device, dtype=torch.float32).unsqueeze(1)
+    angles = pos * theta.unsqueeze(0)
+    cos = torch.cos(angles)
+    sin = torch.sin(angles)
+    if dim % 2 == 1:
+        cos = torch.nn.functional.pad(cos, (0, 1))
+        sin = torch.nn.functional.pad(sin, (0, 1))
+    return cos, sin
+
+
+def apply_rope(q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor):
+    """對 q,k 套用 RoPE"""
+    cos = cos.unsqueeze(0).unsqueeze(0)
+    sin = sin.unsqueeze(0).unsqueeze(0)
+
+    def _rotate(x: torch.Tensor) -> torch.Tensor:
+        x_even = x[..., ::2]
+        x_odd = x[..., 1::2]
+        x_rot_even = -x_odd
+        x_rot_odd = x_even
+        out = torch.empty_like(x)
+        out[..., ::2] = x_rot_even
+        out[..., 1::2] = x_rot_odd
+        if x.shape[-1] % 2 == 1:
+            out[..., -1] = 0
+        return out
+
+    q_rot = _rotate(q)
+    k_rot = _rotate(k)
+    q_out = q * cos + q_rot * sin
+    k_out = k * cos + k_rot * sin
+    return q_out, k_out


### PR DESCRIPTION
## Summary
- add RoPE utilities and transformer blocks with optional FlashAttention
- export new utilities from `utils`
- refactor `DynamicMET` to use new transformer blocks

## Testing
- `isort --check .`
- `black --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688756a52f908324a217edc33003c69a