### PR TITLE
Ensure deterministic predictions

### DIFF
--- a/agents/met_agent.py
+++ b/agents/met_agent.py
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover - torch missing
 
 from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board
 from model import DynamicMET
-from utils import ensure_only_blank, index_to_coord
+from utils import ensure_only_blank
 
 logger = logging.getLogger(__name__)
 
@@ -88,20 +88,18 @@ def predict(
         candidate_scores.shape[0] == candidate_idx.shape[0]
     ), f"空白格 {candidate_idx.shape[0]} 个，却只打分了 {candidate_scores.shape[0]} 个！"
     logger.debug("✅ 完整打分：空白格共 %s 个，已收到分数", candidate_idx.shape[0])
-    order = np.argsort(-candidate_scores)
-    top5_idx = order[: min(5, candidate_scores.size)]
-    logger.debug(
-        "Top-5 raw scores: %s",
-        ", ".join(f"{candidate_scores[i]:.4f}" for i in top5_idx),
-    )
-    top_indices = candidate_idx[order]
+
+    coord_scores = []
+    for idx, sc in zip(candidate_idx, candidate_scores):
+        r, c = divmod(int(idx), cols)
+        coord_scores.append((r, c, float(sc)))
+    coord_scores.sort(key=lambda x: (-x[2], x[0], x[1]))
     if topk is not None:
-        top_indices = top_indices[:topk]
+        coord_scores = coord_scores[:topk]
 
     results: List[Dict[str, Any]] = []
-    for idx in top_indices:
-        r, c = index_to_coord(int(idx), board.shape)
-        results.append({"row": r, "col": c, "score": float(scores_all[idx])})
+    for r, c, sc in coord_scores:
+        results.append({"row": r, "col": c, "score": sc})
     results = ensure_only_blank(board, results, BLANK_VALUE)
     for item in results:
         item["row"] += 1

--- a/app.py
+++ b/app.py
@@ -1,21 +1,39 @@
-import glob
-import logging
 import os
-import re
-from typing import Dict, List, Optional, Tuple
+import random
 
 import numpy as np
+
+# 1. OS / Python level determinism
+os.environ["PYTHONHASHSEED"] = "42"
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+random.seed(42)
+np.random.seed(42)
 
 try:
     import torch
 except Exception:  # torch may be unavailable in minimal runtimes
     torch = None  # type: ignore[assignment]
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, Field, model_validator
+else:  # pragma: no branch - executed when torch is available
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+    torch.backends.cudnn.benchmark = False
+    torch.backends.cudnn.deterministic = True
+    try:
+        torch.use_deterministic_algorithms(True)
+    except AttributeError:  # pragma: no cover - older torch
+        pass
 
-from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board
-from model import DynamicMET
-from utils import ensure_only_blank, ensure_unique
+import glob  # noqa: E402
+import logging  # noqa: E402
+import re  # noqa: E402
+from typing import Dict, List, Optional, Tuple  # noqa: E402
+
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from pydantic import BaseModel, Field, model_validator  # noqa: E402
+
+from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board  # noqa: E402
+from model import DynamicMET  # noqa: E402
+from utils import ensure_only_blank, ensure_unique  # noqa: E402
 
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO"),
@@ -324,40 +342,35 @@ def predict(req: PredictRequest):
         candidate_scores.shape[0] == candidate_idx.shape[0]
     ), f"空白格 {candidate_idx.shape[0]} 个，却只打分了 {candidate_scores.shape[0]} 个！"
     logger.debug("✅ 完整打分：空白格共 %s 个，已收到分数", candidate_idx.shape[0])
-    order = np.argsort(-candidate_scores)
-    top5_idx = order[: min(5, candidate_scores.size)]
-    logger.debug(
-        "Top-5 raw scores: %s",
-        ", ".join(f"{candidate_scores[i]:.4f}" for i in top5_idx),
-    )
-    total = float(candidate_scores.sum())
-    if total > 0:
-        norm_scores = candidate_scores / total
-    else:
-        norm_scores = np.full_like(candidate_scores, 1 / len(candidate_scores))
-    k = min(3, len(candidate_scores))
-    top_indices = candidate_idx[order][:k]
-    top_scores = norm_scores[order][:k]
-    logger.info("TopK: candidates = %s, k=%s", len(candidate_scores), k)
-    logger.info("[CHK] top_indices=%s", top_indices.tolist())
 
-    picked_vals = [int(flat[idx]) for idx in top_indices]
+    coord_scores = []
+    for idx, sc in zip(candidate_idx, candidate_scores):
+        r, c = np.unravel_index(int(idx), board.shape)
+        coord_scores.append((r, c, float(sc), int(idx)))
+    coord_scores.sort(key=lambda x: (-x[2], x[0], x[1]))
+
+    total = float(sum(item[2] for item in coord_scores))
+    if total > 0:
+        norm_scores = [item[2] / total for item in coord_scores]
+    else:
+        norm_scores = [1 / len(coord_scores)] * len(coord_scores)
+
+    k = min(3, len(coord_scores))
+    top_items = coord_scores[:k]
+    logger.info("TopK: candidates = %s, k=%s", len(coord_scores), k)
+    logger.info("[CHK] top_indices=%s", [it[3] for it in top_items])
+
+    picked_vals = [int(flat[item[3]]) for item in top_items]
     # 中文 log：以 row-col 形式列出 top3 名次，並確認格子皆為空白
-    pos_str = " ".join(
-        f"{r}-{c}"
-        for idx in top_indices
-        for r, c in [np.unravel_index(int(idx), board.shape)]
-    )
-    logger.info("top3=%s %s格皆為空格（符合預期）", pos_str, len(top_indices))
+    pos_str = " ".join(f"{r}-{c}" for r, c, _, _ in top_items)
+    logger.info("top3=%s %s格皆為空格（符合預期）", pos_str, len(top_items))
     logger.info(
         "[CHK] picked vals=%s (should all be BLANK_VALUE=%s)",
         picked_vals,
         BLANK_VALUE,
     )
     violations = [
-        (*np.unravel_index(int(idx), board.shape), int(flat[idx]))
-        for idx in top_indices
-        if flat[idx] != BLANK_VALUE
+        (r, c, int(flat[idx])) for r, c, _, idx in top_items if flat[idx] != BLANK_VALUE
     ]
     if violations:
         logger.error("[FATAL] non-blank selected! violations=%s", violations)
@@ -366,15 +379,14 @@ def predict(req: PredictRequest):
             detail={"error": "non-blank-selected", "violations": violations},
         )
 
-    raw = []
-    for idx, sc in zip(top_indices, top_scores):
-        r, c = np.unravel_index(int(idx), board.shape)
+    raw: List[Prediction] = []
+    for i, (r, c, _, idx) in enumerate(top_items):
         raw.append(
             Prediction(
                 row=r,
                 col=c,
-                score=round(float(sc * 100), 2),
-                idx=int(idx),
+                score=round(float(norm_scores[i] * 100), 2),
+                idx=idx,
                 cell_value=int(flat[idx]),
             )
         )

--- a/tests/test_agents/test_met_agent.py
+++ b/tests/test_agents/test_met_agent.py
@@ -66,3 +66,25 @@ def test_met_agent_scoring_and_order() -> None:
     assert len(results) == blank_count
     scores = [item["score"] for item in results]
     assert scores == sorted(scores, reverse=True)
+
+
+def test_met_agent_stable_order_with_ties() -> None:
+    class DummyModel:
+        def __init__(self) -> None:
+            self.num_fields = 4
+            self.num_values = 4
+            self.rows = 2
+            self.cols = 2
+
+        def __call__(self, x: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
+            batch, n = x.shape
+            return np.zeros((batch, n, self.num_values))
+
+        def eval(self) -> None:  # pragma: no cover - compatibility stub
+            pass
+
+    board = np.full((2, 2), BLANK_VALUE)
+    model = DummyModel()
+    res = predict(board.copy(), target=1, model=model, topk=3)
+    coords = [(item["row"], item["col"]) for item in res]
+    assert coords == [(1, 1), (1, 2), (2, 1)]

--- a/tests/test_stable_topk.py
+++ b/tests/test_stable_topk.py
@@ -1,0 +1,31 @@
+import importlib
+
+import numpy as np
+
+import app as appmod
+
+
+class DummyModel:
+    def __init__(self) -> None:
+        self.rows = 2
+        self.cols = 2
+        self.num_fields = 4
+        self.num_values = 4
+
+    def __call__(self, x: np.ndarray) -> np.ndarray:  # pragma: no cover - simple stub
+        batch, n = x.shape
+        return np.zeros((batch, n, self.num_values))
+
+    def eval(self) -> None:  # pragma: no cover - compatibility stub
+        pass
+
+
+def test_app_predict_stable_order() -> None:
+    importlib.reload(appmod)
+    appmod.models.clear()
+    appmod.models[(2, 2)] = DummyModel()
+    board = np.full((2, 2), appmod.BLANK_VALUE).tolist()
+    req = appmod.PredictRequest(board=board, target=1)
+    res = appmod.predict(req)
+    coords = [(p.row, p.col) for p in res]
+    assert coords == [(1, 1), (1, 2), (2, 1)]


### PR DESCRIPTION
## Summary
- enforce OS/Python/Torch seeds for deterministic startup
- implement stable top-k selection by score→row→col
- add tests to verify deterministic ordering when scores tie

## Testing
- `black app.py agents/met_agent.py tests/test_agents/test_met_agent.py tests/test_stable_topk.py --check`
- `isort app.py agents/met_agent.py tests/test_agents/test_met_agent.py tests/test_stable_topk.py --check -v`
- `flake8 app.py agents/met_agent.py tests/test_agents/test_met_agent.py tests/test_stable_topk.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688eff02bf0c8324a75705c118eef174