### PR TITLE
feat: adopt 81-class index mapping

### DIFF
--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -1,5 +1,6 @@
 """Agent that predicts scratch card positions using a DynamicMET model."""
 
+import logging
 from typing import Any, Dict, List
 
 import numpy as np
@@ -12,9 +13,11 @@ except Exception:  # pragma: no cover - torch missing
     torch = None  # type: ignore[assignment]
     TORCH_AVAILABLE = False
 
-from dataset import BLANK_VALUE
+from dataset import BLANK_VALUE, MASK_TOKEN_ID
 from model import DynamicMET
 from utils import ensure_only_blank, index_to_coord
+
+logger = logging.getLogger(__name__)
 
 
 def predict(
@@ -24,41 +27,52 @@ def predict(
     rows, cols = board.shape
     flat = board.flatten()
 
-    mask_pos = np.where(flat == BLANK_VALUE)[0]
-    if mask_pos.size == 0:
+    candidate_idx = np.where(flat == BLANK_VALUE)[0]
+    if candidate_idx.size == 0:
         return []
 
-    arr_inp = np.where(flat < 0, 0, flat)
+    arr_inp = np.where(flat == BLANK_VALUE, MASK_TOKEN_ID, flat).astype(np.int64)
 
     if TORCH_AVAILABLE and isinstance(model, torch.nn.Module):
         inp = torch.as_tensor(arr_inp, dtype=torch.long).unsqueeze(0)
-        logits = model(inp)
+        model.eval()
+        with torch.no_grad():
+            logits = model(inp)
+        logger.info(
+            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            tuple(logits.shape),
+        )
         probs = torch.softmax(logits, dim=-1)
         V = probs.shape[-1]
-        target_idx = target if V == flat.size + 1 else target - 1
+        target_idx = target
         if not (0 <= target_idx < V):
             raise RuntimeError(
                 f"target_idx out of range: target={target} -> {target_idx}, V={V}"
             )
         scores_all = probs[0, :, target_idx].detach().cpu().numpy()
     else:
-        inp = arr_inp.reshape(1, -1).astype(np.int64, copy=False)
+        inp = arr_inp.reshape(1, -1)
         logits = model(inp)
+        logger.info(
+            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            tuple(logits.shape),
+        )
         arr = np.asarray(logits)
         V = arr.shape[-1]
-        target_idx = target if V == flat.size + 1 else target - 1
+        target_idx = target
         if not (0 <= target_idx < V):
             raise RuntimeError(
                 f"target_idx out of range: target={target} -> {target_idx}, V={V}"
             )
         scores_all = arr[0, :, target_idx]
 
-    cand_scores = scores_all[mask_pos]
-    k = min(topk, cand_scores.size)
+    candidate_scores = scores_all[candidate_idx]
+    k = min(topk, candidate_scores.size)
     if k == 0:
         return []
-    local_idx = np.argsort(cand_scores)[-k:][::-1]
-    top_indices = mask_pos[local_idx]
+    topk_local = np.argpartition(candidate_scores, -k)[-k:]
+    order = np.lexsort((candidate_idx[topk_local], -candidate_scores[topk_local]))
+    top_indices = candidate_idx[topk_local][order][-k:][::-1]
 
     results: List[Dict[str, Any]] = []
     for idx in top_indices:

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ except Exception:  # torch may be unavailable in minimal runtimes
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
-from dataset import BLANK_VALUE
+from dataset import BLANK_VALUE, MASK_TOKEN_ID
 from model import DynamicMET
 from utils import ensure_only_blank
 
@@ -98,8 +98,24 @@ models: Dict[Tuple[int, int], DynamicMET] = {}
 
 def _create_model(rows: int, cols: int) -> DynamicMET:
     """Return a :class:`DynamicMET` with training hyperparameters."""
-
-    return DynamicMET(rows * cols, rows * cols, rows=rows, cols=cols, **MODEL_PARAMS)
+    logger.info(
+        "Model: shape=%sx%s, d_model=%s, depth=%s, nhead=%s, num_values=81",
+        rows,
+        cols,
+        MODEL_PARAMS["d_model"],
+        MODEL_PARAMS["depth"],
+        MODEL_PARAMS["nhead"],
+    )
+    logger.info(
+        "Mapping: BLANK_VALUE=%s -> MASK_TOKEN_ID=%s ; labels 1..80",
+        BLANK_VALUE,
+        MASK_TOKEN_ID,
+    )
+    det = False
+    if torch is not None and hasattr(torch, "are_deterministic_algorithms_enabled"):
+        det = torch.are_deterministic_algorithms_enabled()
+    logger.info("Deterministic: %s", det)
+    return DynamicMET(rows * cols, num_values=81, rows=rows, cols=cols, **MODEL_PARAMS)
 
 
 def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
@@ -112,6 +128,7 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
         model.load_state_dict(state, strict=False)
         if hasattr(model, "eval"):
             model.eval()
+        assert model.classifier.out_features == 81, "num_values 必須是 81 (含空白)"
         logger.info(
             "載入模型檔案 %s，尺寸 %sx%s", path, rows, cols
         )  # 中文log：載入已存在的模型
@@ -119,6 +136,7 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
         logger.info(
             "建立新模型，尺寸 %sx%s", rows, cols
         )  # 中文log：未找到檔案時新建模型
+        assert model.classifier.out_features == 81, "num_values 必須是 81 (含空白)"
     return model
 
 
@@ -204,7 +222,9 @@ def predict(req: PredictRequest):
     logger.info("[CHK] mask_pos=%s", mask_pos.tolist())
 
     # ensure contiguous int64 array to avoid torch dtype inference errors
-    flat_input = np.where(flat < 0, 0, flat).astype(np.int64, copy=False)
+    flat_input = np.where(flat == BLANK_VALUE, MASK_TOKEN_ID, flat).astype(
+        np.int64, copy=False
+    )
     flat_input = np.ascontiguousarray(flat_input)
     logger.info(
         "[CHK] flat_input: shape=%s dtype=%s sample=%s",
@@ -229,7 +249,13 @@ def predict(req: PredictRequest):
     if torch is not None:
         # use as_tensor to avoid copy and specify dtype explicitly
         inp = torch.as_tensor(flat_input, dtype=torch.long).unsqueeze(0)
-        logits = model(inp)  # type: ignore[misc]
+        model.eval()
+        with torch.no_grad():
+            logits = model(inp)  # type: ignore[misc]
+        logger.info(
+            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            tuple(logits.shape),
+        )
         if logger.isEnabledFor(logging.DEBUG):
             n_f = logits.size(1)
             pos_ids = torch.arange(n_f, device=logits.device)
@@ -249,7 +275,7 @@ def predict(req: PredictRequest):
             tuple(probs.shape),
         )
         V = probs.shape[-1]
-        target_idx = target if V == n + 1 else target - 1
+        target_idx = target
         if not (0 <= target_idx < V):
             raise HTTPException(
                 status_code=422,
@@ -266,8 +292,12 @@ def predict(req: PredictRequest):
             inp.shape,
             arr.shape,
         )
+        logger.info(
+            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            arr.shape,
+        )
         V = arr.shape[-1]
-        target_idx = target if V == n + 1 else target - 1
+        target_idx = target
         if not (0 <= target_idx < V):
             raise HTTPException(
                 status_code=422,
@@ -275,12 +305,13 @@ def predict(req: PredictRequest):
             )
         scores_np = arr[0, :, target_idx]
 
-    candidate_scores = scores_np[mask_pos]
-    topk_local = np.argsort(candidate_scores)[-min(3, len(candidate_scores)) :][::-1]
-    logger.info(
-        "從 %s 個候選格中挑選前 %s 名", len(candidate_scores), len(topk_local)
-    )  # 中文log：候選格與返回數量
-    top_indices = mask_pos[topk_local]
+    candidate_idx = mask_pos
+    candidate_scores = scores_np[candidate_idx]
+    k = min(3, len(candidate_scores))
+    topk_local = np.argpartition(candidate_scores, -k)[-k:]
+    order = np.lexsort((candidate_idx[topk_local], -candidate_scores[topk_local]))
+    top_indices = candidate_idx[topk_local][order][-k:][::-1]
+    logger.info("TopK: candidates = %s, k=%s", len(candidate_scores), k)
     logger.info("[CHK] top_indices=%s", top_indices.tolist())
 
     picked_vals = [int(flat[idx]) for idx in top_indices]

--- a/dataset.py
+++ b/dataset.py
@@ -14,6 +14,7 @@ except Exception:  # pragma: no cover - torch missing
 
 MASK_TOKEN_ID = 0
 BLANK_VALUE = -1
+MAX_VALUE = 80
 
 
 def mask_target_patch(
@@ -35,11 +36,10 @@ def mask_target_patch(
 def validate_board(board: np.ndarray) -> None:
     """Validate board contents.
 
-    Ensures numbers are unique and within ``1..N`` where ``N`` is the board
-    size. ``BLANK_VALUE`` (-1) is allowed to denote empty cells.
+    Ensures numbers are unique and within ``1..MAX_VALUE``. ``BLANK_VALUE``
+    (-1) is allowed to denote empty cells.
     """
-    n = board.size
-    valid_values = set(range(1, n + 1))
+    valid_values = set(range(1, MAX_VALUE + 1))
     flat = board.ravel()
     for v in flat:
         if v != BLANK_VALUE and v not in valid_values:
@@ -114,7 +114,9 @@ class ScratchCardDataset(Dataset):
             raise RuntimeError("Torch is required for ScratchCardDataset")
 
         board_arr = self.boards[idx].flatten()
-        board = torch.from_numpy(board_arr).long()
+        board_arr_mapped = np.where(board_arr == BLANK_VALUE, MASK_TOKEN_ID, board_arr)
+        board = torch.from_numpy(board_arr_mapped).long()
+        board_orig = torch.from_numpy(board_arr).long()
         target_val = int(self.targets[idx])
         target = torch.tensor(target_val).long()
 
@@ -126,10 +128,10 @@ class ScratchCardDataset(Dataset):
             else:
                 ratio = self.mask_ratio
             mask = torch.rand(board.shape) < ratio
-            mask |= board == target_val
-            mask |= board == BLANK_VALUE
+            mask |= board_orig == target_val
+            mask |= board_orig == BLANK_VALUE
         elif self.mode == "target":
-            mask = (board == target_val) | (board == BLANK_VALUE)
+            mask = (board_orig == target_val) | (board_orig == BLANK_VALUE)
         elif self.mode == "patch":
             board2d = self.boards[idx]
             r, c = np.argwhere(board2d == target_val)[0]
@@ -143,9 +145,7 @@ class ScratchCardDataset(Dataset):
         inp = board.clone()
         inp[mask] = MASK_TOKEN_ID
 
-        orig = torch.full_like(board, MASK_TOKEN_ID)
-        valid_mask = mask & (board != BLANK_VALUE)
-        orig[valid_mask] = board[valid_mask]
+        orig = torch.where(mask, board, torch.full_like(board, MASK_TOKEN_ID))
 
         return {
             "input_vals": inp,

--- a/model.py
+++ b/model.py
@@ -17,7 +17,7 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
     def __init__(
         self,
         num_fields: int,
-        num_values: int,
+        num_values: int = 81,
         d_model: int = 128,
         nhead: int = 4,
         depth: int = 6,
@@ -27,6 +27,8 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
         rows: int = 1,
         cols: int | None = None,
     ) -> None:
+        if num_values != 81:
+            raise ValueError("num_values must be 81 (including blank)")
         self.num_fields = int(num_fields)
         self.num_values = int(num_values)
         self.d_model = int(d_model)
@@ -36,7 +38,7 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             raise ValueError("rows*cols must equal num_fields")
         if TORCH_AVAILABLE:
             super().__init__()  # type: ignore[misc]
-            self.token_emb = nn.Embedding(num_values + 1, d_model)
+            self.token_emb = nn.Embedding(num_values, d_model)
             row_dim = d_model // 2
             col_dim = d_model - row_dim
             self.row_emb = nn.Embedding(self.rows, row_dim)
@@ -57,7 +59,8 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
                 ]
             )
             self.norm_out = nn.LayerNorm(d_model)
-            self.head = nn.Linear(d_model, num_values + 1)
+            self.classifier = nn.Linear(d_model, num_values)
+            assert self.classifier.out_features == 81, "num_values 必須是 81 (含空白)"
         else:
             self.token_emb = None
             self.row_emb = None
@@ -78,11 +81,11 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             for blk in self.blocks:
                 h = blk(h, row_ids, col_ids, attn_mask=None)
             h = self.norm_out(h)
-            logits = self.head(h)
+            logits = self.classifier(h)
             return logits
         import numpy as np
 
         bsz, fields = x.shape
-        return np.zeros((bsz, fields, self.num_values + 1), dtype=float)
+        return np.zeros((bsz, fields, self.num_values), dtype=float)
 
     __call__ = forward

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -16,7 +16,7 @@ def test_met_agent_predict_on_10x12() -> None:
     non_blanks = np.argwhere(grid != BLANK_VALUE)
     target_r, target_c = non_blanks[rng.integers(len(non_blanks))]
     target = int(grid[target_r, target_c])
-    model = DynamicMET(rows * cols, 100, rows=rows, cols=cols)
+    model = DynamicMET(rows * cols, 81, rows=rows, cols=cols)
     result = predict(grid.copy(), target=target, model=model)
     assert isinstance(result, list)
     assert len(result) > 0
@@ -35,7 +35,7 @@ def test_met_agent_only_returns_blank() -> None:
             [16, BLANK_VALUE, 18, 19, 20],
         ]
     )
-    model = DynamicMET(rows * cols, rows * cols + 1, rows=rows, cols=cols)
+    model = DynamicMET(rows * cols, 81, rows=rows, cols=cols)
     target = 15
     res = predict(board.copy(), target=target, model=model, topk=3)
     assert len(res) <= 3

--- a/tests/test_app_fallback.py
+++ b/tests/test_app_fallback.py
@@ -14,7 +14,7 @@ def test_app_predict_numpy(monkeypatch):
     importlib.reload(model)
     importlib.reload(appmod)
     appmod.models.clear()
-    appmod.models[(2, 2)] = model.DynamicMET(4, 5, rows=2, cols=2)
+    appmod.models[(2, 2)] = model.DynamicMET(4, 81, rows=2, cols=2)
     board = np.array([[1, 2], [3, -1]]).tolist()
     payload = appmod.PredictRequest(board=board, target_value=1)
     result = appmod.predict(payload)

--- a/tests/test_blank_top3.py
+++ b/tests/test_blank_top3.py
@@ -9,7 +9,7 @@ import app as appmod
 def test_predict_only_blank_top3(caplog):
     importlib.reload(appmod)
     appmod.models.clear()
-    appmod.models[(2, 3)] = appmod.DynamicMET(6, 6, rows=2, cols=3)
+    appmod.models[(2, 3)] = appmod.DynamicMET(6, 81, rows=2, cols=3)
     board = np.array([[1, -1, 2], [-1, 3, 4]]).tolist()
     payload = appmod.PredictRequest(board=board, target=1)
     with caplog.at_level(logging.INFO):

--- a/tests/test_index_mapping.py
+++ b/tests/test_index_mapping.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from dataset import BLANK_VALUE, MASK_TOKEN_ID
+from model import DynamicMET
+
+torch = pytest.importorskip("torch")
+
+
+def test_model_output_dim_and_mapping():
+    model = DynamicMET(num_fields=80, num_values=81, rows=8, cols=10)
+    assert model.classifier.out_features == 81
+
+    board = np.full((8, 10), BLANK_VALUE, dtype=int)
+    board[3, 5] = 17
+    x = np.where(board == BLANK_VALUE, MASK_TOKEN_ID, board).astype(np.int64)
+    y = np.where(board == BLANK_VALUE, MASK_TOKEN_ID, board).astype(np.int64)
+    assert y[3, 5] == 17
+
+    inp = torch.from_numpy(x.flatten()).unsqueeze(0)
+    logits = model(inp)
+    assert logits.shape == (1, 80, 81)
+    dist = logits[0, 3 * 10 + 5]
+    assert dist.shape[0] == 81
+    # bias to force argmax at 17 to smoke-test index semantics
+    model.classifier.bias.data.zero_()
+    model.classifier.bias.data[17] = 1.0
+    logits2 = model(inp)
+    dist2 = logits2[0, 3 * 10 + 5]
+    assert int(dist2.argmax().item()) == 17
+
+
+def test_no_prior_keywords():
+    banned = ["alpha", "heatmap", "prior", "temperature", "label_bias", "position_bias"]
+    for path in ["agents/met_agent.py", "app.py"]:
+        text = open(path, encoding="utf-8").read().lower()
+        for word in banned:
+            assert word not in text

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,7 +6,7 @@ torch = pytest.importorskip("torch")
 
 
 def test_dynamic_met_forward() -> None:
-    model = DynamicMET(num_fields=20, num_values=10, rows=4, cols=5)
-    x = torch.randint(0, 11, (2, 20))
+    model = DynamicMET(num_fields=20, num_values=81, rows=4, cols=5)
+    x = torch.randint(0, 81, (2, 20))
     out = model(x)
-    assert out.shape == (2, 20, 11)
+    assert out.shape == (2, 20, 81)

--- a/train.py
+++ b/train.py
@@ -1,6 +1,8 @@
 import argparse
+import random
 from pathlib import Path
 
+import numpy as np
 import torch
 import torch.nn as nn
 import yaml
@@ -8,7 +10,7 @@ from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from dataset import MASK_TOKEN_ID, ScratchCardDataset, validate_board
+from dataset import BLANK_VALUE, MASK_TOKEN_ID, ScratchCardDataset, validate_board
 from model import DynamicMET
 from utils.io_utils import load_boards_from_archives
 from utils.logger import save_checkpoint, setup_logger
@@ -100,6 +102,13 @@ def main() -> None:
         cfg["training"]["epochs"] = args.epochs
     epochs = int(cfg["training"]["epochs"])
 
+    seed = 20250802
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.benchmark = False
+
     # Load all boards; masking is handled by the dataset according to mode
     boards = load_boards_from_archives(cfg["data"]["data_dir"], mask_target=False)
     if not boards:
@@ -135,10 +144,15 @@ def main() -> None:
         logger.info(
             f"Starting training for shape {model_name} with {len(group)} samples"
         )
+        logger.info(
+            "TRAIN cfg: num_values=81, MASK_TOKEN_ID=%s, BLANK_VALUE=%s",
+            MASK_TOKEN_ID,
+            BLANK_VALUE,
+        )
 
         # Prepare model fields
         cfg["model"]["num_fields"] = rows * cols
-        cfg["model"]["num_values"] = rows * cols
+        cfg["model"]["num_values"] = 81
 
         # Prepare datasets and loaders with a validation split
         n_items = len(group)
@@ -201,7 +215,7 @@ def main() -> None:
                 model.col_emb,
                 model.embed_dropout,
                 model.norm_out,
-                model.head,
+                model.classifier,
             ]:
                 if mod is not None:
                     other_params += list(mod.parameters())
@@ -217,10 +231,7 @@ def main() -> None:
                 weight_decay=weight_decay,
             )
 
-        criterion = nn.CrossEntropyLoss(
-            ignore_index=MASK_TOKEN_ID,
-            label_smoothing=float(cfg["training"].get("label_smoothing", 0.0)),
-        )
+        criterion = nn.CrossEntropyLoss(ignore_index=MASK_TOKEN_ID)
 
         total_steps = epochs * len(train_loader)
         warmup_epochs = float(


### PR DESCRIPTION
## Summary
- fix index mapping to 0=blank, 1..80=values with 81-class head
- remove prior/temperature tricks and enforce pure logits ordering
- add regression tests for mapping and banned keywords

## Testing
- `isort . --profile black --check`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d6df620ac8324bd683c3ff8c75458