### PR TITLE
Refactor indexing to fixed 81-class mapping

### DIFF
--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -1,5 +1,6 @@
 """Agent that predicts scratch card positions using a DynamicMET model."""
 
+import logging
 from typing import Any, Dict, List
 
 import numpy as np
@@ -12,9 +13,11 @@ except Exception:  # pragma: no cover - torch missing
     torch = None  # type: ignore[assignment]
     TORCH_AVAILABLE = False
 
-from dataset import BLANK_VALUE
+from dataset import BLANK_VALUE, MASK_TOKEN_ID
 from model import DynamicMET
 from utils import ensure_only_blank, index_to_coord
+
+logger = logging.getLogger(__name__)
 
 
 def predict(
@@ -24,41 +27,43 @@ def predict(
     rows, cols = board.shape
     flat = board.flatten()
 
-    mask_pos = np.where(flat == BLANK_VALUE)[0]
-    if mask_pos.size == 0:
+    candidate_idx = np.where(flat == BLANK_VALUE)[0]
+    if candidate_idx.size == 0:
         return []
 
-    arr_inp = np.where(flat < 0, 0, flat)
+    arr_inp = np.where(flat == BLANK_VALUE, MASK_TOKEN_ID, flat).astype(np.int64)
 
     if TORCH_AVAILABLE and isinstance(model, torch.nn.Module):
-        inp = torch.as_tensor(arr_inp, dtype=torch.long).unsqueeze(0)
-        logits = model(inp)
-        probs = torch.softmax(logits, dim=-1)
-        V = probs.shape[-1]
-        target_idx = target if V == flat.size + 1 else target - 1
-        if not (0 <= target_idx < V):
-            raise RuntimeError(
-                f"target_idx out of range: target={target} -> {target_idx}, V={V}"
+        model.eval()
+        with torch.no_grad():
+            inp = torch.as_tensor(arr_inp, dtype=torch.long).unsqueeze(0)
+            logits = model(inp)
+            logger.info(
+                "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+                tuple(logits.shape),
             )
-        scores_all = probs[0, :, target_idx].detach().cpu().numpy()
+            probs = torch.softmax(logits, dim=-1)
+            scores_all = probs[0, :, target].detach().cpu().numpy()
     else:
-        inp = arr_inp.reshape(1, -1).astype(np.int64, copy=False)
+        inp = arr_inp.reshape(1, -1)
         logits = model(inp)
+        logger.info(
+            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            np.shape(logits),
+        )
         arr = np.asarray(logits)
-        V = arr.shape[-1]
-        target_idx = target if V == flat.size + 1 else target - 1
-        if not (0 <= target_idx < V):
-            raise RuntimeError(
-                f"target_idx out of range: target={target} -> {target_idx}, V={V}"
-            )
-        scores_all = arr[0, :, target_idx]
+        exp_arr = np.exp(arr - arr.max(axis=-1, keepdims=True))
+        probs = exp_arr / exp_arr.sum(axis=-1, keepdims=True)
+        scores_all = probs[0, :, target]
 
-    cand_scores = scores_all[mask_pos]
-    k = min(topk, cand_scores.size)
+    candidate_scores = scores_all[candidate_idx]
+    k = min(topk, candidate_scores.size)
+    logger.info("TopK: candidates=%s, k=%s", candidate_idx.size, k)
     if k == 0:
         return []
-    local_idx = np.argsort(cand_scores)[-k:][::-1]
-    top_indices = mask_pos[local_idx]
+    topk_local = np.argpartition(candidate_scores, -k)[-k:]
+    order = np.lexsort((candidate_idx[topk_local], -candidate_scores[topk_local]))
+    top_indices = candidate_idx[topk_local][order][-k:][::-1]
 
     results: List[Dict[str, Any]] = []
     for idx in top_indices:

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ except Exception:  # torch may be unavailable in minimal runtimes
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
-from dataset import BLANK_VALUE
+from dataset import BLANK_VALUE, MASK_TOKEN_ID
 from model import DynamicMET
 from utils import ensure_only_blank
 
@@ -99,7 +99,7 @@ models: Dict[Tuple[int, int], DynamicMET] = {}
 def _create_model(rows: int, cols: int) -> DynamicMET:
     """Return a :class:`DynamicMET` with training hyperparameters."""
 
-    return DynamicMET(rows * cols, rows * cols, rows=rows, cols=cols, **MODEL_PARAMS)
+    return DynamicMET(rows * cols, 81, rows=rows, cols=cols, **MODEL_PARAMS)
 
 
 def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
@@ -196,15 +196,17 @@ def predict(req: PredictRequest):
     )  # 中文log：記錄盤面大小與目標數字
 
     flat = board.flatten()
-    mask_pos = np.where(flat == BLANK_VALUE)[0]
-    if mask_pos.size == 0:
+    candidate_idx = np.where(flat == BLANK_VALUE)[0]
+    if candidate_idx.size == 0:
         raise HTTPException(
             status_code=422, detail=f"no blank cells ({BLANK_VALUE}) to predict"
         )
-    logger.info("[CHK] mask_pos=%s", mask_pos.tolist())
+    logger.info("[CHK] mask_pos=%s", candidate_idx.tolist())
 
     # ensure contiguous int64 array to avoid torch dtype inference errors
-    flat_input = np.where(flat < 0, 0, flat).astype(np.int64, copy=False)
+    flat_input = np.where(flat == BLANK_VALUE, MASK_TOKEN_ID, flat).astype(
+        np.int64, copy=False
+    )
     flat_input = np.ascontiguousarray(flat_input)
     logger.info(
         "[CHK] flat_input: shape=%s dtype=%s sample=%s",
@@ -226,61 +228,54 @@ def predict(req: PredictRequest):
     else:
         logger.info("使用已載入的模型 %sx%s", rows, cols)  # 中文log：重複尺寸共用模型
 
+    logger.info(
+        "Model: shape=%sx%s, d_model=%s, depth=%s, nhead=%s, num_values=%s",
+        rows,
+        cols,
+        getattr(model, "d_model", "?"),
+        getattr(model, "depth", "?"),
+        getattr(model, "nhead", "?"),
+        getattr(getattr(model, "classifier", None), "out_features", "?"),
+    )
+    logger.info(
+        "Mapping: BLANK_VALUE=%s -> MASK_TOKEN_ID=%s ; labels 1..80",
+        BLANK_VALUE,
+        MASK_TOKEN_ID,
+    )
+    det = torch.are_deterministic_algorithms_enabled() if torch is not None else False
+    logger.info("Deterministic: %s", det)
+
     if torch is not None:
         # use as_tensor to avoid copy and specify dtype explicitly
-        inp = torch.as_tensor(flat_input, dtype=torch.long).unsqueeze(0)
-        logits = model(inp)  # type: ignore[misc]
-        if logger.isEnabledFor(logging.DEBUG):
-            n_f = logits.size(1)
-            pos_ids = torch.arange(n_f, device=logits.device)
-            row_ids = torch.div(pos_ids, cols, rounding_mode="floor")
-            col_ids = pos_ids % cols
-            logger.debug(
-                "[RoPE] row_ids=%s col_ids=%s sample_q=%s",
-                row_ids[:10].tolist(),
-                col_ids[:10].tolist(),
-                logits[0, :5, :5].detach().cpu().numpy().round(4),
-            )
-        probs = torch.softmax(logits, dim=-1)
+        model.eval()
+        with torch.no_grad():
+            inp = torch.as_tensor(flat_input, dtype=torch.long).unsqueeze(0)
+            logits = model(inp)  # type: ignore[misc]
         logger.info(
-            "[PRED] torch path: inp=%s logits=%s probs=%s",
-            tuple(inp.shape),
+            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
             tuple(logits.shape),
-            tuple(probs.shape),
         )
-        V = probs.shape[-1]
-        target_idx = target if V == n + 1 else target - 1
-        if not (0 <= target_idx < V):
-            raise HTTPException(
-                status_code=422,
-                detail=f"target index out of range: target={target}, mapped={target_idx}, V={V}",
-            )
-        scores_all = probs[0, :, target_idx]
-        scores_np = scores_all.detach().cpu().numpy()
+        probs = torch.softmax(logits, dim=-1)
+        scores_np = probs[0, :, target].detach().cpu().numpy()
     else:
         inp = flat_input.reshape(1, -1)
         logits = model(inp)
-        arr = np.asarray(logits)
         logger.info(
-            "[PRED] numpy path: inp=%s logits=%s",
-            inp.shape,
-            arr.shape,
+            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            np.shape(logits),
         )
-        V = arr.shape[-1]
-        target_idx = target if V == n + 1 else target - 1
-        if not (0 <= target_idx < V):
-            raise HTTPException(
-                status_code=422,
-                detail=f"target index out of range: target={target}, mapped={target_idx}, V={V}",
-            )
-        scores_np = arr[0, :, target_idx]
+        arr = np.asarray(logits)
+        exp_arr = np.exp(arr - arr.max(axis=-1, keepdims=True))
+        probs = exp_arr / exp_arr.sum(axis=-1, keepdims=True)
+        scores_np = probs[0, :, target]
 
-    candidate_scores = scores_np[mask_pos]
-    topk_local = np.argsort(candidate_scores)[-min(3, len(candidate_scores)) :][::-1]
-    logger.info(
-        "從 %s 個候選格中挑選前 %s 名", len(candidate_scores), len(topk_local)
-    )  # 中文log：候選格與返回數量
-    top_indices = mask_pos[topk_local]
+    candidate_scores = scores_np[candidate_idx]
+    k = min(3, candidate_scores.size)
+    logger.info("TopK: candidates=%s, k=%s", candidate_idx.size, k)
+    logger.info("從 %s 個候選格中挑選前 %s 名", candidate_idx.size, k)
+    topk_local = np.argpartition(candidate_scores, -k)[-k:]
+    order = np.lexsort((candidate_idx[topk_local], -candidate_scores[topk_local]))
+    top_indices = candidate_idx[topk_local][order][-k:][::-1]
     logger.info("[CHK] top_indices=%s", top_indices.tolist())
 
     picked_vals = [int(flat[idx]) for idx in top_indices]

--- a/configs/tabular.yaml
+++ b/configs/tabular.yaml
@@ -1,7 +1,7 @@
 model:
   name: DynamicMET
   num_fields: ${BOARD_ROWS}*${BOARD_COLS}
-  num_values: ${MAX_VALUE}
+  num_values: 81
   d_model: 256
   nhead: 8
   depth: 8
@@ -13,7 +13,7 @@ training:
   epochs: 20
   lr: 3e-4
   weight_decay: 0.0001
-  label_smoothing: 0.1
+  label_smoothing: 0.0
   scheduler:
     type: cosine
     warmup_epochs: 2

--- a/dataset.py
+++ b/dataset.py
@@ -114,7 +114,11 @@ class ScratchCardDataset(Dataset):
             raise RuntimeError("Torch is required for ScratchCardDataset")
 
         board_arr = self.boards[idx].flatten()
-        board = torch.from_numpy(board_arr).long()
+        board_orig = torch.from_numpy(board_arr).long()
+        board_tokens = np.where(
+            board_arr == BLANK_VALUE, MASK_TOKEN_ID, board_arr
+        ).astype(np.int64)
+        board = torch.from_numpy(board_tokens)
         target_val = int(self.targets[idx])
         target = torch.tensor(target_val).long()
 
@@ -126,10 +130,10 @@ class ScratchCardDataset(Dataset):
             else:
                 ratio = self.mask_ratio
             mask = torch.rand(board.shape) < ratio
-            mask |= board == target_val
-            mask |= board == BLANK_VALUE
+            mask |= board_orig == target_val
+            mask |= board_orig == BLANK_VALUE
         elif self.mode == "target":
-            mask = (board == target_val) | (board == BLANK_VALUE)
+            mask = (board_orig == target_val) | (board_orig == BLANK_VALUE)
         elif self.mode == "patch":
             board2d = self.boards[idx]
             r, c = np.argwhere(board2d == target_val)[0]
@@ -144,7 +148,7 @@ class ScratchCardDataset(Dataset):
         inp[mask] = MASK_TOKEN_ID
 
         orig = torch.full_like(board, MASK_TOKEN_ID)
-        valid_mask = mask & (board != BLANK_VALUE)
+        valid_mask = mask & (board != MASK_TOKEN_ID)
         orig[valid_mask] = board[valid_mask]
 
         return {

--- a/model.py
+++ b/model.py
@@ -17,7 +17,7 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
     def __init__(
         self,
         num_fields: int,
-        num_values: int,
+        num_values: int = 81,
         d_model: int = 128,
         nhead: int = 4,
         depth: int = 6,
@@ -29,14 +29,17 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
     ) -> None:
         self.num_fields = int(num_fields)
         self.num_values = int(num_values)
+        assert self.num_values == 81, "num_values 必須是 81 (含空白)"
         self.d_model = int(d_model)
+        self.nhead = int(nhead)
+        self.depth = int(depth)
         self.rows = int(rows)
         self.cols = int(cols if cols is not None else rows if rows > 0 else 1)
         if self.rows * self.cols != self.num_fields:
             raise ValueError("rows*cols must equal num_fields")
         if TORCH_AVAILABLE:
             super().__init__()  # type: ignore[misc]
-            self.token_emb = nn.Embedding(num_values + 1, d_model)
+            self.token_emb = nn.Embedding(self.num_values, d_model)
             row_dim = d_model // 2
             col_dim = d_model - row_dim
             self.row_emb = nn.Embedding(self.rows, row_dim)
@@ -57,12 +60,13 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
                 ]
             )
             self.norm_out = nn.LayerNorm(d_model)
-            self.head = nn.Linear(d_model, num_values + 1)
+            self.classifier = nn.Linear(d_model, self.num_values)
         else:
             self.token_emb = None
             self.row_emb = None
             self.col_emb = None
             self.embed_dropout = None
+            self.classifier = None
 
     def forward(self, x: "torch.Tensor") -> "torch.Tensor":  # type: ignore[override]
         if TORCH_AVAILABLE:
@@ -78,11 +82,11 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             for blk in self.blocks:
                 h = blk(h, row_ids, col_ids, attn_mask=None)
             h = self.norm_out(h)
-            logits = self.head(h)
+            logits = self.classifier(h)
             return logits
         import numpy as np
 
         bsz, fields = x.shape
-        return np.zeros((bsz, fields, self.num_values + 1), dtype=float)
+        return np.zeros((bsz, fields, self.num_values), dtype=float)
 
     __call__ = forward

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -5,10 +5,10 @@ from dataset import BLANK_VALUE
 from model import DynamicMET
 
 
-def test_met_agent_predict_on_10x12() -> None:
+def test_met_agent_predict_on_board() -> None:
     rng = np.random.default_rng(42)
-    rows, cols = 10, 12
-    grid = rng.integers(1, 100, size=(rows, cols))
+    rows, cols = 8, 10
+    grid = rng.integers(1, 81, size=(rows, cols))
     blank_indices = rng.choice(rows * cols, size=rng.integers(15, 26), replace=False)
     for idx in blank_indices:
         r, c = divmod(idx, cols)
@@ -16,7 +16,7 @@ def test_met_agent_predict_on_10x12() -> None:
     non_blanks = np.argwhere(grid != BLANK_VALUE)
     target_r, target_c = non_blanks[rng.integers(len(non_blanks))]
     target = int(grid[target_r, target_c])
-    model = DynamicMET(rows * cols, 100, rows=rows, cols=cols)
+    model = DynamicMET(rows * cols, rows=rows, cols=cols)
     result = predict(grid.copy(), target=target, model=model)
     assert isinstance(result, list)
     assert len(result) > 0
@@ -35,7 +35,7 @@ def test_met_agent_only_returns_blank() -> None:
             [16, BLANK_VALUE, 18, 19, 20],
         ]
     )
-    model = DynamicMET(rows * cols, rows * cols + 1, rows=rows, cols=cols)
+    model = DynamicMET(rows * cols, rows=rows, cols=cols)
     target = 15
     res = predict(board.copy(), target=target, model=model, topk=3)
     assert len(res) <= 3

--- a/tests/test_app_fallback.py
+++ b/tests/test_app_fallback.py
@@ -14,7 +14,7 @@ def test_app_predict_numpy(monkeypatch):
     importlib.reload(model)
     importlib.reload(appmod)
     appmod.models.clear()
-    appmod.models[(2, 2)] = model.DynamicMET(4, 5, rows=2, cols=2)
+    appmod.models[(2, 2)] = model.DynamicMET(4, rows=2, cols=2)
     board = np.array([[1, 2], [3, -1]]).tolist()
     payload = appmod.PredictRequest(board=board, target_value=1)
     result = appmod.predict(payload)

--- a/tests/test_blank_top3.py
+++ b/tests/test_blank_top3.py
@@ -9,7 +9,7 @@ import app as appmod
 def test_predict_only_blank_top3(caplog):
     importlib.reload(appmod)
     appmod.models.clear()
-    appmod.models[(2, 3)] = appmod.DynamicMET(6, 6, rows=2, cols=3)
+    appmod.models[(2, 3)] = appmod.DynamicMET(6, rows=2, cols=3)
     board = np.array([[1, -1, 2], [-1, 3, 4]]).tolist()
     payload = appmod.PredictRequest(board=board, target=1)
     with caplog.at_level(logging.INFO):

--- a/tests/test_index_mapping.py
+++ b/tests/test_index_mapping.py
@@ -1,0 +1,61 @@
+import random
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from agents.met_agent import predict
+from dataset import BLANK_VALUE, MASK_TOKEN_ID
+from model import DynamicMET
+
+torch = pytest.importorskip("torch")
+
+
+def test_classifier_output_dim() -> None:
+    model = DynamicMET(num_fields=80, rows=8, cols=10)
+    assert model.classifier.out_features == 81
+
+
+def test_index_semantics() -> None:
+    model = DynamicMET(num_fields=80, rows=8, cols=10)
+    board = np.full((8, 10), BLANK_VALUE, dtype=int)
+    board[3, 5] = 17
+    x = np.where(board == BLANK_VALUE, MASK_TOKEN_ID, board)
+    y = np.where(board == BLANK_VALUE, MASK_TOKEN_ID, board)
+    inp = torch.as_tensor(x.reshape(1, -1), dtype=torch.long)
+    logits = model(inp)
+    assert logits.shape == (1, 80, 81)
+    dist = logits[0, 3 * 10 + 5]
+    assert dist.shape[0] == 81
+    assert y.flatten()[3 * 10 + 5] == 17
+
+
+def test_deterministic_topk() -> None:
+    seed = 20250802
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.benchmark = False
+    board = np.full((8, 10), BLANK_VALUE, dtype=int)
+    board[0, 0] = 1
+    model = DynamicMET(num_fields=80, rows=8, cols=10)
+    results = [predict(board.copy(), target=1, model=model) for _ in range(10)]
+    for r in results[1:]:
+        assert r == results[0]
+
+
+def test_no_forbidden_keywords() -> None:
+    forbidden = (
+        "alpha",
+        "heatmap",
+        "prior",
+        "temperature",
+        "label_bias",
+        "position_bias",
+        "fuse_predictions_with_heatmap",
+    )
+    paths = [Path("agents/met_agent.py"), Path("app.py")]
+    text = "\n".join(p.read_text().lower() for p in paths)
+    for kw in forbidden:
+        assert kw not in text

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,7 +6,7 @@ torch = pytest.importorskip("torch")
 
 
 def test_dynamic_met_forward() -> None:
-    model = DynamicMET(num_fields=20, num_values=10, rows=4, cols=5)
-    x = torch.randint(0, 11, (2, 20))
+    model = DynamicMET(num_fields=20, rows=4, cols=5)
+    x = torch.randint(0, 81, (2, 20))
     out = model(x)
-    assert out.shape == (2, 20, 11)
+    assert out.shape == (2, 20, 81)

--- a/train.py
+++ b/train.py
@@ -8,7 +8,7 @@ from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from dataset import MASK_TOKEN_ID, ScratchCardDataset, validate_board
+from dataset import ScratchCardDataset, validate_board
 from model import DynamicMET
 from utils.io_utils import load_boards_from_archives
 from utils.logger import save_checkpoint, setup_logger
@@ -114,6 +114,7 @@ def main() -> None:
 
     logger = setup_logger()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info("TRAIN cfg: num_values=81, MASK_TOKEN_ID=0, BLANK_VALUE=-1")
 
     # Extract and parse training hyperparams
     if args.mode == "reconstruct":
@@ -138,7 +139,7 @@ def main() -> None:
 
         # Prepare model fields
         cfg["model"]["num_fields"] = rows * cols
-        cfg["model"]["num_values"] = rows * cols
+        cfg["model"]["num_values"] = 81
 
         # Prepare datasets and loaders with a validation split
         n_items = len(group)
@@ -201,7 +202,7 @@ def main() -> None:
                 model.col_emb,
                 model.embed_dropout,
                 model.norm_out,
-                model.head,
+                model.classifier,
             ]:
                 if mod is not None:
                     other_params += list(mod.parameters())
@@ -217,10 +218,7 @@ def main() -> None:
                 weight_decay=weight_decay,
             )
 
-        criterion = nn.CrossEntropyLoss(
-            ignore_index=MASK_TOKEN_ID,
-            label_smoothing=float(cfg["training"].get("label_smoothing", 0.0)),
-        )
+        criterion = nn.CrossEntropyLoss(ignore_index=0)
 
         total_steps = epochs * len(train_loader)
         warmup_epochs = float(


### PR DESCRIPTION
## Summary
- fix dataset/model/training to use 81 classes with 0 as blank
- enforce deterministic inference and stable top-k on blank cells
- add regression tests for index semantics and banned keywords

## Testing
- `isort --check .`
- `black --check .`
- `flake8 && echo flake8_ok`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d6dfc9d30832482e83a4b8873fe24