### PR TITLE
Add pydantic constraints for board schema

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ import random
 import threading
 from pathlib import Path
 
-
 import numpy as np
 
 # 1. OS / Python level determinism
@@ -33,7 +32,7 @@ import re  # noqa: E402
 from typing import Dict, List, Optional, Tuple  # noqa: E402
 
 from fastapi import FastAPI, HTTPException  # noqa: E402
-from pydantic import BaseModel, Field, model_validator  # noqa: E402
+from pydantic import BaseModel, Field, conlist, model_validator  # noqa: E402
 
 from agents.memory_agent import build_memory as build_memory_agent  # noqa: E402
 from agents.memory_agent import predict as memory_predict  # noqa: E402
@@ -49,6 +48,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Matrix Factorization Service", version="0.1.0")
+
 
 @app.get("/")
 def root() -> dict[str, str]:
@@ -68,7 +68,9 @@ def health():
 
 
 class PredictRequest(BaseModel):
-    board: List[List[int]] = Field(
+    """Schema for prediction requests."""
+
+    board: conlist(conlist(int, min_length=1), min_length=1) = Field(
         ..., description=f"2D grid, blanks use {BLANK_VALUE}."
     )
     # 兩個欄位都接受，擇一或兩者皆送都行

--- a/tests/test_bad_board.py
+++ b/tests/test_bad_board.py
@@ -10,6 +10,16 @@ def test_ragged_board_422() -> None:
     assert r.status_code == 422
 
 
+def test_empty_board_422() -> None:
+    r = client.post("/predict", json={"board": [], "target": 1})
+    assert r.status_code == 422
+
+
+def test_empty_row_422() -> None:
+    r = client.post("/predict", json={"board": [[]], "target": 1})
+    assert r.status_code == 422
+
+
 def test_target_out_of_range_422() -> None:
     r = client.post("/predict", json={"board": [[-1, -1], [-1, -1]], "target": 99})
     assert r.status_code == 422


### PR DESCRIPTION
## Summary
- enforce non-empty 2D board via `conlist`
- test empty board and empty row validation

## Testing
- `isort --profile black --check app.py tests/test_bad_board.py -v`
- `black --check app.py tests/test_bad_board.py`
- `flake8 --count`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907dc3c128832483a2c67b8e799785