### PR TITLE
Ensure full scoring before top3 selection

### DIFF
--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -1,7 +1,7 @@
 """Agent that predicts scratch card positions using a DynamicMET model."""
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -21,9 +21,19 @@ logger = logging.getLogger(__name__)
 
 
 def predict(
-    board: np.ndarray, *, target: int, model: DynamicMET, topk: int = 3
+    board: np.ndarray,
+    *,
+    target: int,
+    model: DynamicMET,
+    topk: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
-    """Predict top-k blank positions for ``target`` using ``model``."""
+    """Predict blank positions for ``target`` using ``model``.
+
+    The function scores **all** cells on the board in a single forward pass
+    and then selects the scores corresponding to blank cells.  Returned
+    results are sorted by score in descending order.  ``topk`` can be used to
+    limit the number of returned positions (e.g. ``topk=3`` for top-3).
+    """
     validate_board(board, allow_blank=True)
     rows, cols = board.shape
     flat = board.flatten()
@@ -74,12 +84,19 @@ def predict(
         scores_all = arr[0, :, target_idx]
 
     candidate_scores = scores_all[candidate_idx]
-    k = min(topk, candidate_scores.size)
-    if k == 0:
-        return []
-    topk_local = np.argpartition(candidate_scores, -k)[-k:]
-    order = np.lexsort((candidate_idx[topk_local], -candidate_scores[topk_local]))
-    top_indices = candidate_idx[topk_local][order][-k:][::-1]
+    assert (
+        candidate_scores.shape[0] == candidate_idx.shape[0]
+    ), f"空白格 {candidate_idx.shape[0]} 个，却只打分了 {candidate_scores.shape[0]} 个！"
+    logger.debug("✅ 完整打分：空白格共 %s 个，已收到分数", candidate_idx.shape[0])
+    order = np.argsort(-candidate_scores)
+    top5_idx = order[: min(5, candidate_scores.size)]
+    logger.debug(
+        "Top-5 raw scores: %s",
+        ", ".join(f"{candidate_scores[i]:.4f}" for i in top5_idx),
+    )
+    top_indices = candidate_idx[order]
+    if topk is not None:
+        top_indices = top_indices[:topk]
 
     results: List[Dict[str, Any]] = []
     for idx in top_indices:

--- a/app.py
+++ b/app.py
@@ -320,16 +320,24 @@ def predict(req: PredictRequest):
 
     candidate_idx = mask_pos
     candidate_scores = scores_np[candidate_idx]
+    assert (
+        candidate_scores.shape[0] == candidate_idx.shape[0]
+    ), f"空白格 {candidate_idx.shape[0]} 个，却只打分了 {candidate_scores.shape[0]} 个！"
+    logger.debug("✅ 完整打分：空白格共 %s 个，已收到分数", candidate_idx.shape[0])
+    order = np.argsort(-candidate_scores)
+    top5_idx = order[: min(5, candidate_scores.size)]
+    logger.debug(
+        "Top-5 raw scores: %s",
+        ", ".join(f"{candidate_scores[i]:.4f}" for i in top5_idx),
+    )
     total = float(candidate_scores.sum())
     if total > 0:
         norm_scores = candidate_scores / total
     else:
         norm_scores = np.full_like(candidate_scores, 1 / len(candidate_scores))
     k = min(3, len(candidate_scores))
-    topk_local = np.argpartition(candidate_scores, -k)[-k:]
-    order = np.lexsort((candidate_idx[topk_local], -candidate_scores[topk_local]))
-    top_indices = candidate_idx[topk_local][order][-k:][::-1]
-    top_scores = norm_scores[topk_local][order][-k:][::-1]
+    top_indices = candidate_idx[order][:k]
+    top_scores = norm_scores[order][:k]
     logger.info("TopK: candidates = %s, k=%s", len(candidate_scores), k)
     logger.info("[CHK] top_indices=%s", top_indices.tolist())
 

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -19,10 +19,10 @@ def test_met_agent_predict_on_10x12() -> None:
     model = DynamicMET(rows * cols, num_values=rows * cols, rows=rows, cols=cols)
     result = predict(grid.copy(), target=target, model=model)
     assert isinstance(result, list)
-    assert len(result) > 0
-    for item in result:
-        assert isinstance(item, dict)
-        assert "row" in item and "col" in item and "score" in item
+    blank_count = np.sum(grid == BLANK_VALUE)
+    assert len(result) == blank_count
+    scores = [item["score"] for item in result]
+    assert scores == sorted(scores, reverse=True)
 
 
 def test_met_agent_only_returns_blank() -> None:
@@ -38,7 +38,31 @@ def test_met_agent_only_returns_blank() -> None:
     model = DynamicMET(rows * cols, num_values=rows * cols, rows=rows, cols=cols)
     target = 15
     res = predict(board.copy(), target=target, model=model, topk=3)
-    assert len(res) <= 3
+    blank_count = np.sum(board == BLANK_VALUE)
+    assert len(res) == min(3, blank_count)
     for item in res:
         r0, c0 = item["row"] - 1, item["col"] - 1
         assert board[r0, c0] == BLANK_VALUE
+
+
+def test_met_agent_scoring_and_order() -> None:
+    rng = np.random.default_rng(123)
+    rows, cols = rng.integers(4, 8), rng.integers(4, 8)
+    vals = np.arange(1, rows * cols + 1)
+    rng.shuffle(vals)
+    grid = vals.reshape(rows, cols)
+    blank_indices = rng.choice(
+        rows * cols, size=rng.integers(1, rows * cols // 2), replace=False
+    )
+    for idx in blank_indices:
+        r, c = divmod(idx, cols)
+        grid[r, c] = BLANK_VALUE
+    non_blanks = np.argwhere(grid != BLANK_VALUE)
+    target_r, target_c = non_blanks[rng.integers(len(non_blanks))]
+    target = int(grid[target_r, target_c])
+    model = DynamicMET(rows * cols, num_values=rows * cols, rows=rows, cols=cols)
+    results = predict(grid.copy(), target=target, model=model)
+    blank_count = np.sum(grid == BLANK_VALUE)
+    assert len(results) == blank_count
+    scores = [item["score"] for item in results]
+    assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary
- score every blank cell before taking top-3 predictions
- add assertions and debug logs to check scoring coverage and show raw scores
- test that scoring covers all blanks and results are sorted

## Testing
- `isort agents/met_agent.py app.py tests/test_agents/test_met_agent.py --check --diff`
- `black agents/met_agent.py app.py tests/test_agents/test_met_agent.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef0c7a42c832490cae73ffec514ea