### PR TITLE
Add early stop when validation perfect

### DIFF
--- a/train.py
+++ b/train.py
@@ -287,6 +287,15 @@ def main() -> None:
                 topk["top3"],
                 topk["top5"],
             )
+            # 如果在 validation 上 top1/top3/top5 都達到 1.0，就提早結束此尺寸訓練
+            if topk["top1"] == 1.0 and topk["top3"] == 1.0 and topk["top5"] == 1.0:
+                logger.info(
+                    "Validation perfect for %s at epoch %s → stopping early.",
+                    model_name,
+                    epoch,
+                )
+                trained_epochs = epoch
+                break
             if early_stop.step(val_loss, model):
                 logger.info("Early stopping triggered for %s", model_name)
                 trained_epochs = epoch


### PR DESCRIPTION
## Summary
- stop training early if top1/top3/top5 reach 1.0 on validation

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9310b9f48324bdbf7535d1b33071