### PR TITLE
Add bucketed heatmap loading

### DIFF
--- a/precompute_heatmap.py
+++ b/precompute_heatmap.py
@@ -1,5 +1,3 @@
-
-
 """Precompute heatmap and cell frequency statistics from datasets."""
 
 from __future__ import annotations
@@ -24,8 +22,8 @@ CONSIDER_BLANK_ONLY = True  # True ➔ 只把「還沒翻的格子」算進分�
 
 
 class Bucket(Enum):
-    SMALL = "small"  #  1–5
-    MID = "mid"  #  6–15
+    SMALL = "small"  # 1–5
+    MID = "mid"  # 6–15
     LARGE = "large"  # 16–20
 
 

--- a/tests/test_training_utils.py
+++ b/tests/test_training_utils.py
@@ -28,7 +28,7 @@ def test_early_stopping_restore() -> None:
 
 def test_load_heatmap(tmp_path) -> None:
     arr = np.arange(9, dtype=np.float32).reshape(3, 3)
-    path = tmp_path / "heatmap_3x3.npy"
+    path = tmp_path / "heatmap_mid_3x3.npy"
     np.save(path, arr)
-    hm = load_heatmap(3, 3, directory=str(tmp_path))
+    hm = load_heatmap(3, 3, target=7, directory=str(tmp_path))
     assert hm.shape == (3, 3)

--- a/train.py
+++ b/train.py
@@ -154,6 +154,7 @@ def main() -> None:
     # Train a model for each board shape
     for shape, group in shape_groups.items():
         rows, cols = shape
+        target = group[0][1]
         model_name = f"{rows}x{cols}"
         logger.info(
             f"Starting training for shape {model_name} with {len(group)} samples"
@@ -191,7 +192,7 @@ def main() -> None:
             for r in val_ratios
         ]
 
-        heat = load_heatmap(rows, cols).to(device)
+        heat = load_heatmap(rows, cols, target, device=device)
         prior = torch.log(heat.flatten() + 1e-6)
 
         criterion_cls = FocalLoss(gamma=args.gamma)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
 from .guard import ensure_only_blank, index_to_coord
-from .prior import load_heatmap
+from .prior import bucket_of, load_heatmap
 from .rope import apply_rope, build_rope_cache
 
 __all__ = [
@@ -7,5 +7,6 @@ __all__ = [
     "index_to_coord",
     "build_rope_cache",
     "apply_rope",
+    "bucket_of",
     "load_heatmap",
 ]

--- a/utils/prior.py
+++ b/utils/prior.py
@@ -7,6 +7,12 @@ from typing import Iterable, Tuple
 
 import numpy as np
 
+
+def bucket_of(val: int) -> str:
+    """Return bucket name for ``val``."""
+    return "small" if val <= 5 else "mid" if val <= 15 else "large"
+
+
 try:
     import torch
 
@@ -28,11 +34,41 @@ def build_heatmap(
     return mat
 
 
-def load_heatmap(rows: int, cols: int, directory: str = "priors") -> "torch.Tensor":
-    """Load heatmap ``rows`` x ``cols`` from ``directory``."""
-    path = Path(directory) / f"heatmap_{rows}x{cols}.npy"
+def load_heatmap(
+    rows: int,
+    cols: int,
+    target: int | None = None,
+    directory: str = "priors",
+    *,
+    device: str | None = None,
+) -> "torch.Tensor":
+    """Load heatmap for ``rows`` x ``cols`` optionally using ``target`` bucket."""
+
+    if target is None:
+        fname = f"heatmap_{rows}x{cols}.npy"
+    else:
+        fname = f"heatmap_{bucket_of(target)}_{rows}x{cols}.npy"
+    path = Path(directory) / fname
+
+    if not path.exists():
+        if TORCH_AVAILABLE:
+            import torch  # local
+
+            return torch.full(
+                (rows, cols),
+                1.0 / (rows * cols),
+                device=device,
+                dtype=torch.float32,
+            )
+        return np.full((rows, cols), 1.0 / (rows * cols), dtype=np.float32)
+
     arr = np.load(path)
     if arr.shape != (rows, cols):
         raise ValueError("heatmap shape mismatch")
-    tensor = torch.from_numpy(arr.astype(np.float32)) if TORCH_AVAILABLE else arr
+    if TORCH_AVAILABLE:
+        import torch
+
+        tensor = torch.tensor(arr, device=device, dtype=torch.float32)
+    else:
+        tensor = arr
     return tensor


### PR DESCRIPTION
## Summary
- support target bucket selection when loading heatmaps
- export `bucket_of` in utils
- adapt training script for new `load_heatmap` API
- update precompute script comment style
- adjust unit test

## Testing
- `black --check .`
- `isort --check --diff .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f97678a883248cc7c74ceb0e6e99