### PR TITLE
Support bucket-based heatmap priors

### DIFF
--- a/precompute_heatmap.py
+++ b/precompute_heatmap.py
@@ -1,5 +1,3 @@
-
-
 """Precompute heatmap and cell frequency statistics from datasets."""
 
 from __future__ import annotations
@@ -24,8 +22,8 @@ CONSIDER_BLANK_ONLY = True  # True ➔ 只把「還沒翻的格子」算進分�
 
 
 class Bucket(Enum):
-    SMALL = "small"  #  1–5
-    MID = "mid"  #  6–15
+    SMALL = "small"  # 1–5
+    MID = "mid"  # 6–15
     LARGE = "large"  # 16–20
 
 

--- a/tests/test_training_utils.py
+++ b/tests/test_training_utils.py
@@ -26,9 +26,22 @@ def test_early_stopping_restore() -> None:
     assert torch.allclose(model.weight, initial)
 
 
-def test_load_heatmap(tmp_path) -> None:
+def test_load_heatmap(tmp_path, monkeypatch) -> None:
     arr = np.arange(9, dtype=np.float32).reshape(3, 3)
-    path = tmp_path / "heatmap_3x3.npy"
-    np.save(path, arr)
-    hm = load_heatmap(3, 3, directory=str(tmp_path))
+    arr = arr / arr.sum()
+    priors = tmp_path / "priors"
+    priors.mkdir()
+    np.save(priors / "heatmap_small_3x3.npy", arr)
+    monkeypatch.chdir(tmp_path)
+    hm = load_heatmap(3, 3, target=4, device="cpu")
     assert hm.shape == (3, 3)
+    assert abs(float(hm.sum()) - 1) < 1e-6
+    cv = float(hm.std() / hm.mean())
+    assert cv > 0.05
+
+
+def test_load_heatmap_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    hm = load_heatmap(2, 2, target=1, device="cpu")
+    assert hm.shape == (2, 2)
+    assert abs(float(hm.sum()) - 1) < 1e-6

--- a/train.py
+++ b/train.py
@@ -191,7 +191,8 @@ def main() -> None:
             for r in val_ratios
         ]
 
-        heat = load_heatmap(rows, cols).to(device)
+        target = group[0][1]
+        heat = load_heatmap(rows, cols, target).to(device)
         prior = torch.log(heat.flatten() + 1e-6)
 
         criterion_cls = FocalLoss(gamma=args.gamma)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
 from .guard import ensure_only_blank, index_to_coord
-from .prior import load_heatmap
+from .prior import bucket_of, load_heatmap
 from .rope import apply_rope, build_rope_cache
 
 __all__ = [
@@ -7,5 +7,6 @@ __all__ = [
     "index_to_coord",
     "build_rope_cache",
     "apply_rope",
+    "bucket_of",
     "load_heatmap",
 ]

--- a/utils/prior.py
+++ b/utils/prior.py
@@ -28,11 +28,46 @@ def build_heatmap(
     return mat
 
 
-def load_heatmap(rows: int, cols: int, directory: str = "priors") -> "torch.Tensor":
-    """Load heatmap ``rows`` x ``cols`` from ``directory``."""
-    path = Path(directory) / f"heatmap_{rows}x{cols}.npy"
+def bucket_of(val: int) -> str:
+    """Return ``"small"`` | ``"mid"`` | ``"large"`` for ``val``."""
+
+    return "small" if val <= 5 else "mid" if val <= 15 else "large"
+
+
+def load_heatmap(
+    rows: int,
+    cols: int,
+    target: int | None = None,
+    device: str | "torch.device" = "cpu",
+) -> "torch.Tensor":
+    """Load a smoothed heatmap prior.
+
+    Parameters
+    ----------
+    rows, cols
+        Board shape.
+    target
+        Target value.  ``None`` uses the legacy single-map path.
+    device
+        Torch device string or object for output tensor.
+    """
+
+    if target is None:
+        fname = f"heatmap_{rows}x{cols}.npy"
+    else:
+        fname = f"heatmap_{bucket_of(target)}_{rows}x{cols}.npy"
+
+    path = Path("priors") / fname
+    if not path.exists():  # graceful fallback to uniform prior
+        if torch is None:  # pragma: no cover - torch missing
+            raise FileNotFoundError(path)
+        return torch.full((rows, cols), 1.0 / (rows * cols), device=device)
+
     arr = np.load(path)
     if arr.shape != (rows, cols):
         raise ValueError("heatmap shape mismatch")
-    tensor = torch.from_numpy(arr.astype(np.float32)) if TORCH_AVAILABLE else arr
+    if torch is not None:
+        tensor = torch.tensor(arr, device=device, dtype=torch.float32)
+    else:  # pragma: no cover - torch missing
+        tensor = arr
     return tensor


### PR DESCRIPTION
## Summary
- extend `load_heatmap` to select prior by target bucket and fallback to uniform map
- expose `bucket_of` in utils package
- use bucket-aware heatmap in training
- fix inline comment spacing for flake8
- update heatmap unit tests for new API

## Testing
- `isort --check $(git ls-files '*.py')`
- `black --check $(git ls-files '*.py')`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f97678a883248cc7c74ceb0e6e99