### PR TITLE
Add memory-based agent with example and test

### DIFF
--- a/agents/memory_agent.py
+++ b/agents/memory_agent.py
@@ -1,0 +1,121 @@
+"""Memory-based agent that fuses model predictions with kNN retrieved scores.
+
+This agent demonstrates how a memory bank of prior boards can be used to
+refine predictions. Each memory entry stores a hidden-state vector (key) and
+model scores (value). At inference time, the query board embedding is compared
+with memory keys using cosine similarity. The top-k most similar entries are
+used to average the stored scores, which are then fused with the model's own
+scores.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Tuple
+
+import numpy as np
+
+from dataset import BLANK_VALUE, validate_board
+from utils import ensure_only_blank
+
+
+def build_memory(
+    samples: Sequence[Tuple[np.ndarray, int]],
+    model: Any,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Build a memory bank from ``samples`` using ``model``.
+
+    Parameters
+    ----------
+    samples:
+        Iterable of ``(board, target)`` pairs.
+    model:
+        Object that provides ``get_hidden_state`` and ``forward`` methods.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        ``(keys, values)`` where ``keys`` has shape ``(M, H)`` and ``values`` has
+        shape ``(M, N)``. ``M`` is number of samples, ``H`` is embedding
+        dimension and ``N`` equals ``rows*cols``.
+    """
+    memory_keys: List[np.ndarray] = []
+    memory_values: List[np.ndarray] = []
+    for board, target in samples:
+        flat = board.flatten()
+        h = model.get_hidden_state(flat)
+        # 1) 取出原始 logits（可能是 torch.Tensor，且 requires_grad=True）
+        logits = model.forward(flat)
+        # 2) 如果是 Tensor，先 detach, cpu，再轉成 numpy
+        if hasattr(logits, "detach"):
+            arr = logits.detach().cpu().numpy()
+        else:
+            arr = np.asarray(logits)
+        if arr.ndim == 3:
+            arr = arr[0]
+        # 3) 從 numpy array 取出 target 對應分數
+        t_idx = int(target) - 1
+        if not 0 <= t_idx < arr.shape[1]:
+            raise IndexError("target index out of range")
+        scores = arr[:, t_idx]
+        memory_keys.append(h)
+        memory_values.append(scores)
+    return np.stack(memory_keys, axis=0), np.stack(memory_values, axis=0)
+
+
+def predict(
+    board: np.ndarray,
+    *,
+    target: int,
+    model: Any,
+    memory_keys: np.ndarray,
+    memory_values: np.ndarray,
+    alpha: float = 0.5,
+    k_neighbors: int = 2,
+    topk: int | None = None,
+    query_index: int | None = None,
+) -> List[Dict[str, Any]]:
+    """Return ranked blank cell predictions by fusing model and memory scores.
+
+    The function computes cosine similarity between the query board's hidden
+    state and each key in ``memory_keys``. The ``k_neighbors`` most similar
+    entries are averaged to obtain ``memory`` scores. These scores are blended
+    with the model's own predictions using weight ``alpha`` and then ranked.
+    """
+    validate_board(board, allow_blank=True)
+    rows, cols = board.shape
+    num_cells = rows * cols
+
+    flat = board.flatten()
+    h_q = model.get_hidden_state(flat)
+
+    norms = np.linalg.norm(memory_keys, axis=1) * np.linalg.norm(h_q)
+    cos_sim = (memory_keys @ h_q) / norms
+    order = np.argsort(-cos_sim)
+    if query_index is not None:
+        order = order[order != query_index]
+    neighbors = order[:k_neighbors]
+
+    scores_mem = memory_values[neighbors].mean(axis=0)
+    t_idx = int(target) - 1
+    logits_q = model.forward(flat)
+    if hasattr(logits_q, "detach"):
+        arr = logits_q.detach().cpu().numpy()
+    else:
+        arr = np.asarray(logits_q)
+    if arr.ndim == 3:
+        arr = arr[0]
+    if not 0 <= t_idx < arr.shape[1]:
+        raise IndexError("target index out of range")
+    scores_model = arr[:, t_idx]
+    scores_final = alpha * scores_model + (1 - alpha) * scores_mem
+
+    mask = flat != BLANK_VALUE
+    scores_final[mask] = -np.inf
+
+    coords = [(i // cols, i % cols, scores_final[i]) for i in range(num_cells)]
+    coords.sort(key=lambda x: (-x[2], x[0], x[1]))
+    if topk is not None:
+        coords = coords[:topk]
+
+    results = [{"row": r + 1, "col": c + 1, "score": float(sc)} for r, c, sc in coords]
+    return ensure_only_blank(board, results, BLANK_VALUE)

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
+import json
 import os
 import random
+from pathlib import Path
 
 import numpy as np
 
@@ -31,6 +33,8 @@ from typing import Dict, List, Optional, Tuple  # noqa: E402
 from fastapi import FastAPI, HTTPException  # noqa: E402
 from pydantic import BaseModel, Field, model_validator  # noqa: E402
 
+from agents.memory_agent import build_memory as build_memory_agent  # noqa: E402
+from agents.memory_agent import predict as memory_predict  # noqa: E402
 from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board  # noqa: E402
 from model import DynamicMET  # noqa: E402
 from utils import ensure_only_blank, ensure_unique  # noqa: E402
@@ -112,6 +116,7 @@ MODEL_PARAMS = {
 }
 
 models: Dict[Tuple[int, int], DynamicMET] = {}
+memories: Dict[Tuple[int, int], Tuple[np.ndarray, np.ndarray]] = {}
 
 
 def _create_model(rows: int, cols: int) -> DynamicMET:
@@ -171,6 +176,19 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
     return model
 
 
+def _load_memory_for_shape(rows: int, cols: int, model: DynamicMET) -> None:
+    """Build memory bank for ``(rows, cols)`` if archive exists."""
+    file_path = Path("data_archives") / f"{rows}x{cols}.json"
+    if not file_path.is_file():
+        logger.warning("未找到記憶庫檔案：%s", file_path)
+        return
+    data = json.load(open(file_path, "r", encoding="utf-8"))
+    samples = [(np.array(e["board"], dtype=int), int(e["target"])) for e in data]
+    keys, values = build_memory_agent(samples, model)
+    memories[(rows, cols)] = (keys, values)
+    logger.info("✅ 記憶庫就緒：keys=%s values=%s", keys.shape, values.shape)
+
+
 def _discover_models() -> None:
     """Locate all checkpoint files under ``MODEL_GLOB`` and load them."""
     found = False
@@ -181,12 +199,14 @@ def _discover_models() -> None:
             continue
         r, c = int(m.group(1)), int(m.group(2))
         models[(r, c)] = _load_one(path, r, c)
+        _load_memory_for_shape(r, c, models[(r, c)])
         found = True
     if not found:
         r, c = 8, 10
         models[(r, c)] = _create_model(r, c)
         if hasattr(models[(r, c)], "eval"):
             models[(r, c)].eval()
+        _load_memory_for_shape(r, c, models[(r, c)])
         logger.warning(
             "未找到模型檔案，使用預設模型 %sx%s", r, c
         )  # 中文log：沒有模型時使用預設
@@ -248,6 +268,68 @@ def predict(req: PredictRequest):
         )
     logger.info("[CHK] mask_pos=%s", mask_pos.tolist())
 
+    model = models.get((rows, cols))
+    if model is None:
+        logger.info(
+            "尚未載入 %sx%s 的模型，立即建立", rows, cols
+        )  # 中文log：動態建立模型
+        model = _create_model(rows, cols)
+        if hasattr(model, "eval"):
+            model.eval()
+        models[(rows, cols)] = model
+        _load_memory_for_shape(rows, cols, model)
+    else:
+        logger.info("使用已載入的模型 %sx%s", rows, cols)  # 中文log：重複尺寸共用模型
+
+    memory = memories.get((rows, cols))
+    if memory is not None:
+        memory_keys, memory_values = memory
+        fused = memory_predict(
+            board.copy(),
+            target=target,
+            model=model,
+            memory_keys=memory_keys,
+            memory_values=memory_values,
+            alpha=0.5,
+            k_neighbors=2,
+            topk=3,
+        )
+        coords = []
+        for item in fused:
+            r0 = int(item["row"]) - 1
+            c0 = int(item["col"]) - 1
+            idx = r0 * cols + c0
+            coords.append((r0, c0, float(item["score"]), idx))
+        if coords:
+            total = float(sum(sc for _, _, sc, _ in coords))
+            if total > 0:
+                norm_scores = [sc / total for _, _, sc, _ in coords]
+            else:
+                norm_scores = [1 / len(coords)] * len(coords)
+            raw_preds = [
+                Prediction(
+                    row=r0,
+                    col=c0,
+                    score=round(ns * 100, 2),
+                    idx=idx,
+                    cell_value=BLANK_VALUE,
+                )
+                for (r0, c0, _, idx), ns in zip(coords, norm_scores)
+            ]
+            validated = ensure_only_blank(board, raw_preds, BLANK_VALUE)
+            validated = ensure_unique(validated)
+            expected = min(3, mask_pos.size)
+            if len(validated) == expected:
+                for item in validated:
+                    item.row += 1
+                    item.col += 1
+                percent_msg = " ".join(
+                    f"top{i + 1}={item.row}-{item.col}({item.score:.0f}%)"
+                    for i, item in enumerate(validated)
+                )
+                logger.info("預測機率 %s", percent_msg)
+                return validated
+
     # ensure contiguous int64 array to avoid torch dtype inference errors
     flat_input = np.where(flat == BLANK_VALUE, MASK_TOKEN_ID, flat).astype(
         np.int64, copy=False
@@ -260,18 +342,6 @@ def predict(req: PredictRequest):
         flat_input[: min(10, flat_input.size)].tolist(),
     )
     # 中文log：檢查輸入資料
-
-    model = models.get((rows, cols))
-    if model is None:
-        logger.info(
-            "尚未載入 %sx%s 的模型，立即建立", rows, cols
-        )  # 中文log：動態建立模型
-        model = _create_model(rows, cols)
-        if hasattr(model, "eval"):
-            model.eval()
-        models[(rows, cols)] = model
-    else:
-        logger.info("使用已載入的模型 %sx%s", rows, cols)  # 中文log：重複尺寸共用模型
 
     if torch is not None:
         # use as_tensor to avoid copy and specify dtype explicitly

--- a/memory_agent_demo.py
+++ b/memory_agent_demo.py
@@ -1,0 +1,60 @@
+"""Demo script for the memory-based agent."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from agents.memory_agent import build_memory, predict
+
+
+class DummyModel:
+    """Minimal model used for demonstration purposes."""
+
+    def __init__(self, num_cells: int, hidden_dim: int, seed: int = 42) -> None:
+        self.num_cells = num_cells
+        self.hidden_dim = hidden_dim
+        np.random.seed(seed)
+
+    def forward(self, board_flat: np.ndarray) -> np.ndarray:
+        return np.random.rand(self.num_cells, self.num_cells)
+
+    def get_hidden_state(self, board_flat: np.ndarray) -> np.ndarray:
+        return np.random.rand(self.hidden_dim)
+
+
+def load_samples_for_shape(rows: int, cols: int, base_dir: str = "data_archives"):
+    file_path = Path(base_dir) / f"{rows}x{cols}.json"
+    if not file_path.is_file():
+        raise FileNotFoundError(f"找不到：{file_path}")
+    data = json.load(open(file_path, "r", encoding="utf-8"))
+    samples = []
+    for entry in data:
+        board = np.array(entry["board"], dtype=int)
+        target = int(entry["target"])
+        samples.append((board, target))
+    print(f"✅ 載入 {rows}×{cols} 樣本共 {len(samples)} 筆")
+    return samples
+
+
+def main() -> None:
+    rows, cols = 4, 5
+    samples = load_samples_for_shape(rows, cols)
+    model = DummyModel(num_cells=rows * cols, hidden_dim=8)
+    memory_keys, memory_values = build_memory(samples, model)
+    print(f"✅ 記憶庫建置完畢：keys {memory_keys.shape}, values {memory_values.shape}")
+    board, target = samples[0]
+    results = predict(
+        board.copy(),
+        target=target,
+        model=model,
+        memory_keys=memory_keys,
+        memory_values=memory_values,
+        topk=3,
+        query_index=0,
+    )
+    print("🏆 最終 Top-3 候選格子:", results)
+
+
+if __name__ == "__main__":
+    main()

--- a/model.py
+++ b/model.py
@@ -8,6 +8,8 @@ except Exception:  # pragma: no cover - torch missing
     nn = object  # type: ignore[misc]
     TORCH_AVAILABLE = False
 
+import numpy as np
+
 from models.blocks import TransformerBlock
 
 
@@ -75,8 +77,12 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             self.col_emb = None
             self.embed_dropout = None
 
-    def forward(self, x: "torch.Tensor") -> "torch.Tensor":  # type: ignore[override]
+    def forward(self, x: "torch.Tensor | np.ndarray") -> "torch.Tensor | np.ndarray":  # type: ignore[override]
         if TORCH_AVAILABLE:
+            if isinstance(x, np.ndarray):
+                x = torch.as_tensor(x, dtype=torch.long).unsqueeze(0)
+            elif x.dim() == 1:
+                x = x.unsqueeze(0)
             _, N = x.shape
             tok = self.token_emb(x)
             pos_ids = torch.arange(N, device=x.device)
@@ -91,9 +97,30 @@ class DynamicMET(nn.Module if TORCH_AVAILABLE else object):
             h = self.norm_out(h)
             logits = self.classifier(h)
             return logits
-        import numpy as np
 
+        if isinstance(x, np.ndarray) and x.ndim == 1:
+            x = x[None, :]
         bsz, fields = x.shape
         return np.zeros((bsz, fields, self.num_values), dtype=float)
+
+    def get_hidden_state(self, board_flat: np.ndarray) -> np.ndarray:
+        """Return pooled hidden representation for ``board_flat``."""
+        if TORCH_AVAILABLE:
+            with torch.no_grad():
+                x = torch.as_tensor(board_flat, dtype=torch.long).unsqueeze(0)
+                tok = self.token_emb(x)
+                pos_ids = torch.arange(self.num_fields, device=x.device)
+                row_ids = torch.div(pos_ids, self.cols, rounding_mode="floor")
+                col_ids = pos_ids % self.cols
+                pos = torch.cat([self.row_emb(row_ids), self.col_emb(col_ids)], dim=-1)
+                tok = tok + pos.unsqueeze(0)
+                tok = self.embed_dropout(tok)
+                h = tok
+                for blk in self.blocks:
+                    h = blk(h, row_ids, col_ids, attn_mask=None)
+                h = self.norm_out(h)
+                pooled = h.mean(dim=1)
+                return pooled.squeeze(0).cpu().numpy()
+        return np.zeros(self.d_model, dtype=float)
 
     __call__ = forward

--- a/tests/test_agents/test_memory_agent.py
+++ b/tests/test_agents/test_memory_agent.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from agents.memory_agent import build_memory, predict
+
+torch = pytest.importorskip("torch")
+
+
+class DummyModel:
+    def __init__(self, num_cells: int, hidden_dim: int, seed: int = 0) -> None:
+        self.num_cells = num_cells
+        self.hidden_dim = hidden_dim
+        np.random.seed(seed)
+
+    def forward(self, board_flat: np.ndarray) -> np.ndarray:
+        return np.random.rand(self.num_cells, self.num_cells)
+
+    def get_hidden_state(self, board_flat: np.ndarray) -> np.ndarray:
+        return np.random.rand(self.hidden_dim)
+
+
+class TorchModel(DummyModel):
+    def forward(self, board_flat: np.ndarray):  # type: ignore[override]
+        return torch.randn(self.num_cells, self.num_cells, requires_grad=True)
+
+
+def load_samples_for_shape(rows: int, cols: int, base_dir: str = "data_archives"):
+    file_path = Path(base_dir) / f"{rows}x{cols}.json"
+    data = json.load(open(file_path, "r", encoding="utf-8"))
+    samples = []
+    for entry in data:
+        board = np.array(entry["board"], dtype=int)
+        target = int(entry["target"])
+        samples.append((board, target))
+    return samples
+
+
+def test_memory_agent_predict_top3() -> None:
+    rows, cols = 4, 5
+    samples = load_samples_for_shape(rows, cols)
+    model = DummyModel(num_cells=rows * cols, hidden_dim=8)
+    memory_keys, memory_values = build_memory(samples, model)
+    board, target = samples[0]
+    res = predict(
+        board.copy(),
+        target=target,
+        model=model,
+        memory_keys=memory_keys,
+        memory_values=memory_values,
+        topk=3,
+        query_index=0,
+    )
+    blank_count = np.sum(board == -1)
+    assert len(res) == min(3, blank_count)
+    scores = [item["score"] for item in res]
+    assert scores == sorted(scores, reverse=True)
+    for item in res:
+        r0, c0 = item["row"] - 1, item["col"] - 1
+        assert board[r0, c0] == -1
+
+
+def test_memory_agent_handles_torch_tensor() -> None:
+    rows, cols = 4, 5
+    samples = load_samples_for_shape(rows, cols)
+    model = TorchModel(num_cells=rows * cols, hidden_dim=8)
+    memory_keys, memory_values = build_memory(samples, model)
+    board, target = samples[0]
+    res = predict(
+        board.copy(),
+        target=target,
+        model=model,
+        memory_keys=memory_keys,
+        memory_values=memory_values,
+        topk=3,
+        query_index=0,
+    )
+    assert isinstance(res, list) and res

--- a/tests/test_app_memory_fusion.py
+++ b/tests/test_app_memory_fusion.py
@@ -1,0 +1,27 @@
+import json
+
+import numpy as np
+from fastapi.testclient import TestClient
+
+from app import app
+from dataset import BLANK_VALUE
+
+client = TestClient(app)
+
+
+def test_app_memory_fusion_top3() -> None:
+    data = json.load(open("data_archives/4x5.json", "r", encoding="utf-8"))
+    board = np.array(data[0]["board"], dtype=int)
+    board[0, 1] = BLANK_VALUE
+    board[2, 3] = BLANK_VALUE
+    target = data[0]["target"]
+    resp = client.post("/predict", json={"board": board.tolist(), "target": target})
+    assert resp.status_code == 200
+    res = resp.json()
+    blank_count = np.sum(np.array(board) == BLANK_VALUE)
+    assert len(res) == min(3, blank_count)
+    scores = [item["score"] for item in res]
+    assert scores == sorted(scores, reverse=True)
+    for item in res:
+        r0, c0 = item["row"] - 1, item["col"] - 1
+        assert board[r0][c0] == BLANK_VALUE

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,6 +14,14 @@ def test_dynamic_met_forward() -> None:
     assert out.shape == (2, num_fields, model.num_values)
 
 
+def test_dynamic_met_get_hidden_state() -> None:
+    num_fields = 20
+    model = DynamicMET(num_fields=num_fields, num_values=num_fields, rows=4, cols=5)
+    board = torch.randint(0, model.num_values, (num_fields,))
+    h = model.get_hidden_state(board.numpy())
+    assert h.shape == (model.d_model,)
+
+
 def test_relative_2d_attention_forward() -> None:
     d_model, nhead = 32, 4
     attn = Relative2DAttention(d_model, nhead, max_rel_row=3, max_rel_col=3)


### PR DESCRIPTION
## Summary
- add memory agent that fuses model scores with kNN memory retrieval
- provide demo script showing memory bank construction and top-3 output
- add unit test ensuring memory agent returns sorted blank positions
- integrate memory fusion into FastAPI prediction flow with DynamicMET support
- test memory fusion via FastAPI client and expose model hidden state API
- detach logits to NumPy conversion to avoid gradient issues and cover torch tensors in tests

## Testing
- `black --check agents/memory_agent.py memory_agent_demo.py tests/test_agents/test_memory_agent.py`
- `isort --profile black --check agents/memory_agent.py memory_agent_demo.py tests/test_agents/test_memory_agent.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f5efdd95483249d30338a62a06385