### PR TITLE
Honor MEMORY_MAX_SCAN limit during memory scan

### DIFF
--- a/agents/memory_agent.py
+++ b/agents/memory_agent.py
@@ -278,12 +278,16 @@ def _collect_embeddings_from_jsonl(
     embeddings_list: list[np.ndarray] = []
     buf_inputs: list[np.ndarray] = []
 
+    max_scan = int(os.getenv("MEMORY_MAX_SCAN", "0"))
+
     with jsonl_path.open("rb") as f, mmap.mmap(
         f.fileno(), 0, access=mmap.ACCESS_READ
     ) as mm:
         line_idx = 0
         for raw in iter(mm.readline, b""):
             if not raw:
+                break
+            if max_scan and line_idx >= max_scan:
                 break
             rec = orjson.loads(raw)
             rec_id = rec.get("id", line_idx)

--- a/app.py
+++ b/app.py
@@ -41,13 +41,7 @@ from agents.memory_agent import predict_stream as memory_predict_stream  # noqa:
 from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board  # noqa: E402
 from model import DynamicMET  # noqa: E402
 from utils import ensure_only_blank, ensure_unique  # noqa: E402
-from pydantic import BaseModel, conlist
 
-class PredictRequest(BaseModel):
-    # board：二維整數陣列，至少 1×1
-    board: conlist(conlist(int, min_items=1), min_items=1)
-    # 如果還有傳 target，打開下面這行
-    # target: int | None = None
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO"),
     format="%(asctime)s %(levelname)s: %(message)s",
@@ -55,12 +49,6 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Matrix Factorization Service", version="0.1.0")
-@app.post("/predict")
-async def predict(req: PredictRequest):
-    board = np.array(req.board, dtype=int)
-    if np.all(board == BLANK_VALUE):
-        # 👇 健康檢查專用：100 毫秒內回 200
-        return {"status": "ok", "note": "all-blank health-check"}
 
 @app.get("/")
 def root() -> dict[str, str]:

--- a/app.py
+++ b/app.py
@@ -48,7 +48,12 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Matrix Factorization Service", version="0.1.0")
-
+@app.post("/predict")
+async def predict(req: PredictRequest):
+    board = np.array(req.board, dtype=int)
+    if np.all(board == BLANK_VALUE):
+        # 👇 健康檢查專用：100 毫秒內回 200
+        return {"status": "ok", "note": "all-blank health-check"}
 
 @app.get("/")
 def root() -> dict[str, str]:

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import random
 import threading
 from pathlib import Path
 
+
 import numpy as np
 
 # 1. OS / Python level determinism
@@ -40,7 +41,13 @@ from agents.memory_agent import predict_stream as memory_predict_stream  # noqa:
 from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board  # noqa: E402
 from model import DynamicMET  # noqa: E402
 from utils import ensure_only_blank, ensure_unique  # noqa: E402
+from pydantic import BaseModel, conlist
 
+class PredictRequest(BaseModel):
+    # board：二維整數陣列，至少 1×1
+    board: conlist(conlist(int, min_items=1), min_items=1)
+    # 如果還有傳 target，打開下面這行
+    # target: int | None = None
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO"),
     format="%(asctime)s %(levelname)s: %(message)s",

--- a/tests/test_agents/test_memory_agent_max_scan.py
+++ b/tests/test_agents/test_memory_agent_max_scan.py
@@ -1,0 +1,30 @@
+import numpy as np
+import orjson
+
+from agents.memory_agent import online_topk_from_jsonl
+from dataset import BLANK_VALUE
+
+
+class DummyModel:
+    """Model returning constant embeddings for testing."""
+
+    def get_hidden_state(self, x: np.ndarray) -> np.ndarray:  # noqa: D401
+        if x.ndim == 1:
+            return np.ones(4, dtype=float)
+        return np.ones((x.shape[0], 4), dtype=float)
+
+
+def test_online_topk_respects_max_scan(tmp_path, monkeypatch) -> None:
+    board = np.array([[BLANK_VALUE, 2], [3, 4]], dtype=int)
+    data = [{"board": board.tolist(), "target": 1} for _ in range(3)]
+    jsonl = tmp_path / "mem.jsonl"
+    with jsonl.open("wb") as f:
+        for obj in data:
+            f.write(orjson.dumps(obj) + b"\n")
+
+    monkeypatch.setenv("MEMORY_MAX_SCAN", "1")
+
+    model = DummyModel()
+    res = online_topk_from_jsonl(jsonl, board, model, top_k=5)
+    assert len(res) == 1
+    assert res[0][0] == 0


### PR DESCRIPTION
## Summary
- Skip reading beyond a configurable MEMORY_MAX_SCAN limit when loading embeddings from JSONL memory files
- Add regression test ensuring JSONL scanning stops at MEMORY_MAX_SCAN records

## Testing
- `black --check agents/memory_agent.py tests/test_agents/test_memory_agent_max_scan.py tests/test_agents/test_memory_agent_sampling.py`
- `isort --check-only -v agents/memory_agent.py tests/test_agents/test_memory_agent_max_scan.py tests/test_agents/test_memory_agent_sampling.py`
- `flake8 -q`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68903cd8efb883249f5b1cf251723332