### PR TITLE
feat: remove fixed value count from DynamicMET

### DIFF
--- a/agent_demo.py
+++ b/agent_demo.py
@@ -20,7 +20,15 @@ def main() -> None:
         board = np.array(json.load(f)["board"], dtype=int)
 
     rows, cols = board.shape
-    model = DynamicMET(rows * cols, 80, rows=rows, cols=cols)
+    num_fields = rows * cols
+    model = DynamicMET(
+        num_fields=num_fields,
+        num_values=num_fields,
+        d_model=256,
+        rows=rows,
+        cols=cols,
+        dropout=0.1,
+    )
     ckpt = torch.load(args.model, map_location="cpu")
     model.load_state_dict(ckpt["model"])  # type: ignore[arg-type]
 

--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -38,8 +38,11 @@ def predict(
         model.eval()
         with torch.no_grad():
             logits = model(inp)
+        n = model.num_fields
         logger.info(
-            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            "IDX semantics: 0=blank(ignored), 1..%s=numbers 1..%s ; logits.shape=%s",
+            n,
+            n,
             tuple(logits.shape),
         )
         probs = torch.softmax(logits, dim=-1)
@@ -53,8 +56,11 @@ def predict(
     else:
         inp = arr_inp.reshape(1, -1)
         logits = model(inp)
+        n = model.num_fields
         logger.info(
-            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            "IDX semantics: 0=blank(ignored), 1..%s=numbers 1..%s ; logits.shape=%s",
+            n,
+            n,
             tuple(logits.shape),
         )
         arr = np.asarray(logits)

--- a/app.py
+++ b/app.py
@@ -98,24 +98,33 @@ models: Dict[Tuple[int, int], DynamicMET] = {}
 
 def _create_model(rows: int, cols: int) -> DynamicMET:
     """Return a :class:`DynamicMET` with training hyperparameters."""
+    num_fields = rows * cols
     logger.info(
-        "Model: shape=%sx%s, d_model=%s, depth=%s, nhead=%s, num_values=81",
+        "Model: shape=%sx%s, d_model=%s, depth=%s, nhead=%s, num_values=%s",
         rows,
         cols,
         MODEL_PARAMS["d_model"],
         MODEL_PARAMS["depth"],
         MODEL_PARAMS["nhead"],
+        num_fields,
     )
     logger.info(
-        "Mapping: BLANK_VALUE=%s -> MASK_TOKEN_ID=%s ; labels 1..80",
+        "Mapping: BLANK_VALUE=%s -> MASK_TOKEN_ID=%s ; labels 1..%s",
         BLANK_VALUE,
         MASK_TOKEN_ID,
+        num_fields,
     )
     det = False
     if torch is not None and hasattr(torch, "are_deterministic_algorithms_enabled"):
         det = torch.are_deterministic_algorithms_enabled()
     logger.info("Deterministic: %s", det)
-    return DynamicMET(rows * cols, num_values=81, rows=rows, cols=cols, **MODEL_PARAMS)
+    return DynamicMET(
+        num_fields=num_fields,
+        num_values=num_fields,
+        rows=rows,
+        cols=cols,
+        **MODEL_PARAMS,
+    )
 
 
 def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
@@ -128,7 +137,9 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
         model.load_state_dict(state, strict=False)
         if hasattr(model, "eval"):
             model.eval()
-        assert model.classifier.out_features == 81, "num_values 必須是 81 (含空白)"
+        assert (
+            model.classifier.out_features == model.num_values
+        ), "classifier dim mismatch"
         logger.info(
             "載入模型檔案 %s，尺寸 %sx%s", path, rows, cols
         )  # 中文log：載入已存在的模型
@@ -136,7 +147,9 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
         logger.info(
             "建立新模型，尺寸 %sx%s", rows, cols
         )  # 中文log：未找到檔案時新建模型
-        assert model.classifier.out_features == 81, "num_values 必須是 81 (含空白)"
+        assert (
+            model.classifier.out_features == model.num_values
+        ), "classifier dim mismatch"
     return model
 
 
@@ -253,7 +266,9 @@ def predict(req: PredictRequest):
         with torch.no_grad():
             logits = model(inp)  # type: ignore[misc]
         logger.info(
-            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            "IDX semantics: 0=blank(ignored), 1..%s=numbers 1..%s ; logits.shape=%s",
+            n,
+            n,
             tuple(logits.shape),
         )
         if logger.isEnabledFor(logging.DEBUG):
@@ -293,7 +308,9 @@ def predict(req: PredictRequest):
             arr.shape,
         )
         logger.info(
-            "IDX semantics: 0=blank(ignored), 1..80=numbers 1..80 ; logits.shape=%s",
+            "IDX semantics: 0=blank(ignored), 1..%s=numbers 1..%s ; logits.shape=%s",
+            n,
+            n,
             arr.shape,
         )
         V = arr.shape[-1]

--- a/dataset.py
+++ b/dataset.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - torch missing
 
 MASK_TOKEN_ID = 0
 BLANK_VALUE = -1
-MAX_VALUE = 80
+# Maximum board value is derived from board size at runtime
 
 
 def mask_target_patch(
@@ -36,10 +36,11 @@ def mask_target_patch(
 def validate_board(board: np.ndarray) -> None:
     """Validate board contents.
 
-    Ensures numbers are unique and within ``1..MAX_VALUE``. ``BLANK_VALUE``
+    Ensures numbers are unique and within ``1..board.size``. ``BLANK_VALUE``
     (-1) is allowed to denote empty cells.
     """
-    valid_values = set(range(1, MAX_VALUE + 1))
+    max_value = board.size
+    valid_values = set(range(1, max_value + 1))
     flat = board.ravel()
     for v in flat:
         if v != BLANK_VALUE and v not in valid_values:

--- a/model.py
+++ b/model.py
@@ -17,7 +17,7 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
     def __init__(
         self,
         num_fields: int,
-        num_values: int = 81,
+        num_values: int | None = None,
         d_model: int = 128,
         nhead: int = 4,
         depth: int = 6,
@@ -27,10 +27,8 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
         rows: int = 1,
         cols: int | None = None,
     ) -> None:
-        if num_values != 81:
-            raise ValueError("num_values must be 81 (including blank)")
         self.num_fields = int(num_fields)
-        self.num_values = int(num_values)
+        self.num_values = int(num_values if num_values is not None else num_fields) + 1
         self.d_model = int(d_model)
         self.rows = int(rows)
         self.cols = int(cols if cols is not None else rows if rows > 0 else 1)
@@ -38,7 +36,7 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             raise ValueError("rows*cols must equal num_fields")
         if TORCH_AVAILABLE:
             super().__init__()  # type: ignore[misc]
-            self.token_emb = nn.Embedding(num_values, d_model)
+            self.token_emb = nn.Embedding(self.num_values, d_model)
             row_dim = d_model // 2
             col_dim = d_model - row_dim
             self.row_emb = nn.Embedding(self.rows, row_dim)
@@ -59,8 +57,10 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
                 ]
             )
             self.norm_out = nn.LayerNorm(d_model)
-            self.classifier = nn.Linear(d_model, num_values)
-            assert self.classifier.out_features == 81, "num_values 必須是 81 (含空白)"
+            self.classifier = nn.Linear(d_model, self.num_values)
+            assert (
+                self.classifier.out_features == self.num_values
+            ), "classifier dim mismatch"
         else:
             self.token_emb = None
             self.row_emb = None

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -16,7 +16,7 @@ def test_met_agent_predict_on_10x12() -> None:
     non_blanks = np.argwhere(grid != BLANK_VALUE)
     target_r, target_c = non_blanks[rng.integers(len(non_blanks))]
     target = int(grid[target_r, target_c])
-    model = DynamicMET(rows * cols, 81, rows=rows, cols=cols)
+    model = DynamicMET(rows * cols, num_values=rows * cols, rows=rows, cols=cols)
     result = predict(grid.copy(), target=target, model=model)
     assert isinstance(result, list)
     assert len(result) > 0
@@ -35,7 +35,7 @@ def test_met_agent_only_returns_blank() -> None:
             [16, BLANK_VALUE, 18, 19, 20],
         ]
     )
-    model = DynamicMET(rows * cols, 81, rows=rows, cols=cols)
+    model = DynamicMET(rows * cols, num_values=rows * cols, rows=rows, cols=cols)
     target = 15
     res = predict(board.copy(), target=target, model=model, topk=3)
     assert len(res) <= 3

--- a/tests/test_app_fallback.py
+++ b/tests/test_app_fallback.py
@@ -14,7 +14,7 @@ def test_app_predict_numpy(monkeypatch):
     importlib.reload(model)
     importlib.reload(appmod)
     appmod.models.clear()
-    appmod.models[(2, 2)] = model.DynamicMET(4, 81, rows=2, cols=2)
+    appmod.models[(2, 2)] = model.DynamicMET(4, num_values=4, rows=2, cols=2)
     board = np.array([[1, 2], [3, -1]]).tolist()
     payload = appmod.PredictRequest(board=board, target_value=1)
     result = appmod.predict(payload)

--- a/tests/test_blank_top3.py
+++ b/tests/test_blank_top3.py
@@ -9,7 +9,7 @@ import app as appmod
 def test_predict_only_blank_top3(caplog):
     importlib.reload(appmod)
     appmod.models.clear()
-    appmod.models[(2, 3)] = appmod.DynamicMET(6, 81, rows=2, cols=3)
+    appmod.models[(2, 3)] = appmod.DynamicMET(6, num_values=6, rows=2, cols=3)
     board = np.array([[1, -1, 2], [-1, 3, 4]]).tolist()
     payload = appmod.PredictRequest(board=board, target=1)
     with caplog.at_level(logging.INFO):

--- a/tests/test_index_mapping.py
+++ b/tests/test_index_mapping.py
@@ -8,10 +8,14 @@ torch = pytest.importorskip("torch")
 
 
 def test_model_output_dim_and_mapping():
-    model = DynamicMET(num_fields=80, num_values=81, rows=8, cols=10)
-    assert model.classifier.out_features == 81
+    rows, cols = 8, 10
+    num_fields = rows * cols
+    model = DynamicMET(
+        num_fields=num_fields, num_values=num_fields, rows=rows, cols=cols
+    )
+    assert model.classifier.out_features == model.num_values
 
-    board = np.full((8, 10), BLANK_VALUE, dtype=int)
+    board = np.full((rows, cols), BLANK_VALUE, dtype=int)
     board[3, 5] = 17
     x = np.where(board == BLANK_VALUE, MASK_TOKEN_ID, board).astype(np.int64)
     y = np.where(board == BLANK_VALUE, MASK_TOKEN_ID, board).astype(np.int64)
@@ -19,9 +23,9 @@ def test_model_output_dim_and_mapping():
 
     inp = torch.from_numpy(x.flatten()).unsqueeze(0)
     logits = model(inp)
-    assert logits.shape == (1, 80, 81)
+    assert logits.shape == (1, num_fields, model.num_values)
     dist = logits[0, 3 * 10 + 5]
-    assert dist.shape[0] == 81
+    assert dist.shape[0] == model.num_values
     # bias to force argmax at 17 to smoke-test index semantics
     model.classifier.bias.data.zero_()
     model.classifier.bias.data[17] = 1.0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,7 +6,8 @@ torch = pytest.importorskip("torch")
 
 
 def test_dynamic_met_forward() -> None:
-    model = DynamicMET(num_fields=20, num_values=81, rows=4, cols=5)
-    x = torch.randint(0, 81, (2, 20))
+    num_fields = 20
+    model = DynamicMET(num_fields=num_fields, num_values=num_fields, rows=4, cols=5)
+    x = torch.randint(0, model.num_values, (2, num_fields))
     out = model(x)
-    assert out.shape == (2, 20, 81)
+    assert out.shape == (2, num_fields, model.num_values)

--- a/train.py
+++ b/train.py
@@ -144,15 +144,17 @@ def main() -> None:
         logger.info(
             f"Starting training for shape {model_name} with {len(group)} samples"
         )
+        num_fields = rows * cols
         logger.info(
-            "TRAIN cfg: num_values=81, MASK_TOKEN_ID=%s, BLANK_VALUE=%s",
+            "TRAIN cfg: num_values=%s, MASK_TOKEN_ID=%s, BLANK_VALUE=%s",
+            num_fields,
             MASK_TOKEN_ID,
             BLANK_VALUE,
         )
 
         # Prepare model fields
-        cfg["model"]["num_fields"] = rows * cols
-        cfg["model"]["num_values"] = 81
+        cfg["model"]["num_fields"] = num_fields
+        cfg["model"]["num_values"] = num_fields
 
         # Prepare datasets and loaders with a validation split
         n_items = len(group)


### PR DESCRIPTION
## Summary
- allow DynamicMET to derive its token and classifier size from board dimensions
- update FastAPI app, agent demo and training script to pass dynamic `num_values`
- adjust dataset validation and tests for variable board sizes

## Testing
- `isort --check .`
- `black --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7de1566c8324b884cfd66c82117d