### PR TITLE
Ensure target masking in dataset

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -90,8 +90,18 @@ class ScratchCardDataset(Dataset):
             ratio = torch.rand(1).mul_(high - low).add_(low).item()
         else:
             ratio = self.mask_ratio
-        mask = torch.rand(board.shape) < ratio
-        mask |= board == BLANK_VALUE
+        mask = torch.zeros_like(board, dtype=torch.bool)
+        blank_positions = board == BLANK_VALUE
+        mask |= blank_positions
+        target_pos = board == target
+        mask |= target_pos
+        candidates = (~blank_positions) & (~target_pos)
+        candidate_idx = torch.nonzero(candidates, as_tuple=False).squeeze(-1)
+        if candidate_idx.numel() > 0 and ratio > 0.0:
+            num_mask = int(ratio * float(candidate_idx.numel()))
+            if num_mask > 0:
+                perm = torch.randperm(candidate_idx.numel())[:num_mask]
+                mask[candidate_idx[perm]] = True
         inp = board.clone()
         inp[mask] = MASK_TOKEN_ID
         orig = torch.where(board == BLANK_VALUE, MASK_TOKEN_ID, board)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -18,6 +18,15 @@ def test_dataset_mask_ratio() -> None:
     assert item["target"].item() == 7
 
 
+def test_dataset_masks_target() -> None:
+    board = np.arange(1, 13).reshape(3, 4)
+    ds = ScratchCardDataset([(board, 7)], mask_ratio=0.0)
+    item = ds[0]
+    mask = item["mask"].reshape(board.shape)
+    target_pos = np.argwhere(board == 7)[0]
+    assert mask[tuple(target_pos)]
+
+
 def test_dataset_mask_ratio_range() -> None:
     data = [(np.arange(1, 13).reshape(3, 4), 7)]
     torch.manual_seed(0)


### PR DESCRIPTION
## Summary
- guarantee target cell is always masked when building training items
- add regression test for target masking

## Testing
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688785d04a98832494727305a8322273