### PR TITLE
feat: add async memory loader

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,8 @@ from dataset import BLANK_VALUE, MASK_TOKEN_ID, validate_board  # noqa: E402
 from model import DynamicMET  # noqa: E402
 from utils import ensure_only_blank, ensure_unique  # noqa: E402
 
+from memory_loader import MEMORY_CACHE, ensure_loaded, preload_hot_shapes  # noqa: E402
+
 try:  # optional approximate nearest neighbor library
     import hnswlib  # noqa: E402
 except Exception:  # pragma: no cover - allow environments without hnswlib
@@ -341,8 +343,11 @@ def filter_by_target(rows: int, cols: int, target: int) -> List[int]:
     目前盤面最相似的範例。
     """
 
-    targets = memory_targets.get((rows, cols))
-    if targets is None:
+    data = MEMORY_CACHE.get((rows, cols))
+    if data is None:
+        raise KeyError(f"targets for {rows}x{cols} not loaded")
+    targets = data[2]
+    if targets.size == 0:
         raise KeyError(f"targets for {rows}x{cols} not loaded")
     return np.where(targets == target)[0].tolist()
 
@@ -396,8 +401,9 @@ def preload_memories() -> None:
 
 
 @app.on_event("startup")
-def load_models() -> None:
-    """Search and load checkpoints following pattern met_{R}x{C}.pth."""
+async def startup() -> None:
+    """Search and load checkpoints and preload hot memory shapes."""
+
     root_logger = logging.getLogger()
     env_level = os.environ.get("LOG_LEVEL")
     if env_level:
@@ -406,11 +412,11 @@ def load_models() -> None:
         root_logger.setLevel(logging.getLogger("uvicorn").level)
     logger.info("應用啟動，準備載入模型")  # 中文log：啟動事件
     _discover_models()
-    preload_memories()
+    await preload_hot_shapes([(5, 10), (4, 10), (4, 5)])  # 熱門尺寸
 
 
 @app.post("/predict", response_model=List[Prediction])
-def predict(req: PredictRequest):
+async def predict(req: PredictRequest):
     if not req.board or not all(isinstance(r, list) and r for r in req.board):
         raise HTTPException(
             status_code=422, detail="`board` must be a non-empty 2D list."
@@ -464,12 +470,9 @@ def predict(req: PredictRequest):
     else:
         logger.info("使用已載入的模型 %sx%s", rows, cols)  # 中文log：重複尺寸共用模型
 
-    memory = memories.get((rows, cols))
-    if memory is None:
-        _load_memory_for_shape(rows, cols)
-        memory = memories.get((rows, cols))
-
-    mem_n = int(memory[0].shape[0]) if memory is not None else 0
+    await ensure_loaded(rows, cols)
+    keys, values, _, _ = MEMORY_CACHE.get((rows, cols), (None, None, None, None))
+    mem_n = 0 if keys is None else int(keys.shape[0])
     logger.info("記憶庫：尺寸=%sx%s；📦 共 %d 筆樣本", rows, cols, mem_n)
 
     # ensure contiguous int64 array to avoid torch dtype inference errors
@@ -560,8 +563,7 @@ def predict(req: PredictRequest):
     except KeyError:
         sim_indices = []
     retrieved = len(sim_indices)
-    if sim_indices and memory is not None:
-        keys, values = memory
+    if sim_indices and keys is not None and values is not None:
         q, _ = build_memory_agent([(board, target)], model)
         dists = np.linalg.norm(keys[sim_indices] - q[0], axis=1)
         k_mem = min(3, len(sim_indices))

--- a/memory_loader.py
+++ b/memory_loader.py
@@ -1,0 +1,94 @@
+"""Asynchronous memory loader using background tasks and memmap.
+
+Implements plan A from the design document: load hot shapes in a
+background task during FastAPI startup while allowing lazy loading for
+other shapes on demand.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+# Directory containing sharded memory files such as
+# ``{rows}x{cols}_keys_p0.npy`` / ``{rows}x{cols}_vals_p0.npy``.
+DATA_DIR = Path(os.environ.get("MEMORY_DATA_DIR", "data_archives"))
+
+# Cache mapping ``(rows, cols)`` to ``(keys, values, targets, boards)``.
+MEMORY_CACHE: Dict[
+    Tuple[int, int], Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+] = {}
+
+# Locks to avoid duplicate loads for the same shape.
+LOCKS: Dict[Tuple[int, int], asyncio.Lock] = {}
+
+logger = logging.getLogger(__name__)
+
+_PART_RE = re.compile(r"_p(\d+)\.npy$")
+
+
+def _glob_paths(rows: int, cols: int, kind: str) -> List[Path]:
+    """Return all shard paths for ``kind`` sorted by part number."""
+
+    pat = DATA_DIR / f"{rows}x{cols}_{kind}_p*.npy"
+    paths = pat.parent.glob(pat.name)
+    return sorted(paths, key=lambda p: int(_PART_RE.search(p.name).group(1)))
+
+
+def _load_shape(rows: int, cols: int) -> None:
+    """Load memory arrays for ``(rows, cols)`` and cache them.
+
+    Sharded files with pattern ``{rows}x{cols}_{kind}_p*.npy`` are
+    concatenated in order of part number. Missing ``targets`` or ``boards``
+    shards yield empty arrays.
+    """
+
+    k_paths = _glob_paths(rows, cols, "keys")
+    v_paths = _glob_paths(rows, cols, "vals")
+    if not k_paths or not v_paths:
+        raise FileNotFoundError(f"missing keys/vals shards for {rows}x{cols}")
+
+    keys = np.concatenate([np.load(p, mmap_mode="r") for p in k_paths], axis=0)
+    vals = np.concatenate([np.load(p, mmap_mode="r") for p in v_paths], axis=0)
+
+    t_paths = _glob_paths(rows, cols, "targets")
+    if t_paths:
+        targets = np.concatenate([np.load(p, mmap_mode="r") for p in t_paths], axis=0)
+    else:
+        targets = np.empty((0,), dtype=np.int16)
+
+    b_paths = _glob_paths(rows, cols, "boards")
+    if b_paths:
+        boards = np.concatenate([np.load(p, mmap_mode="r") for p in b_paths], axis=0)
+    else:
+        boards = np.empty((0, rows * cols), dtype=np.int8)
+
+    MEMORY_CACHE[(rows, cols)] = (keys, vals, targets, boards)
+    logger.info("✅ memory %dx%d loaded parts=%d", rows, cols, len(k_paths))
+
+
+async def ensure_loaded(rows: int, cols: int) -> None:
+    """Ensure memory for `(rows, cols)` is available in the cache."""
+
+    if (rows, cols) in MEMORY_CACHE:
+        return
+    lock = LOCKS.setdefault((rows, cols), asyncio.Lock())
+    async with lock:
+        if (rows, cols) not in MEMORY_CACHE:
+            try:
+                await asyncio.to_thread(_load_shape, rows, cols)
+            except FileNotFoundError:
+                logger.warning("memory files missing for %dx%d", rows, cols)
+
+
+async def preload_hot_shapes(hot_shapes: list[tuple[int, int]]) -> None:
+    """Spawn background tasks to load commonly used shapes."""
+
+    for rows, cols in hot_shapes:
+        asyncio.create_task(ensure_loaded(rows, cols))

--- a/tests/test_app_fallback.py
+++ b/tests/test_app_fallback.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import sys
 
@@ -17,7 +18,7 @@ def test_app_predict_numpy(monkeypatch):
     appmod.models[(2, 2)] = model.DynamicMET(4, num_values=4, rows=2, cols=2)
     board = np.array([[1, 2], [3, -1]]).tolist()
     payload = appmod.PredictRequest(board=board, target_value=1)
-    result = appmod.predict(payload)
+    result = asyncio.run(appmod.predict(payload))
     assert isinstance(result, list) and len(result) == 1
     for item in result:
         assert {"row", "col", "score"} <= set(item.model_dump().keys())

--- a/tests/test_blank_top3.py
+++ b/tests/test_blank_top3.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import logging
 
@@ -13,7 +14,7 @@ def test_predict_only_blank_top3(caplog):
     board = np.array([[1, -1, 2], [-1, 3, 4]]).tolist()
     payload = appmod.PredictRequest(board=board, target=1)
     with caplog.at_level(logging.INFO):
-        result = appmod.predict(payload)
+        result = asyncio.run(appmod.predict(payload))
     assert len(result) == 2
     blank_positions = {(1, 2), (2, 1)}
     assert all((item.row, item.col) in blank_positions for item in result)

--- a/tests/test_memory_loader_module.py
+++ b/tests/test_memory_loader_module.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+
+import numpy as np
+
+import memory_loader
+
+
+def test_ensure_loaded(tmp_path: Path) -> None:
+    keys = np.ones((2, 3), dtype=np.float32)
+    vals = np.ones((2, 2), dtype=np.float32)
+    np.save(tmp_path / "2x3_keys_p0.npy", keys)
+    np.save(tmp_path / "2x3_vals_p0.npy", vals)
+    memory_loader.DATA_DIR = tmp_path
+    memory_loader.MEMORY_CACHE.clear()
+    asyncio.run(memory_loader.ensure_loaded(2, 3))
+    assert (2, 3) in memory_loader.MEMORY_CACHE
+    loaded_keys, loaded_vals, loaded_targets, loaded_boards = (
+        memory_loader.MEMORY_CACHE[(2, 3)]
+    )
+    assert loaded_keys.shape == keys.shape
+    assert loaded_vals.shape == vals.shape
+    assert loaded_targets.size == 0
+    assert loaded_boards.size == 0
+
+
+def test_preload_hot_shapes(tmp_path: Path) -> None:
+    keys = np.zeros((1, 4), dtype=np.float32)
+    vals = np.zeros((1, 2), dtype=np.float32)
+    np.save(tmp_path / "1x4_keys_p0.npy", keys)
+    np.save(tmp_path / "1x4_vals_p0.npy", vals)
+    memory_loader.DATA_DIR = tmp_path
+    memory_loader.MEMORY_CACHE.clear()
+
+    async def _run() -> None:
+        await memory_loader.preload_hot_shapes([(1, 4)])
+        for _ in range(10):
+            if (1, 4) in memory_loader.MEMORY_CACHE:
+                break
+            await asyncio.sleep(0.01)
+
+    asyncio.run(_run())
+    assert (1, 4) in memory_loader.MEMORY_CACHE

--- a/tests/test_memory_loader_multi_part.py
+++ b/tests/test_memory_loader_multi_part.py
@@ -1,0 +1,28 @@
+import asyncio
+from pathlib import Path
+
+import numpy as np
+
+import memory_loader
+
+
+def test_memory_loader_multi_part(tmp_path: Path) -> None:
+    rows, cols = 2, 3
+    parts = [2, 3, 1]
+    offset = 0
+    for idx, n in enumerate(parts):
+        k = np.full((n, 2), idx, dtype=np.float32)
+        v = np.full((n, cols * rows // 2), idx, dtype=np.float32)
+        t = np.arange(offset, offset + n, dtype=np.int16)
+        np.save(tmp_path / f"{rows}x{cols}_keys_p{idx}.npy", k)
+        np.save(tmp_path / f"{rows}x{cols}_vals_p{idx}.npy", v)
+        np.save(tmp_path / f"{rows}x{cols}_targets_p{idx}.npy", t)
+        offset += n
+    memory_loader.DATA_DIR = tmp_path
+    memory_loader.MEMORY_CACHE.clear()
+    asyncio.run(memory_loader.ensure_loaded(rows, cols))
+    keys, vals, targets, boards = memory_loader.MEMORY_CACHE[(rows, cols)]
+    assert keys.shape[0] == sum(parts)
+    assert vals.shape[0] == sum(parts)
+    assert targets.shape[0] == sum(parts)
+    assert boards.shape == (0, rows * cols)

--- a/tests/test_memory_search.py
+++ b/tests/test_memory_search.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 from pathlib import Path
@@ -5,6 +6,7 @@ from pathlib import Path
 import numpy as np
 
 import app
+import memory_loader
 from dataset import BLANK_VALUE
 
 
@@ -14,6 +16,14 @@ def test_find_similar_and_filter_by_target():
         model.eval()
     app.models[(4, 5)] = model
     app._load_memory_for_shape(4, 5)
+    keys, values = app.memories[(4, 5)]
+    targets = app.memory_targets[(4, 5)]
+    memory_loader.MEMORY_CACHE[(4, 5)] = (
+        keys,
+        values,
+        targets,
+        np.empty((0, 20), dtype=np.int8),
+    )
 
     data = json.load(Path("data_archives/4x5.json").open("r", encoding="utf-8"))[0]
     board = np.array(data["board"], dtype=int)
@@ -45,7 +55,6 @@ def test_predict_memory_fusion_prefers_memory():
     if hasattr(model, "eval"):
         model.eval()
     app.models[(4, 5)] = model
-    app._load_memory_for_shape(4, 5)
 
     data = json.load(Path("data_archives/4x5.json").open("r", encoding="utf-8"))[0]
     board = np.array(data["board"], dtype=int)
@@ -58,11 +67,19 @@ def test_predict_memory_fusion_prefers_memory():
     mask_pos = np.where(board.flatten() == BLANK_VALUE)[0]
     assert mask_pos.size > 0
     bidx = int(mask_pos[0])
-    keys, values = app.memories[(4, 5)]
-    values[:] = 0
-    values[:, bidx] = 1.0
-    app.memories[(4, 5)] = (keys, values)
+
+    memory_loader.MEMORY_CACHE.clear()
+    keys = np.zeros((1, 256), dtype=np.float32)
+    values = np.zeros((1, board.size), dtype=np.float32)
+    values[0, bidx] = 1.0
+    targets = np.array([target], dtype=np.int16)
+    memory_loader.MEMORY_CACHE[(4, 5)] = (
+        keys,
+        values,
+        targets,
+        np.empty((0, board.size), dtype=np.int8),
+    )
 
     req = app.PredictRequest(board=board.tolist(), target=target)
-    preds = app.predict(req)
+    preds = asyncio.run(app.predict(req))
     assert preds[0].idx == bidx

--- a/tests/test_stable_topk.py
+++ b/tests/test_stable_topk.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 
 import numpy as np
@@ -26,6 +27,6 @@ def test_app_predict_stable_order() -> None:
     appmod.models[(2, 2)] = DummyModel()
     board = np.full((2, 2), appmod.BLANK_VALUE).tolist()
     req = appmod.PredictRequest(board=board, target=1)
-    res = appmod.predict(req)
+    res = asyncio.run(appmod.predict(req))
     coords = [(p.row, p.col) for p in res]
     assert coords == [(1, 1), (1, 2), (2, 1)]


### PR DESCRIPTION
## Summary
- support sharded memory files (keys/vals/targets/boards)
- preload hot memory shapes and access targets via MEMORY_CACHE
- add tests for multi-part loading and adjust existing tests

## Testing
- `isort --profile black memory_loader.py app.py tests/test_memory_loader_module.py tests/test_memory_search.py tests/test_memory_loader_multi_part.py`
- `black memory_loader.py app.py tests/test_memory_loader_module.py tests/test_memory_search.py tests/test_memory_loader_multi_part.py`
- `flake8 memory_loader.py app.py tests/test_memory_loader_module.py tests/test_memory_search.py tests/test_memory_loader_multi_part.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891ffb1183c8324b9d0dd4fc5a1cd44