### PR TITLE
Improve heatmap statistics

### DIFF
--- a/precompute_heatmap.py
+++ b/precompute_heatmap.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import zipfile
+from enum import Enum
 from pathlib import Path
 from typing import Dict, Iterable, Tuple
 
@@ -15,31 +16,59 @@ from tqdm import tqdm
 from dataset import BLANK_VALUE
 from utils.io_utils import _extract_boards
 
+# ---------- 參數可按需調整 ----------
+ALPHA: float = 1e-3  # Dirichlet 平滑強度
+CONSIDER_BLANK_ONLY = True  # True ➔ 只把「還沒翻的格子」算進分母
+
+
+class Bucket(Enum):
+    SMALL = "small"  #  1–5
+    MID = "mid"  #  6–15
+    LARGE = "large"  # 16–20
+
+
+def bucket_of(val: int) -> Bucket:
+    if val <= 5:
+        return Bucket.SMALL
+    if val <= 15:
+        return Bucket.MID
+    return Bucket.LARGE
+
 
 def _update_stats(
     board: np.ndarray,
     target: int,
-    heatmaps: Dict[Tuple[int, int], np.ndarray],
-    counts: Dict[Tuple[int, int], np.ndarray],
+    heatmaps: Dict[Tuple[int, int, Bucket], np.ndarray],
+    counts: Dict[Tuple[int, int, Bucket], np.ndarray],
 ) -> None:
     rows, cols = board.shape
-    shape = (rows, cols)
+    shape = (rows, cols, bucket_of(target))
     if shape not in heatmaps:
-        heatmaps[shape] = np.ones((rows, cols), dtype=np.float64)
-        counts[shape] = np.ones((rows, cols), dtype=np.float64)
+        heatmaps[shape] = np.zeros((rows, cols), dtype=np.float64)
+        counts[shape] = np.zeros((rows, cols), dtype=np.float64)
+
+    # 分子：該格真的放了目標值
     pos = np.argwhere(board == target)
     if pos.size > 0:
         r, c = pos[0]
         heatmaps[shape][r, c] += 1
-    counts[shape] += (board != BLANK_VALUE).astype(np.float64)
+
+    # 分母：此格「可能被選中」的次數
+    if CONSIDER_BLANK_ONLY:
+        counts[shape] += (board == BLANK_VALUE).astype(np.float64)
+    else:
+        counts[shape] += 1.0  # 把每局都算一次
 
 
 def collect_statistics(
     data_dir: str,
-) -> Tuple[Dict[Tuple[int, int], np.ndarray], Dict[Tuple[int, int], np.ndarray]]:
+) -> Tuple[
+    Dict[Tuple[int, int, Bucket], np.ndarray],
+    Dict[Tuple[int, int, Bucket], np.ndarray],
+]:
     """Traverse ``data_dir`` and return heatmap and count statistics."""
-    heatmaps: Dict[Tuple[int, int], np.ndarray] = {}
-    counts: Dict[Tuple[int, int], np.ndarray] = {}
+    heatmaps: Dict[Tuple[int, int, Bucket], np.ndarray] = {}
+    counts: Dict[Tuple[int, int, Bucket], np.ndarray] = {}
     files: list[Path] = []
     for root, _, fns in os.walk(data_dir):
         for name in fns:
@@ -63,19 +92,19 @@ def collect_statistics(
 
 
 def save_statistics(
-    heatmaps: Dict[Tuple[int, int], np.ndarray],
-    counts: Dict[Tuple[int, int], np.ndarray],
+    heatmaps: Dict[Tuple[int, int, Bucket], np.ndarray],
+    counts: Dict[Tuple[int, int, Bucket], np.ndarray],
     out_dir: str,
 ) -> None:
     """Save statistics to ``out_dir``."""
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
-    for (rows, cols), mat in heatmaps.items():
-        arr = mat / mat.sum()
-        np.save(out / f"heatmap_{rows}x{cols}.npy", arr)
-    for (rows, cols), mat in counts.items():
-        arr = mat / mat.sum()
-        np.save(out / f"counts_{rows}x{cols}.npy", arr)
+    for (rows, cols, bucket), hits in heatmaps.items():
+        denom = counts[(rows, cols, bucket)]
+        # Dirichlet 平滑，避免 0 / 0
+        prior = (hits + ALPHA) / (denom + ALPHA * (rows * cols))
+        fname = f"heatmap_{bucket.value}_{rows}x{cols}.npy"
+        np.save(out / fname, prior)
 
 
 def main(args: Iterable[str] | None = None) -> None:

--- a/tests/test_heatmap_precompute.py
+++ b/tests/test_heatmap_precompute.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from dataset import BLANK_VALUE
+from precompute_heatmap import _update_stats, bucket_of, save_statistics
+
+
+def test_update_stats_counts_blank_only() -> None:
+    board = np.array([[1, BLANK_VALUE], [BLANK_VALUE, 2]])
+    heatmaps = {}
+    counts = {}
+    _update_stats(board, target=2, heatmaps=heatmaps, counts=counts)
+    shape = (2, 2, bucket_of(2))
+    expected_hits = np.array([[0.0, 0.0], [0.0, 1.0]])
+    expected_counts = np.array([[0.0, 1.0], [1.0, 0.0]])
+    np.testing.assert_array_equal(heatmaps[shape], expected_hits)
+    np.testing.assert_array_equal(counts[shape], expected_counts)
+
+
+def test_save_statistics_bucket_and_blank_only(tmp_path) -> None:
+    board = np.array([[1, BLANK_VALUE], [BLANK_VALUE, 2]])
+    heatmaps = {}
+    counts = {}
+    _update_stats(board, target=2, heatmaps=heatmaps, counts=counts)
+    save_statistics(heatmaps, counts, str(tmp_path))
+    fname = tmp_path / "heatmap_small_2x2.npy"
+    assert fname.exists()
+    arr = np.load(fname)
+    assert arr.shape == (2, 2)
+    # value at target position should be highest
+    assert arr[1, 1] > arr[0, 1]


### PR DESCRIPTION
## Summary
- refine heatmap prior computation with bucketing and blank counting
- save probabilities with Dirichlet smoothing
- add unit tests for statistics logic

## Testing
- `isort . --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f2975d008324ab7a5b81b8c8ee59