### PR TITLE
Fix zero-loss early stop after full epoch

### DIFF
--- a/train.py
+++ b/train.py
@@ -201,7 +201,6 @@ def main() -> None:
                 unit="batch",
             )
             total_loss = 0.0
-            zero_loss = False  # 中文註釋：偵測是否出現零損失
             for batch_idx, batch in enumerate(pbar, start=1):
                 inp = batch["input_vals"].to(device)
                 orig = batch["orig_vals"].to(device)
@@ -214,18 +213,16 @@ def main() -> None:
                 optimizer.step()
                 scheduler.step()
                 total_loss += loss.item()
-                if is_zero_loss(loss.item()):
-                    logger.info("偵測到 loss=0.000，提前結束此尺寸訓練")
-                    zero_loss = True
-                    break
                 avg_loss = total_loss / batch_idx
                 pbar.set_postfix({"loss": f"{avg_loss:.4f}"})
 
-            if zero_loss:
+            avg_loss = total_loss / len(train_loader)
+            logger.info(f"{model_name} epoch {epoch}: train_loss={avg_loss:.4f}")
+
+            if is_zero_loss(avg_loss):
+                logger.info("偵測到 loss=0.000，提前結束此尺寸訓練")
                 trained_epochs = epoch
                 break
-
-            avg_loss = total_loss / len(train_loader)
 
             # Validation phase over multiple loaders
             val_losses = []


### PR DESCRIPTION
## Summary
- only stop training when entire epoch avg loss is zero

## Testing
- `black train.py app.py utils/training.py --check`
- `isort train.py app.py utils/training.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a854590e8832482d22c84da65f64f