### PR TITLE
Add memory cache builder and integrate into workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - run: flake8
       - run: mypy . --ignore-missing-imports
       - run: python -m py_compile $(git ls-files '*.py')
+      - run: MEMORY_SAMPLE_LIMIT=5 python build_memories.py
       - run: pytest -q
 
   train-and-package:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN pip install --upgrade pip setuptools wheel \
 
 # 再把專案原始碼放進來
 COPY . .
+RUN python build_memories.py
 ENV LOG_LEVEL=DEBUG
 # 預設執行指令（依你的專案入口）
 # 若採方案4，app 模組是 app:app；若改用 coco_service.main，請調整為 coco_service.main:app

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+# isort:skip_file
 import json
 import os
 import random
@@ -32,6 +33,7 @@ import logging  # noqa: E402
 import re  # noqa: E402
 from typing import Dict, List, Optional, Tuple  # noqa: E402
 
+import orjson  # noqa: E402
 from fastapi import FastAPI, HTTPException  # noqa: E402
 from pydantic import BaseModel, Field, conlist, model_validator  # noqa: E402
 
@@ -111,7 +113,7 @@ class Prediction(BaseModel):
 
 MODEL_GLOB = os.environ.get("MODEL_GLOB", os.path.join("checkpoints", "met_*x*.pth"))
 _PATTERN = re.compile(r"met_(\d+)x(\d+)\.pth$")
-_JSON_PATTERN = re.compile(r"(\d+)x(\d+)\.json$")
+_JSON_PATTERN = re.compile(r"(\d+)x(\d+)\.jsonl?$")
 
 # Training-time hyperparameters required for loading checkpoints
 MODEL_PARAMS = {
@@ -195,32 +197,59 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
 
 def _load_memory_for_shape(rows: int, cols: int, model: DynamicMET) -> None:
     """Register memory source for ``(rows, cols)`` if archive exists."""
-    file_path = Path("data_archives") / f"{rows}x{cols}.json"
-    jsonl_path = Path("data_archives") / f"{rows}x{cols}.jsonl"
-    if file_path.is_file():
-        data = json.load(open(file_path, "r", encoding="utf-8"))
-        if MEMORY_SAMPLE_LIMIT is not None and len(data) > MEMORY_SAMPLE_LIMIT:
-            logger.info("限制記憶庫樣本 %s -> %s", len(data), MEMORY_SAMPLE_LIMIT)
-            data = data[:MEMORY_SAMPLE_LIMIT]
-        samples = [(np.array(e["board"], dtype=int), int(e["target"])) for e in data]
+
+    base = Path("data_archives")
+    npz_path = base / f"{rows}x{cols}_memory.npz"
+    json_path = base / f"{rows}x{cols}.json"
+    jsonl_path = base / f"{rows}x{cols}.jsonl"
+
+    if npz_path.is_file():
+        data = np.load(npz_path)
+        memories[(rows, cols)] = (data["keys"], data["values"])
+        logger.info(
+            "✅ 快取記憶庫載入：%s keys=%s values=%s",
+            npz_path,
+            data["keys"].shape,
+            data["values"].shape,
+        )
+        return
+
+    if json_path.is_file() or jsonl_path.is_file():
+        if json_path.is_file():
+            data_list = json.load(open(json_path, "r", encoding="utf-8"))
+        else:
+            data_list = []
+            with jsonl_path.open("rb") as fh:
+                for idx, line in enumerate(fh):
+                    if MEMORY_SAMPLE_LIMIT is not None and idx >= MEMORY_SAMPLE_LIMIT:
+                        break
+                    data_list.append(orjson.loads(line))
+        if MEMORY_SAMPLE_LIMIT is not None and len(data_list) > MEMORY_SAMPLE_LIMIT:
+            logger.info("限制記憶庫樣本 %s -> %s", len(data_list), MEMORY_SAMPLE_LIMIT)
+            data_list = data_list[:MEMORY_SAMPLE_LIMIT]
+        samples = [
+            (np.array(e["board"], dtype=int), int(e["target"])) for e in data_list
+        ]
         keys, values = build_memory_agent(samples, model)
         memories[(rows, cols)] = (keys, values)
         logger.info("✅ 記憶庫就緒：keys=%s values=%s", keys.shape, values.shape)
         return
-    if jsonl_path.is_file():
-        memory_files[(rows, cols)] = jsonl_path
-        logger.info("記憶庫採流式讀取：%s", jsonl_path)
-        return
-    logger.warning("未找到記憶庫檔案：%s 或 %s", file_path, jsonl_path)
+
+    logger.warning("未找到記憶庫檔案：%s 或 %s 或 %s", json_path, jsonl_path, npz_path)
 
 
 def find_all_json_files(base_dir: str = "data_archives"):
     """Yield ``((rows, cols), Path)`` for all JSON archives under ``base_dir``."""
+
     base = Path(base_dir)
-    for path in base.glob("*x*.json"):
+    seen: set[tuple[int, int]] = set()
+    for path in base.glob("*x*.json*"):
         m = _JSON_PATTERN.match(path.name)
         if m:
-            yield (int(m.group(1)), int(m.group(2))), path
+            shape = (int(m.group(1)), int(m.group(2)))
+            if shape not in seen:
+                seen.add(shape)
+                yield shape, path
 
 
 def _discover_models() -> None:

--- a/build_memories.py
+++ b/build_memories.py
@@ -1,0 +1,84 @@
+"""Build pre-computed memory banks for all JSON/JSONL archives.
+
+The script scans ``data_archives`` for files named ``{rows}x{cols}.json`` or
+``{rows}x{cols}.jsonl`` and generates a corresponding compressed ``npz`` memory
+file ``{rows}x{cols}_memory.npz`` for each unique shape.  It prints Chinese log
+messages showing how many samples are processed for each size.
+
+The number of samples loaded from each archive can be limited by setting the
+environment variable ``MEMORY_SAMPLE_LIMIT``.  When specified, at most that many
+records are read from the archive.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import orjson
+
+from agents.memory_agent import build_memory as build_memory_agent
+from app import _create_model
+
+BASE = Path("data_archives")
+
+
+def _iter_archives() -> list[tuple[str, Path]]:
+    """Return mapping of shape ``"{rows}x{cols}"`` to archive path.
+
+    If both ``.json`` and ``.jsonl`` exist for the same shape, the ``.jsonl``
+    file takes precedence.
+    """
+
+    mapping: dict[str, Path] = {}
+    for p in BASE.glob("*x*.json"):
+        mapping[p.stem] = p
+    for p in BASE.glob("*x*.jsonl"):
+        mapping[p.stem] = p  # prefer jsonl if both exist
+    return sorted(mapping.items())
+
+
+def _load_records(path: Path, limit: int | None) -> list[dict[str, object]]:
+    """Load records from ``path`` respecting ``limit`` if provided."""
+
+    records: list[dict[str, object]] = []
+    if path.suffix == ".jsonl":
+        with path.open("rb") as fh:
+            for idx, line in enumerate(fh):
+                if limit is not None and idx >= limit:
+                    break
+                records.append(orjson.loads(line))
+    else:
+        records = json.load(path.open("r", encoding="utf-8"))
+        if limit is not None and len(records) > limit:
+            records = records[:limit]
+    return records
+
+
+def main() -> None:
+    """Entry-point that builds memories for all archives under ``BASE``."""
+
+    limit_env = os.getenv("MEMORY_SAMPLE_LIMIT")
+    limit = int(limit_env) if limit_env and limit_env.isdigit() else None
+
+    for shape, path in _iter_archives():
+        rows, cols = map(int, shape.split("x"))
+        data = _load_records(path, limit)
+        print(f"讀取 {shape}：共 {len(data)} 筆樣本")
+
+        model = _create_model(rows, cols)
+        if hasattr(model, "eval"):
+            model.eval()
+
+        samples = [(np.array(e["board"], dtype=int), int(e["target"])) for e in data]
+        keys, values = build_memory_agent(samples, model)
+
+        out = BASE / f"{shape}_memory.npz"
+        np.savez_compressed(out, keys=keys, values=values)
+        print(f"已快取 {shape}：{len(samples)} 筆樣本 → {out}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/test_build_memories.py
+++ b/tests/test_build_memories.py
@@ -1,0 +1,27 @@
+import importlib
+from pathlib import Path
+
+import numpy as np
+
+
+def test_build_memories_creates_npz(monkeypatch, capsys):
+    monkeypatch.setenv("MEMORY_SAMPLE_LIMIT", "2")
+
+    for p in Path("data_archives").glob("*_memory.npz"):
+        p.unlink()
+
+    build_memories = importlib.import_module("build_memories")
+    importlib.reload(build_memories)
+    build_memories.main()
+
+    out = capsys.readouterr().out
+    assert "已快取 4x5" in out
+    assert "已快取 8x10" in out
+
+    path_4x5 = Path("data_archives/4x5_memory.npz")
+    path_8x10 = Path("data_archives/8x10_memory.npz")
+    assert path_4x5.is_file()
+    assert path_8x10.is_file()
+
+    data = np.load(path_4x5)
+    assert "keys" in data and "values" in data

--- a/tests/test_memory_cache_preference.py
+++ b/tests/test_memory_cache_preference.py
@@ -9,6 +9,7 @@ from dataset import BLANK_VALUE
 
 
 def test_predict_prefers_memory_cache(monkeypatch):
+    monkeypatch.setenv("MEMORY_SAMPLE_LIMIT", "5")
     importlib.reload(model)
     importlib.reload(app_module)
     app_module._preload_memories()


### PR DESCRIPTION
## Summary
- build precomputed memory caches from all JSON/JSONL archives with Chinese logs and sample limits
- load NPZ caches during app startup and prefer memory over streaming
- run memory cache builder in Docker and CI

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689093a2314c8324979bee3b55d8f8c2