### PR TITLE
Add reconstruction training mode

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -34,42 +34,56 @@ def validate_board(board: np.ndarray) -> None:
 
 
 class ScratchCardDataset(Dataset):
-    """Dataset that randomly masks board values for training.
+    """Dataset that masks board values according to a chosen policy.
 
     Parameters
     ----------
     boards : list of Tuple[np.ndarray, int]
         List of ``(board, target)`` pairs.
     mask_ratio : float or Sequence[float], optional
-        Fraction of fields to mask. When a sequence ``(min, max)`` is given,
-        a ratio is uniformly sampled from the range ``min..max`` for each item.
-        Defaults to ``0.6``.
+        Used only when ``mode`` is ``"reconstruct"``. Fraction of fields to
+        mask. When a sequence ``(min, max)`` is given, a ratio is uniformly
+        sampled from that range for each item. Defaults to ``0.6``.
+    mode : {"target", "reconstruct"}, optional
+        ``"target"`` masks only the target cell. ``"reconstruct"`` masks a
+        random fraction of cells and always includes the target. Defaults to
+        ``"reconstruct"``.
     """
 
     def __init__(
         self,
         boards: List[Tuple[np.ndarray, int]],
         mask_ratio: Union[float, Sequence[float]] = 0.6,
+        *,
+        mode: str = "reconstruct",
     ) -> None:
         self.boards, self.targets = zip(*boards)
         for b in self.boards:
             validate_board(np.asarray(b))
 
-        if isinstance(mask_ratio, Sequence) and not isinstance(
-            mask_ratio, (bytes, str)
-        ):
-            if len(mask_ratio) != 2:
-                raise ValueError("mask_ratio range must have two elements")
-            low, high = float(mask_ratio[0]), float(mask_ratio[1])
-            if not 0.0 <= low <= high <= 1.0:
-                raise ValueError("mask_ratio values must be between 0 and 1")
-            self.mask_ratio = None
-            self.mask_ratio_range = (low, high)
+        if mode not in {"target", "reconstruct"}:
+            raise ValueError("mode must be 'target' or 'reconstruct'")
+        self.mode = mode
+
+        if self.mode == "reconstruct":
+            if isinstance(mask_ratio, Sequence) and not isinstance(
+                mask_ratio, (bytes, str)
+            ):
+                if len(mask_ratio) != 2:
+                    raise ValueError("mask_ratio range must have two elements")
+                low, high = float(mask_ratio[0]), float(mask_ratio[1])
+                if not 0.0 <= low <= high <= 1.0:
+                    raise ValueError("mask_ratio values must be between 0 and 1")
+                self.mask_ratio = None
+                self.mask_ratio_range = (low, high)
+            else:
+                ratio = float(mask_ratio)
+                if not 0.0 <= ratio <= 1.0:
+                    raise ValueError("mask_ratio must be between 0 and 1")
+                self.mask_ratio = ratio
+                self.mask_ratio_range = None
         else:
-            ratio = float(mask_ratio)
-            if not 0.0 <= ratio <= 1.0:
-                raise ValueError("mask_ratio must be between 0 and 1")
-            self.mask_ratio = ratio
+            self.mask_ratio = 0.0
             self.mask_ratio_range = None
 
     def __len__(self) -> int:  # noqa: D401
@@ -83,18 +97,29 @@ class ScratchCardDataset(Dataset):
 
         board_arr = self.boards[idx].flatten()
         board = torch.from_numpy(board_arr).long()
-        target = torch.tensor(int(self.targets[idx])).long()
-        if self.mask_ratio is None:
-            assert self.mask_ratio_range is not None  # noqa: S101
-            low, high = self.mask_ratio_range
-            ratio = torch.rand(1).mul_(high - low).add_(low).item()
-        else:
-            ratio = self.mask_ratio
-        mask = torch.rand(board.shape) < ratio
-        mask |= board == BLANK_VALUE
+        target_val = int(self.targets[idx])
+        target = torch.tensor(target_val).long()
+
+        if self.mode == "reconstruct":
+            if self.mask_ratio is None:
+                assert self.mask_ratio_range is not None  # noqa: S101
+                low, high = self.mask_ratio_range
+                ratio = torch.rand(1).mul_(high - low).add_(low).item()
+            else:
+                ratio = self.mask_ratio
+            mask = torch.rand(board.shape) < ratio
+            mask |= board == target_val
+            mask |= board == BLANK_VALUE
+        else:  # target mode
+            mask = (board == target_val) | (board == BLANK_VALUE)
+
         inp = board.clone()
         inp[mask] = MASK_TOKEN_ID
-        orig = torch.where(board == BLANK_VALUE, MASK_TOKEN_ID, board)
+
+        orig = torch.full_like(board, MASK_TOKEN_ID)
+        valid_mask = mask & (board != BLANK_VALUE)
+        orig[valid_mask] = board[valid_mask]
+
         return {
             "input_vals": inp,
             "mask": mask,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,21 +7,21 @@ from dataset import ScratchCardDataset, validate_board
 torch = pytest.importorskip("torch")
 
 
-def test_dataset_mask_ratio() -> None:
+def test_dataset_reconstruct_ratio() -> None:
     data = [(np.arange(1, 13).reshape(3, 4), 7)]
     torch.manual_seed(0)  # ensure deterministic mask
-    ds = ScratchCardDataset(data, mask_ratio=0.6)
+    ds = ScratchCardDataset(data, mask_ratio=0.6, mode="reconstruct")
     item = ds[0]
     mask = item["mask"].numpy()
     assert mask.mean() == pytest.approx(0.6, rel=0.3)
     assert (item["input_vals"][mask] == MASK_TOKEN_ID).all()
-    assert item["target"].item() == 7
+    assert item["orig_vals"][mask].ne(MASK_TOKEN_ID).all()
 
 
 def test_dataset_mask_ratio_range() -> None:
     data = [(np.arange(1, 13).reshape(3, 4), 7)]
     torch.manual_seed(0)
-    ds = ScratchCardDataset(data, mask_ratio=(0.3, 0.7))
+    ds = ScratchCardDataset(data, mask_ratio=(0.3, 0.7), mode="reconstruct")
     item = ds[0]
     mask = item["mask"].numpy()
     assert 0.3 <= mask.mean() <= 0.7
@@ -37,3 +37,12 @@ def test_dataset_validation_range() -> None:
     board = np.array([[0, 1], [2, BLANK_VALUE]])
     with pytest.raises(ValueError):
         validate_board(board)
+
+
+def test_dataset_target_mode() -> None:
+    data = [(np.arange(1, 13).reshape(3, 4), 7)]
+    ds = ScratchCardDataset(data, mode="target")
+    item = ds[0]
+    mask = item["mask"].nonzero().squeeze().tolist()
+    assert mask == 6  # only the target position is masked (flattened index)
+    assert item["orig_vals"].sum().item() == 7

--- a/train.py
+++ b/train.py
@@ -11,8 +11,11 @@ from dataset import MASK_TOKEN_ID, ScratchCardDataset, validate_board
 from model import DynamicMET
 from utils.io_utils import load_boards_from_archives
 from utils.logger import save_checkpoint, setup_logger
-from utils.training import (EarlyStopping, cosine_schedule_with_warmup,
-                            masked_topk_accuracy)
+from utils.training import (
+    EarlyStopping,
+    cosine_schedule_with_warmup,
+    masked_topk_accuracy,
+)
 
 
 def train_epoch(
@@ -75,6 +78,13 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", default="configs/tabular.yaml")
     parser.add_argument("--epochs", type=int)
+    parser.add_argument(
+        "--mode",
+        choices=["target", "reconstruct"],
+        default="target",
+        help="Masking mode: 'target' only masks the target cell,"
+        " 'reconstruct' masks a random portion of the board",
+    )
     args = parser.parse_args()
 
     # Load configuration
@@ -83,9 +93,8 @@ def main() -> None:
         cfg["training"]["epochs"] = args.epochs
     epochs = int(cfg["training"]["epochs"])
 
-    # Load all boards and mask out the target number so the model learns to
-    # infer it from surrounding numbers
-    boards = load_boards_from_archives(cfg["data"]["data_dir"], mask_target=True)
+    # Load all boards; masking is handled by the dataset according to mode
+    boards = load_boards_from_archives(cfg["data"]["data_dir"], mask_target=False)
     if not boards:
         raise ValueError("No boards loaded from data_dir")
     for b, _ in boards:
@@ -100,11 +109,14 @@ def main() -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     # Extract and parse training hyperparams
-    if "mask_ratio_range" in cfg["training"]:
-        mask_ratio_cfg = cfg["training"]["mask_ratio_range"]
-        mask_ratio = (float(mask_ratio_cfg[0]), float(mask_ratio_cfg[1]))
+    if args.mode == "reconstruct":
+        if "mask_ratio_range" in cfg["training"]:
+            mask_ratio_cfg = cfg["training"]["mask_ratio_range"]
+            mask_ratio = (float(mask_ratio_cfg[0]), float(mask_ratio_cfg[1]))
+        else:
+            mask_ratio = float(cfg["training"].get("mask_ratio", 0.6))
     else:
-        mask_ratio = float(cfg["training"].get("mask_ratio", 0.6))
+        mask_ratio = 0.0
     batch_size = int(cfg["training"]["batch_size"])
     lr = float(cfg["training"]["lr"])
     weight_decay = float(cfg["training"]["weight_decay"])
@@ -131,17 +143,22 @@ def main() -> None:
             train_pairs = [group[i] for i in perm[:split]]
             val_pairs = [group[i] for i in perm[split:]]
 
-        train_ds = ScratchCardDataset(train_pairs, mask_ratio)
+        train_ds = ScratchCardDataset(train_pairs, mask_ratio, mode=args.mode)
         train_loader = DataLoader(
             train_ds,
             batch_size=batch_size,
             shuffle=True,
         )
+        if args.mode == "reconstruct":
+            val_ratios = (0.3, 0.7)
+        else:
+            val_ratios = (0.0,)
         val_loaders = [
             DataLoader(
-                ScratchCardDataset(val_pairs, mask_ratio=r), batch_size=batch_size
+                ScratchCardDataset(val_pairs, mask_ratio=r, mode=args.mode),
+                batch_size=batch_size,
             )
-            for r in (0.3, 0.7)
+            for r in val_ratios
         ]
 
         # Initialize model and optimizer


### PR DESCRIPTION
## Summary
- support reconstruct/target modes in ScratchCardDataset
- allow selecting mode in train.py via `--mode`
- update dataset tests for new behavior

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a4d9012083248cf7b538d84ee85c