### PR TITLE
Apply heatmap priors for prediction

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,13 +15,17 @@ from pydantic import BaseModel, Field, model_validator
 
 from dataset import BLANK_VALUE
 from model import DynamicMET
-from utils import ensure_only_blank
+from utils import (ensure_only_blank, fuse_predictions_with_heatmap,
+                   load_heatmap)
 
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO"),
     format="%(asctime)s %(levelname)s: %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+MODEL_WEIGHT = float(os.environ.get("MODEL_WEIGHT", "0.8"))
+HEATMAP_WEIGHT = float(os.environ.get("HEATMAP_WEIGHT", "0.2"))
 
 app = FastAPI(title="Matrix Factorization Service", version="0.1.0")
 
@@ -242,7 +246,20 @@ def predict(req: PredictRequest):
             )
         scores_np = arr[0, :, target_idx]
 
-    candidate_scores = scores_np[mask_pos]
+    heat = load_heatmap(rows, cols, target=None)
+    if torch is not None and hasattr(heat, "cpu"):
+        heat_np = heat.cpu().numpy()
+    else:
+        heat_np = np.asarray(heat)
+    fused_scores = fuse_predictions_with_heatmap(
+        scores_np,
+        heat_np,
+        board,
+        model_weight=MODEL_WEIGHT,
+        heatmap_weight=HEATMAP_WEIGHT,
+    )
+
+    candidate_scores = fused_scores[mask_pos]
     topk_local = np.argsort(candidate_scores)[-min(3, len(candidate_scores)) :][::-1]
     logger.info(
         "從 %s 個候選格中挑選前 %s 名", len(candidate_scores), len(topk_local)
@@ -282,7 +299,7 @@ def predict(req: PredictRequest):
             Prediction(
                 row=r,
                 col=c,
-                score=float(scores_np[idx]),
+                score=float(fused_scores[idx]),
                 idx=int(idx),
                 cell_value=int(flat[idx]),
             )

--- a/tests/test_app_fallback.py
+++ b/tests/test_app_fallback.py
@@ -15,6 +15,11 @@ def test_app_predict_numpy(monkeypatch):
     importlib.reload(appmod)
     appmod.models.clear()
     appmod.models[(2, 2)] = model.DynamicMET(4, 5)
+    monkeypatch.setattr(
+        appmod,
+        "load_heatmap",
+        lambda r, c, target=None: np.full((r, c), 1.0 / (r * c), dtype=np.float32),
+    )
     board = np.array([[1, 2], [3, -1]]).tolist()
     payload = appmod.PredictRequest(board=board, target_value=1)
     result = appmod.predict(payload)

--- a/tests/test_heatmap_fusion.py
+++ b/tests/test_heatmap_fusion.py
@@ -1,0 +1,19 @@
+import importlib
+
+import numpy as np
+
+import app as appmod
+
+
+def test_predict_heatmap_fusion(monkeypatch):
+    importlib.reload(appmod)
+    appmod.models.clear()
+    appmod.models[(2, 2)] = appmod.DynamicMET(4, 4)
+
+    heatmap = np.array([[0.9, 0.1], [0.0, 0.0]], dtype=np.float32)
+    monkeypatch.setattr(appmod, "load_heatmap", lambda r, c, target=None: heatmap)
+
+    board = [[-1, -1], [-1, -1]]
+    payload = appmod.PredictRequest(board=board, target=1)
+    res = appmod.predict(payload)
+    assert res[0].row == 1 and res[0].col == 1

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
 from .guard import ensure_only_blank, index_to_coord
-from .prior import bucket_of, load_heatmap
+from .prior import bucket_of, fuse_predictions_with_heatmap, load_heatmap
 from .rope import apply_rope, build_rope_cache
 
 __all__ = [
@@ -9,4 +9,5 @@ __all__ = [
     "apply_rope",
     "bucket_of",
     "load_heatmap",
+    "fuse_predictions_with_heatmap",
 ]

--- a/utils/prior.py
+++ b/utils/prior.py
@@ -7,6 +7,8 @@ from typing import Iterable, Tuple
 
 import numpy as np
 
+from dataset import BLANK_VALUE
+
 try:
     import torch
 
@@ -59,9 +61,9 @@ def load_heatmap(
 
     path = Path("priors") / fname
     if not path.exists():  # graceful fallback to uniform prior
-        if torch is None:  # pragma: no cover - torch missing
-            raise FileNotFoundError(path)
-        return torch.full((rows, cols), 1.0 / (rows * cols), device=device)
+        if torch is not None:
+            return torch.full((rows, cols), 1.0 / (rows * cols), device=device)
+        return np.full((rows, cols), 1.0 / (rows * cols), dtype=np.float32)
 
     arr = np.load(path)
     print(f"Loaded heatmap: {fname}")
@@ -72,3 +74,22 @@ def load_heatmap(
     else:  # pragma: no cover - torch missing
         tensor = arr
     return tensor
+
+
+def fuse_predictions_with_heatmap(
+    model_scores: np.ndarray,
+    heatmap: np.ndarray,
+    board: np.ndarray,
+    model_weight: float = 0.8,
+    heatmap_weight: float = 0.2,
+) -> np.ndarray:
+    """Fuse ``model_scores`` with ``heatmap`` respecting masked cells."""
+
+    if heatmap.shape != board.shape:
+        raise ValueError("heatmap shape mismatch")
+    if model_scores.ndim != 1 or model_scores.size != board.size:
+        raise ValueError("model_scores shape mismatch")
+    mask = (board.ravel() == BLANK_VALUE).astype(np.float32)
+    prior = heatmap.ravel() * mask
+    fused = model_weight * model_scores + heatmap_weight * prior
+    return fused


### PR DESCRIPTION
## Summary
- fuse model prediction scores with heatmap prior in `/predict`
- provide uniform fallback for heatmap loading even without torch
- expose new helper `fuse_predictions_with_heatmap`
- add regression test for heatmap fusion
- update fallback API test

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a1e9c441c8324a262224ee06dd5c0