### PR TITLE
feat: preload memory caches for faster predictions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,25 @@ RUN pip install --upgrade pip setuptools wheel \
 # 再把專案原始碼放進來
 COPY . .
 ENV LOG_LEVEL=DEBUG
+# 轉換所有 jsonl -> json 並預先建立記憶快取
+RUN for f in data_archives/*x*.jsonl; do \
+    shape=$(basename "$f" .jsonl); \
+    python - <<'PY'
+import orjson, json, pathlib, sys
+src = pathlib.Path(sys.argv[1])
+dst = src.with_suffix('.json')
+if not dst.exists():
+    data = [orjson.loads(line) for line in src.open('rb')]
+    json.dump(data, dst.open('w', encoding='utf-8'), ensure_ascii=False)
+PY "$f"; \
+    python - <<'PY'
+from agents.memory_agent import build_memory_agent
+import pathlib, sys
+shape = tuple(map(int, sys.argv[1].split('x')))
+json_path = pathlib.Path(f'data_archives/{sys.argv[1]}.json')
+build_memory_agent(shape, json_path)
+PY "$shape"; \
+done
 # 預設執行指令（依你的專案入口）
 # 若採方案4，app 模組是 app:app；若改用 coco_service.main，請調整為 coco_service.main:app
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/agents/memory_agent.py
+++ b/agents/memory_agent.py
@@ -10,6 +10,7 @@ scores.
 
 from __future__ import annotations
 
+import json
 import logging
 import mmap
 import os
@@ -28,6 +29,7 @@ except Exception:  # pragma: no cover - torch missing
     TORCH_AVAILABLE = False
 
 from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board
+from model import DynamicMET
 from utils import ensure_only_blank
 
 logger = logging.getLogger(__name__)
@@ -87,6 +89,59 @@ def build_memory(
         memory_keys.append(h)
         memory_values.append(scores)
     return np.stack(memory_keys, axis=0), np.stack(memory_values, axis=0)
+
+
+def build_memory_agent(
+    shape: tuple[int, int],
+    json_path: Path,
+    *,
+    cache_dir: Path | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build or load memory cache for ``shape`` from ``json_path``.
+
+    If a cached ``.npz`` file exists, load ``keys`` and ``values`` directly.
+    Otherwise the JSON array is parsed and a temporary :class:`DynamicMET`
+    model is used to compute the memory bank, which is then saved for future
+    use.
+    """
+
+    rows, cols = shape
+    cache_dir = cache_dir or json_path.parent
+    cache_file = cache_dir / f"{rows}x{cols}_memory.npz"
+    if cache_file.exists():
+        data = np.load(cache_file)
+        logger.info("載入既有記憶快取：%s", cache_file)
+        return data["keys"], data["values"]
+
+    logger.info("建立記憶快取：%s", cache_file)
+    data = json.load(json_path.open("r", encoding="utf-8"))
+    samples = [
+        (np.array(entry["board"], dtype=int), int(entry["target"])) for entry in data
+    ]
+
+    num_fields = rows * cols
+    model = DynamicMET(
+        num_fields=num_fields,
+        num_values=num_fields,
+        rows=rows,
+        cols=cols,
+        d_model=256,
+        nhead=8,
+        depth=8,
+        dropout=0.1,
+    )
+    if TORCH_AVAILABLE:
+        ckpt_path = Path("checkpoints") / f"met_{rows}x{cols}.pth"
+        if ckpt_path.is_file():
+            ckpt = torch.load(ckpt_path, map_location="cpu")
+            state = ckpt.get("model", ckpt)
+            model.load_state_dict(state, strict=False)
+            if hasattr(model, "eval"):
+                model.eval()
+
+    keys, values = build_memory(samples, model)
+    np.savez(cache_file, keys=keys, values=values)
+    return keys, values
 
 
 def predict(

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
-import json
 import os
 import random
-import threading
+import time
 from pathlib import Path
 
 import numpy as np
@@ -11,6 +10,8 @@ os.environ["PYTHONHASHSEED"] = "42"
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
 random.seed(42)
 np.random.seed(42)
+
+os.environ.setdefault("MEMORY_MAX_SCAN", "1000")
 
 try:
     import torch
@@ -34,7 +35,7 @@ from typing import Dict, List, Optional, Tuple  # noqa: E402
 from fastapi import FastAPI, HTTPException  # noqa: E402
 from pydantic import BaseModel, Field, conlist, model_validator  # noqa: E402
 
-from agents.memory_agent import build_memory as build_memory_agent  # noqa: E402
+from agents.memory_agent import build_memory_agent  # noqa: E402
 from agents.memory_agent import predict as memory_predict  # noqa: E402
 from agents.memory_agent import predict_stream as memory_predict_stream  # noqa: E402
 from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board  # noqa: E402
@@ -191,26 +192,22 @@ def _load_one(path: str, rows: int, cols: int) -> DynamicMET:
     return model
 
 
-def _load_memory_for_shape(rows: int, cols: int, model: DynamicMET) -> None:
-    """Register memory source for ``(rows, cols)`` if archive exists."""
+def _load_memory_for_shape(rows: int, cols: int) -> None:
+    """Load memory cache or register streaming archive for the given shape."""
+    json_path = Path("data_archives") / f"{rows}x{cols}.json"
+    if json_path.is_file():
+        keys, values = build_memory_agent((rows, cols), json_path)
+        memories[(rows, cols)] = (keys, values)
+        logger.info("✅ 使用快取記憶庫：%s", json_path)
+        return
+
     jsonl_path = Path("data_archives") / f"{rows}x{cols}.jsonl"
     if jsonl_path.is_file():
         memory_files[(rows, cols)] = jsonl_path
         logger.info("記憶庫採流式讀取：%s", jsonl_path)
         return
 
-    file_path = Path("data_archives") / f"{rows}x{cols}.json"
-    if not file_path.is_file():
-        logger.warning("未找到記憶庫檔案：%s", file_path)
-        return
-    data = json.load(open(file_path, "r", encoding="utf-8"))
-    if MEMORY_SAMPLE_LIMIT is not None and len(data) > MEMORY_SAMPLE_LIMIT:
-        logger.info("限制記憶庫樣本 %s -> %s", len(data), MEMORY_SAMPLE_LIMIT)
-        data = data[:MEMORY_SAMPLE_LIMIT]
-    samples = [(np.array(e["board"], dtype=int), int(e["target"])) for e in data]
-    keys, values = build_memory_agent(samples, model)
-    memories[(rows, cols)] = (keys, values)
-    logger.info("✅ 記憶庫就緒：keys=%s values=%s", keys.shape, values.shape)
+    logger.warning("未找到記憶庫檔案：%s 或 %s", json_path, jsonl_path)
 
 
 def _discover_models() -> None:
@@ -235,12 +232,25 @@ def _discover_models() -> None:
 
 
 def _preload_memories() -> None:
-    """Load memory banks in background after startup."""
-    for (r, c), model in list(models.items()):
+    """Load memory caches for all available JSON archives."""
+    cached: list[str] = []
+    base = Path("data_archives")
+    for json_path in base.glob("*x*.json"):
         try:
-            _load_memory_for_shape(r, c, model)
+            name = json_path.stem
+            rows, cols = map(int, name.split("x"))
         except Exception:
-            logger.exception("記憶庫載入失敗：%sx%s", r, c)
+            continue
+        try:
+            keys, values = build_memory_agent((rows, cols), json_path)
+            memories[(rows, cols)] = (keys, values)
+            cached.append(f"{rows}x{cols}")
+        except Exception:
+            logger.exception("記憶庫載入失敗：%sx%s", rows, cols)
+    if cached:
+        logger.info("共快取了尺寸：%s", ", ".join(sorted(cached)))
+    else:
+        logger.info("未快取任何記憶庫")
 
 
 @app.on_event("startup")
@@ -254,7 +264,7 @@ def load_models() -> None:
         root_logger.setLevel(logging.getLogger("uvicorn").level)
     logger.info("應用啟動，準備載入模型")  # 中文log：啟動事件
     _discover_models()
-    threading.Thread(target=_preload_memories, daemon=True).start()
+    _preload_memories()
 
 
 @app.post("/predict", response_model=List[Prediction])
@@ -309,27 +319,19 @@ def predict(req: PredictRequest):
         if hasattr(model, "eval"):
             model.eval()
         models[(rows, cols)] = model
-        _load_memory_for_shape(rows, cols, model)
+        _load_memory_for_shape(rows, cols)
     else:
         logger.info("使用已載入的模型 %sx%s", rows, cols)  # 中文log：重複尺寸共用模型
 
     memory = memories.get((rows, cols))
     jsonl = memory_files.get((rows, cols))
     if memory is None and jsonl is None:
-        _load_memory_for_shape(rows, cols, model)
+        _load_memory_for_shape(rows, cols)
         memory = memories.get((rows, cols))
         jsonl = memory_files.get((rows, cols))
-    if jsonl is not None:
-        fused = memory_predict_stream(
-            board.copy(),
-            target=target,
-            model=model,
-            jsonl_path=jsonl,
-            alpha=0.5,
-            k_neighbors=2,
-            topk=3,
-        )
-    elif memory is not None:
+    start_t = time.time()
+    if memory is not None:
+        logger.info("走快取版記憶庫 %sx%s", rows, cols)
         memory_keys, memory_values = memory
         fused = memory_predict(
             board.copy(),
@@ -341,8 +343,22 @@ def predict(req: PredictRequest):
             k_neighbors=2,
             topk=3,
         )
+        logger.info("快取版耗時 %.3f 秒，結果 %s 筆", time.time() - start_t, len(fused))
+    elif jsonl is not None:
+        logger.info("走串流版記憶庫 %sx%s", rows, cols)
+        fused = memory_predict_stream(
+            board.copy(),
+            target=target,
+            model=model,
+            jsonl_path=jsonl,
+            alpha=0.5,
+            k_neighbors=2,
+            topk=3,
+        )
+        logger.info("串流版耗時 %.3f 秒，結果 %s 筆", time.time() - start_t, len(fused))
     else:
         fused = []
+        logger.info("無記憶庫可用")
 
     if fused:
         coords = []

--- a/tests/test_multi_shape_cache.py
+++ b/tests/test_multi_shape_cache.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import orjson
+from fastapi.testclient import TestClient
+
+# 準備 8x10.json（取前幾筆樣本）
+json_file = Path("data_archives/8x10.json")
+if not json_file.exists():
+    items = []
+    with Path("data_archives/8x10.jsonl").open("rb") as f:
+        for _ in range(3):
+            line = f.readline()
+            if not line:
+                break
+            items.append(orjson.loads(line))
+    json.dump(items, json_file.open("w", encoding="utf-8"))
+
+from app import (  # noqa: E402
+    BLANK_VALUE,
+    _preload_memories,
+    app,
+    memories,
+    memory_files,
+)
+
+_preload_memories()
+client = TestClient(app)
+
+
+def _check_shape(rows: int, cols: int) -> None:
+    data = json.load(open(f"data_archives/{rows}x{cols}.json", "r", encoding="utf-8"))
+    board = np.array(data[0]["board"], dtype=int)
+    board.flat[:3] = BLANK_VALUE
+    target = int(data[0]["target"])
+    resp = client.post("/predict", json={"board": board.tolist(), "target": target})
+    assert resp.status_code == 200
+    res = resp.json()
+    blank_count = int(np.sum(board == BLANK_VALUE))
+    assert len(res) == min(3, blank_count)
+
+
+def test_preloaded_memories_multi_shape() -> None:
+    assert (4, 5) in memories and (4, 5) not in memory_files
+    assert (8, 10) in memories and (8, 10) not in memory_files
+    _check_shape(4, 5)
+    _check_shape(8, 10)


### PR DESCRIPTION
## Summary
- build memory agent caches and convert jsonl archives during Docker build
- preload cached memories at startup and log usage
- add tests for multiple board shapes using cached memories

## Testing
- `isort agents/memory_agent.py app.py tests/test_multi_shape_cache.py --profile black`
- `black agents/memory_agent.py app.py tests/test_multi_shape_cache.py`
- `flake8 agents/memory_agent.py app.py tests/test_multi_shape_cache.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68908acd676c8324a54e272b0f276d8e