### PR TITLE
Implement memory cache preloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN pip install --upgrade pip setuptools wheel \
 
 # 再把專案原始碼放進來
 COPY . .
+RUN python build_memories.py
 ENV LOG_LEVEL=DEBUG
 # 預設執行指令（依你的專案入口）
 # 若採方案4，app 模組是 app:app；若改用 coco_service.main，請調整為 coco_service.main:app

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 import numpy as np
+import orjson
 
 # 1. OS / Python level determinism
 os.environ["PYTHONHASHSEED"] = "42"
@@ -37,7 +38,6 @@ from pydantic import BaseModel, Field, conlist, model_validator  # noqa: E402
 
 from agents.memory_agent import build_memory as build_memory_agent  # noqa: E402
 from agents.memory_agent import predict as memory_predict  # noqa: E402
-from agents.memory_agent import predict_stream as memory_predict_stream  # noqa: E402
 from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board  # noqa: E402
 from model import DynamicMET  # noqa: E402
 from utils import ensure_only_blank, ensure_unique  # noqa: E402
@@ -111,7 +111,7 @@ class Prediction(BaseModel):
 
 MODEL_GLOB = os.environ.get("MODEL_GLOB", os.path.join("checkpoints", "met_*x*.pth"))
 _PATTERN = re.compile(r"met_(\d+)x(\d+)\.pth$")
-_JSON_PATTERN = re.compile(r"(\d+)x(\d+)\.json$")
+_MEMORY_PATTERN = re.compile(r"(\d+)x(\d+)_memory\.npz$")
 
 # Training-time hyperparameters required for loading checkpoints
 MODEL_PARAMS = {
@@ -123,7 +123,6 @@ MODEL_PARAMS = {
 
 models: Dict[Tuple[int, int], DynamicMET] = {}
 memories: Dict[Tuple[int, int], Tuple[np.ndarray, np.ndarray]] = {}
-memory_files: Dict[Tuple[int, int], Path] = {}
 
 _mem_limit_env = os.environ.get("MEMORY_SAMPLE_LIMIT")
 MEMORY_SAMPLE_LIMIT: Optional[int]
@@ -194,31 +193,51 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
 
 
 def _load_memory_for_shape(rows: int, cols: int, model: DynamicMET) -> None:
-    """Register memory source for ``(rows, cols)`` if archive exists."""
-    file_path = Path("data_archives") / f"{rows}x{cols}.json"
-    jsonl_path = Path("data_archives") / f"{rows}x{cols}.jsonl"
-    if file_path.is_file():
-        data = json.load(open(file_path, "r", encoding="utf-8"))
-        if MEMORY_SAMPLE_LIMIT is not None and len(data) > MEMORY_SAMPLE_LIMIT:
-            logger.info("限制記憶庫樣本 %s -> %s", len(data), MEMORY_SAMPLE_LIMIT)
-            data = data[:MEMORY_SAMPLE_LIMIT]
-        samples = [(np.array(e["board"], dtype=int), int(e["target"])) for e in data]
-        keys, values = build_memory_agent(samples, model)
+    """Load memory bank for ``(rows, cols)``.
+
+    Preference order:
+    1. Prebuilt ``*_memory.npz`` file.
+    2. Raw ``.json`` or ``.jsonl`` archives which are fully loaded into memory
+       and converted into an ``*_memory.npz`` cache for subsequent runs.
+    """
+
+    base = Path("data_archives")
+    mem_path = base / f"{rows}x{cols}_memory.npz"
+    if mem_path.is_file():
+        data = np.load(mem_path)
+        keys = data["keys"]
+        values = data["values"]
         memories[(rows, cols)] = (keys, values)
-        logger.info("✅ 記憶庫就緒：keys=%s values=%s", keys.shape, values.shape)
+        logger.info(
+            "✅ 記憶庫載入：%s keys=%s values=%s", mem_path, keys.shape, values.shape
+        )
         return
-    if jsonl_path.is_file():
-        memory_files[(rows, cols)] = jsonl_path
-        logger.info("記憶庫採流式讀取：%s", jsonl_path)
+
+    file_path = base / f"{rows}x{cols}.json"
+    jsonl_path = base / f"{rows}x{cols}.jsonl"
+    if file_path.is_file():
+        data = json.load(file_path.open("r", encoding="utf-8"))
+    elif jsonl_path.is_file():
+        data = [orjson.loads(line) for line in jsonl_path.open("rb")]
+    else:
+        logger.warning("未找到記憶庫檔案：%s", mem_path)
         return
-    logger.warning("未找到記憶庫檔案：%s 或 %s", file_path, jsonl_path)
+    logger.info("讀取記憶庫原始樣本：%s 筆", len(data))
+    if MEMORY_SAMPLE_LIMIT is not None and len(data) > MEMORY_SAMPLE_LIMIT:
+        logger.info("限制記憶庫樣本 %s -> %s", len(data), MEMORY_SAMPLE_LIMIT)
+        data = data[:MEMORY_SAMPLE_LIMIT]
+    samples = [(np.array(e["board"], dtype=int), int(e["target"])) for e in data]
+    keys, values = build_memory_agent(samples, model)
+    memories[(rows, cols)] = (keys, values)
+    np.savez_compressed(mem_path, keys=keys, values=values)
+    logger.info("✅ 記憶庫就緒：keys=%s values=%s", keys.shape, values.shape)
 
 
-def find_all_json_files(base_dir: str = "data_archives"):
-    """Yield ``((rows, cols), Path)`` for all JSON archives under ``base_dir``."""
+def find_all_memory_files(base_dir: str = "data_archives"):
+    """Yield ``((rows, cols), Path)`` for all prebuilt memory files under ``base_dir``."""
     base = Path(base_dir)
-    for path in base.glob("*x*.json"):
-        m = _JSON_PATTERN.match(path.name)
+    for path in base.glob("*x*_memory.npz"):
+        m = _MEMORY_PATTERN.match(path.name)
         if m:
             yield (int(m.group(1)), int(m.group(2))), path
 
@@ -247,7 +266,7 @@ def _discover_models() -> None:
 def _preload_memories() -> None:
     """Load memory banks in background after startup."""
     loaded: List[str] = []
-    for (r, c), _ in find_all_json_files():
+    for (r, c), _ in find_all_memory_files():
         model = models.get((r, c))
         if model is None:
             model = _create_model(r, c)
@@ -337,11 +356,9 @@ def predict(req: PredictRequest):
         logger.info("使用已載入的模型 %sx%s", rows, cols)  # 中文log：重複尺寸共用模型
 
     memory = memories.get((rows, cols))
-    jsonl = memory_files.get((rows, cols))
-    if memory is None and jsonl is None:
+    if memory is None:
         _load_memory_for_shape(rows, cols, model)
         memory = memories.get((rows, cols))
-        jsonl = memory_files.get((rows, cols))
     if memory is not None:
         t0 = time.perf_counter()
         memory_keys, memory_values = memory
@@ -360,22 +377,6 @@ def predict(req: PredictRequest):
             time.perf_counter() - t0,
             len(fused),
         )  # 中文log：使用快取版
-    elif jsonl is not None:
-        t0 = time.perf_counter()
-        fused = memory_predict_stream(
-            board.copy(),
-            target=target,
-            model=model,
-            jsonl_path=jsonl,
-            alpha=0.5,
-            k_neighbors=2,
-            topk=3,
-        )
-        logger.info(
-            "走串流版：耗時 %.4f 秒，結果 %s 筆",
-            time.perf_counter() - t0,
-            len(fused),
-        )  # 中文log：使用串流版
     else:
         fused = []
 

--- a/build_memories.py
+++ b/build_memories.py
@@ -1,0 +1,69 @@
+"""Generate memory bank NPZ files from JSON/JSONL archives.
+
+This script scans the ``data_archives`` directory for files named
+``{rows}x{cols}.json`` or ``{rows}x{cols}.jsonl``. For each file it reads all
+records, builds a memory bank using :func:`agents.memory_agent.build_memory`,
+then writes ``{rows}x{cols}_memory.npz``. Chinese logs report the number of
+samples processed for each shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import orjson
+
+from agents.memory_agent import build_memory as build_memory_agent
+from app import MEMORY_SAMPLE_LIMIT, _create_model
+
+BASE = Path("data_archives")
+
+
+def _iter_data_files() -> Dict[str, Path]:
+    """Return mapping from shape (e.g. ``"4x5"``) to data file path.
+
+    ``.json`` files take precedence over ``.jsonl`` if both exist.
+    """
+    files: Dict[str, Path] = {}
+    for path in BASE.glob("*x*.jsonl"):
+        files[path.stem] = path
+    for path in BASE.glob("*x*.json"):
+        files[path.stem] = path  # prefer json over jsonl
+    return files
+
+
+def main() -> None:
+    files = _iter_data_files()
+    if not files:
+        print("未找到任何資料檔")
+        return
+    for shape, path in sorted(files.items()):
+        rows, cols = map(int, shape.split("x"))
+        limit = MEMORY_SAMPLE_LIMIT or 0
+        if path.suffix == ".jsonl":
+            data = []
+            with path.open("rb") as f:
+                for i, line in enumerate(f):
+                    if limit and i >= limit:
+                        break
+                    data.append(orjson.loads(line))
+        else:
+            data = json.load(path.open("r", encoding="utf-8"))
+            if limit and len(data) > limit:
+                data = data[:limit]
+        print(f"尺寸 {shape}：讀取 {len(data)} 筆樣本")
+        model = _create_model(rows, cols)
+        if hasattr(model, "eval"):
+            model.eval()
+        samples = [(np.array(e["board"], dtype=int), int(e["target"])) for e in data]
+        keys, values = build_memory_agent(samples, model)
+        out = BASE / f"{shape}_memory.npz"
+        np.savez_compressed(out, keys=keys, values=values)
+        print(f"已快取 {shape}：{len(samples)} 筆 → {out}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/test_memory_cache_preference.py
+++ b/tests/test_memory_cache_preference.py
@@ -8,18 +8,17 @@ import model
 from dataset import BLANK_VALUE
 
 
-def test_predict_prefers_memory_cache(monkeypatch):
+def test_predict_uses_memory_cache(monkeypatch):
     importlib.reload(model)
     importlib.reload(app_module)
-    app_module._preload_memories()
 
-    called = {"stream": False}
+    called = {"cache": False}
 
-    def fake_stream(*args, **kwargs):  # pragma: no cover - patched in test
-        called["stream"] = True
+    def fake_memory_predict(*args, **kwargs):  # pragma: no cover - patched in test
+        called["cache"] = True
         return []
 
-    monkeypatch.setattr(app_module, "memory_predict_stream", fake_stream)
+    monkeypatch.setattr(app_module, "memory_predict", fake_memory_predict)
 
     data = json.load(open("data_archives/4x5.json", "r", encoding="utf-8"))
     board = np.array(data[0]["board"], dtype=int)
@@ -27,6 +26,5 @@ def test_predict_prefers_memory_cache(monkeypatch):
     target = data[0]["target"]
 
     payload = app_module.PredictRequest(board=board.tolist(), target=target)
-    result = app_module.predict(payload)
-    assert isinstance(result, list)
-    assert called["stream"] is False
+    app_module.predict(payload)
+    assert called["cache"] is True


### PR DESCRIPTION
## Summary
- add `build_memories.py` to compile memory banks from JSON/JSONL archives with Chinese logs
- preload `*_memory.npz` caches in `app.py` and remove streaming path for predictions
- invoke memory build step inside Dockerfile and adjust test to ensure cache path is used

## Testing
- `isort . --check-only`
- `black . --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689093a2314c8324979bee3b55d8f8c2