### PR TITLE
Add dataset and temperature-based decoding utilities

### DIFF
--- a/configs/train_small_mix.yaml
+++ b/configs/train_small_mix.yaml
@@ -1,0 +1,7 @@
+# Training configuration for mixed sizes
+vocab_size: 400
+
+model:
+  d_model: 256
+  n_head: 8
+  num_layers: 6

--- a/scripts/solve_json.py
+++ b/scripts/solve_json.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+from src.inference.decode_temp import iterative_decode_temp
+from src.inference.model_loader import load_model
+
+
+def main() -> None:  # pragma: no cover - CLI
+    p = argparse.ArgumentParser()
+    p.add_argument("ckpt")
+    p.add_argument("in_json")
+    p.add_argument("out_json")
+    p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    p.add_argument("--steps", type=int, default=8)
+    p.add_argument("--fill_ratio", type=float, default=0.3)
+    p.add_argument("--temperature", type=float, default=1.0)
+    p.add_argument("--topk", type=int, default=None)
+    p.add_argument("--topp", type=float, default=None)
+    args = p.parse_args()
+
+    data = json.loads(Path(args.in_json).read_text())
+    boards = data["boards"]
+    model = load_model(args.ckpt, device=args.device)
+
+    outputs = []
+    for b in boards:
+        grid = b["grid"]
+        rows, cols = len(grid), len(grid[0])
+        N = rows * cols
+        flat = []
+        for r in range(rows):
+            for c in range(cols):
+                v = grid[r][c]
+                if v == -1:
+                    v = 0
+                flat.append(v)
+        tokens = torch.tensor(flat, dtype=torch.long, device=args.device).unsqueeze(0)
+        attn = torch.ones_like(tokens, dtype=torch.bool)
+        out = iterative_decode_temp(
+            model,
+            tokens,
+            attn,
+            N,
+            steps=args.steps,
+            fill_ratio=args.fill_ratio,
+            temperature=args.temperature,
+            topk=args.topk,
+            topp=args.topp,
+        )
+        solved = out.view(rows, cols).tolist()
+        outputs.append({"grid": solved})
+
+    Path(args.out_json).write_text(
+        json.dumps({"boards": outputs}, ensure_ascii=False, indent=2)
+    )
+    print(f"wrote -> {args.out_json}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/src/inference/decode_temp.py
+++ b/src/inference/decode_temp.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import torch
+
+from src.models import constraints
+from src.models.vocab import masked_logits_clip
+
+from .decode import select_topk
+
+
+@torch.no_grad()
+def iterative_decode_temp(
+    model,
+    tokens: torch.Tensor,
+    attn_mask: torch.Tensor | None,
+    N: int,
+    *,
+    steps: int = 8,
+    fill_ratio: float = 0.3,
+    temperature: float = 1.0,
+    topk: int | None = None,
+    topp: float | None = None,
+) -> torch.Tensor:
+    """Iterative decode with optional sampling."""
+
+    B, L = tokens.shape
+    for _ in range(steps):
+        logits = model(tokens, attn_mask)
+        logits = masked_logits_clip(logits, N)
+        if temperature != 1.0:
+            logits = logits / max(1e-6, temperature)
+        probs = torch.softmax(logits, dim=-1)
+        conf, pred = probs.max(-1)
+        masked = tokens.eq(0)
+        sel = select_topk(masked, conf, fill_ratio)
+
+        if topk is not None or (topp is not None and 0 < topp < 1):
+            sampled = pred.clone()
+            for b in range(B):
+                idxs = torch.where(sel[b])[0]
+                if idxs.numel() == 0:
+                    continue
+                for i in idxs.tolist():
+                    p = probs[b, i, 1 : N + 1]
+                    if topk is not None:
+                        k = min(topk, p.numel())
+                        vals, ind = torch.topk(p, k)
+                        p_cut = torch.zeros_like(p)
+                        p_cut[ind] = vals
+                        p = p_cut
+                    if topp is not None and 0 < topp < 1:
+                        sorted_p, sorted_idx = torch.sort(p, descending=True)
+                        csum = torch.cumsum(sorted_p, dim=-1)
+                        keep = csum <= topp
+                        if not torch.any(keep):
+                            keep[0] = True
+                        p_cut = torch.zeros_like(p)
+                        p_cut[sorted_idx[keep]] = p[sorted_idx[keep]]
+                        p = p_cut
+                    if p.sum() <= 0:
+                        choice = torch.argmax(p).item() + 1
+                    else:
+                        p = p / p.sum()
+                        choice = torch.multinomial(p, num_samples=1).item() + 1
+                    sampled[b, i] = choice
+            pred = sampled
+
+        tokens = tokens.clone()
+        tokens[sel] = pred[sel]
+        tokens = constraints.uniqueness_projection(logits, masked, N)
+        if not tokens.eq(0).any():
+            break
+
+    if tokens.eq(0).any():
+        tokens = constraints.uniqueness_projection(logits, tokens.eq(0), N)
+    return tokens

--- a/src/training/datasets/__init__.py
+++ b/src/training/datasets/__init__.py
@@ -1,0 +1,5 @@
+"""Dataset utilities for training."""
+
+from .json_boards import MASK_TOKEN, JsonBoardsDataset, MaskConfig, collate_batch
+
+__all__ = ["MASK_TOKEN", "JsonBoardsDataset", "MaskConfig", "collate_batch"]

--- a/src/training/datasets/json_boards.py
+++ b/src/training/datasets/json_boards.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import torch
+from torch.utils.data import Dataset
+
+MASK_TOKEN = 0
+
+
+def _validate_full_grid(grid: List[List[int]]) -> Tuple[int, int, int]:
+    if not isinstance(grid, list) or not grid:
+        raise ValueError("grid must be a non-empty list")
+    rows, cols = len(grid), len(grid[0])
+    if any(not isinstance(r, list) or len(r) != cols for r in grid):
+        raise ValueError("grid must be rectangular")
+    N = rows * cols
+    flat = [v for row in grid for v in row]
+    if any(not isinstance(v, int) or not (1 <= v <= N) for v in flat):
+        raise ValueError(f"values must be 1..{N}")
+    return rows, cols, N
+
+
+def _validate_partial_grid(grid: List[List[int]]) -> Tuple[int, int, int]:
+    if not isinstance(grid, list) or not grid:
+        raise ValueError("grid must be a non-empty list")
+    rows, cols = len(grid), len(grid[0])
+    if any(not isinstance(r, list) or len(r) != cols for r in grid):
+        raise ValueError("grid must be rectangular")
+    N = rows * cols
+    flat = [v for row in grid for v in row]
+    if any(not isinstance(v, int) or (v != -1 and not (1 <= v <= N)) for v in flat):
+        raise ValueError(f"values must be -1 or 1..{N}")
+    return rows, cols, N
+
+
+@dataclass
+class MaskConfig:
+    min_ratio: float = 0.15
+    max_ratio: float = 0.6
+    line_block_prob: float = 0.3
+
+
+class JsonBoardsDataset(Dataset):
+    """Training dataset loading full grids and masking them."""
+
+    def __init__(
+        self, json_path: str | Path, mask_cfg: MaskConfig | None = None, seed: int = 42
+    ) -> None:
+        self.path = Path(json_path)
+        data = json.loads(self.path.read_text())
+        self.boards = [b["grid"] for b in data["boards"]]
+        self.meta = [_validate_full_grid(g) for g in self.boards]
+        self.mask_cfg = mask_cfg or MaskConfig()
+        random.seed(seed)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.boards)
+
+    def _mask_grid(self, grid: List[List[int]]) -> List[List[int]]:
+        rows, cols = len(grid), len(grid[0])
+        total = rows * cols
+        ratio = random.uniform(self.mask_cfg.min_ratio, self.mask_cfg.max_ratio)
+        num_mask = max(1, int(total * ratio))
+        masked = [row[:] for row in grid]
+
+        if random.random() < self.mask_cfg.line_block_prob:
+            if random.random() < 0.5:
+                r = random.randrange(rows)
+                for c in range(cols):
+                    masked[r][c] = MASK_TOKEN
+            else:
+                c = random.randrange(cols)
+                for r in range(rows):
+                    masked[r][c] = MASK_TOKEN
+
+        flat_idx = list(range(total))
+        random.shuffle(flat_idx)
+        count = 0
+        for idx in flat_idx:
+            r, c = divmod(idx, cols)
+            if masked[r][c] != MASK_TOKEN:
+                masked[r][c] = MASK_TOKEN
+                count += 1
+                if count >= num_mask:
+                    break
+        return masked
+
+    def __getitem__(self, i: int) -> Dict[str, Any]:
+        grid = self.boards[i]
+        rows, cols, N = self.meta[i]
+        masked = self._mask_grid(grid)
+
+        target = torch.tensor([v for row in grid for v in row], dtype=torch.long)
+        tokens = torch.tensor([v for row in masked for v in row], dtype=torch.long)
+        attn = torch.ones_like(tokens, dtype=torch.bool)
+
+        return {
+            "tokens": tokens,
+            "target": target,
+            "attn_mask": attn,
+            "rows": rows,
+            "cols": cols,
+            "N": N,
+        }
+
+
+def collate_batch(samples: List[Dict[str, Any]]) -> Dict[str, Any]:
+    tokens = torch.stack([s["tokens"] for s in samples])
+    target = torch.stack([s["target"] for s in samples])
+    attn = torch.stack([s["attn_mask"] for s in samples])
+    rows = torch.tensor([s["rows"] for s in samples], dtype=torch.long)
+    cols = torch.tensor([s["cols"] for s in samples], dtype=torch.long)
+    N = torch.tensor([s["N"] for s in samples], dtype=torch.long)
+    return {
+        "tokens": tokens,
+        "target": target,
+        "attn_mask": attn,
+        "rows": rows,
+        "cols": cols,
+        "N": N,
+    }

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -1,55 +1,144 @@
-"""Minimal training loop placeholder."""
-
 from __future__ import annotations
 
 import argparse
+import os
+import time
 from pathlib import Path
 
 import torch
+from torch import nn
+from torch.utils.data import DataLoader
 
-from ..config import load_config
-from ..data.augment import mask_board
-from ..data.collate import collate_boards
-from ..data.datasets import GridDataset
-from ..models.maskgit import MaskGit
-from .loss import masked_cross_entropy
+from src.config import load_config
+from src.models.maskgit import MaskGit
+from src.models.vocab import masked_logits_clip
+from src.training.datasets import JsonBoardsDataset, MaskConfig, collate_batch
 
 
-def train(cfg_path: str) -> None:
-    cfg = load_config(cfg_path)
-    ds = (
-        GridDataset(Path("data/train.jsonl"))
-        if Path("data/train.jsonl").exists()
-        else None
+def set_seed(seed: int = 42) -> None:
+    import random
+
+    import numpy as np
+
+    random.seed(seed)
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+
+def compute_loss(
+    logits: torch.Tensor, target: torch.Tensor, N: torch.Tensor
+) -> torch.Tensor:
+    B, L, V = logits.shape
+    loss = torch.tensor(0.0, device=logits.device)
+    for b in range(B):
+        n = int(N[b].item())
+        logit_b = masked_logits_clip(logits[b : b + 1], n)
+        ce = nn.functional.cross_entropy(
+            logit_b.view(-1, V), target[b].view(-1), ignore_index=0
+        )
+        loss = loss + ce
+    return loss / B
+
+
+def evaluate(model: nn.Module, loader: DataLoader, device: str) -> dict:
+    model.eval()
+    total_loss = 0.0
+    total_tok = 0
+    with torch.no_grad():
+        for batch in loader:
+            tokens = batch["tokens"].to(device)
+            target = batch["target"].to(device)
+            attn = batch["attn_mask"].to(device)
+            N = batch["N"].to(device)
+            logits = model(tokens, attn)
+            loss = compute_loss(logits, target, N)
+            cnt = (target != 0).sum().item()
+            total_loss += loss.item() * cnt
+            total_tok += cnt
+    return {"loss": total_loss / max(1, total_tok)}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    p = argparse.ArgumentParser()
+    p.add_argument("--train_json", required=True)
+    p.add_argument("--val_json", required=True)
+    p.add_argument("--outdir", default="runs/gridfill")
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--bsz", type=int, default=32)
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    p.add_argument(
+        "--config",
+        default=os.environ.get("GRIDFILL_CFG", "configs/train_small_mix.yaml"),
     )
+    args = p.parse_args()
+
+    set_seed(args.seed)
+    cfg = load_config(args.config)
     model = MaskGit(
         cfg["vocab_size"],
         cfg["model"]["d_model"],
         cfg["model"]["n_head"],
         cfg["model"]["num_layers"],
-    )
-    if ds is None:
-        return
-    opt = torch.optim.Adam(model.parameters(), lr=cfg["train"]["lr"])
-    loader = torch.utils.data.DataLoader(
-        ds, batch_size=cfg["train"]["batch_size"], shuffle=True
-    )
-    for board in loader:
-        tokens, mask = mask_board(board)
-        flat, attn = collate_boards([tokens])
-        logits = model(flat)
-        loss = masked_cross_entropy(logits, flat, mask.flatten())
-        loss.backward()
-        opt.step()
-        opt.zero_grad()
-        break
+    ).to(args.device)
 
+    train_ds = JsonBoardsDataset(args.train_json, mask_cfg=MaskConfig())
+    val_ds = JsonBoardsDataset(args.val_json, mask_cfg=MaskConfig())
 
-def main() -> None:  # pragma: no cover - CLI
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config", type=str, required=True)
-    args = parser.parse_args()
-    train(args.config)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=args.bsz,
+        shuffle=True,
+        num_workers=2,
+        collate_fn=collate_batch,
+        pin_memory=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=args.bsz,
+        shuffle=False,
+        num_workers=2,
+        collate_fn=collate_batch,
+        pin_memory=True,
+    )
+
+    opt = torch.optim.AdamW(model.parameters(), lr=args.lr)
+    best_val = float("inf")
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    best_ckpt = outdir / "best.ckpt"
+
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        t0 = time.time()
+        for step, batch in enumerate(train_loader, 1):
+            tokens = batch["tokens"].to(args.device)
+            target = batch["target"].to(args.device)
+            attn = batch["attn_mask"].to(args.device)
+            N = batch["N"].to(args.device)
+
+            logits = model(tokens, attn)
+            loss = compute_loss(logits, target, N)
+            opt.zero_grad(set_to_none=True)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            opt.step()
+
+            if step % 50 == 0:
+                print(f"[epoch {epoch}] step {step} loss {loss.item():.4f}")
+
+        val = evaluate(model, val_loader, args.device)
+        print(
+            f"[epoch {epoch}] val_loss/token: {val['loss']:.6f} (elapsed {time.time()-t0:.1f}s)"
+        )
+
+        if val["loss"] < best_val:
+            best_val = val["loss"]
+            torch.save(model.state_dict(), best_ckpt)
+            print(f"  -> saved {best_ckpt}")
+
+    torch.save(model.state_dict(), outdir / "final.ckpt")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI

--- a/tests/test_decode_temp.py
+++ b/tests/test_decode_temp.py
@@ -1,0 +1,37 @@
+import numpy as np
+import torch
+from torch import nn
+
+from src.data.augment import mask_board
+from src.inference.decode_temp import iterative_decode_temp
+
+
+class StubModel(nn.Module):
+    def __init__(self, target: torch.Tensor, vocab_size: int = 10) -> None:
+        super().__init__()
+        self.register_buffer("target", target.flatten())
+        self.vocab_size = vocab_size
+
+    def forward(self, tokens: torch.Tensor, attn_mask=None):  # type: ignore[override]
+        B, M = tokens.shape
+        logits = torch.zeros(B, M, self.vocab_size)
+        for i, t in enumerate(self.target):
+            logits[:, i, t] = 10.0
+        return logits
+
+
+def test_iterative_decode_temp_fills_grid() -> None:
+    board = torch.arange(1, 10).view(3, 3)
+    masked, _ = mask_board(board, ratio=0.5, rng=np.random.default_rng(0))
+    tokens = masked.flatten().unsqueeze(0)
+    attn = torch.ones_like(tokens, dtype=torch.bool)
+    model = StubModel(board)
+    out = iterative_decode_temp(
+        model,
+        tokens,
+        attn,
+        N=board.numel(),
+        temperature=0.8,
+        topk=5,
+    )
+    assert torch.equal(out.view_as(board), board)

--- a/tests/test_json_boards_dataset.py
+++ b/tests/test_json_boards_dataset.py
@@ -1,0 +1,18 @@
+import json
+
+from src.training.datasets import JsonBoardsDataset, MaskConfig, collate_batch
+
+
+def test_json_boards_dataset_mask(tmp_path):
+    data = {"boards": [{"grid": [[1, 2], [3, 4]]}]}
+    path = tmp_path / "train.json"
+    path.write_text(json.dumps(data))
+    ds = JsonBoardsDataset(
+        path, mask_cfg=MaskConfig(min_ratio=0.5, max_ratio=0.5, line_block_prob=0.0)
+    )
+    sample = ds[0]
+    assert sample["tokens"].numel() == 4
+    assert (sample["tokens"] == 0).any()
+    assert (sample["target"] > 0).all()
+    collated = collate_batch([sample])
+    assert collated["tokens"].shape == (1, 4)


### PR DESCRIPTION
## Summary
- add JsonBoardsDataset for dynamic masking from JSON grids
- expand training script to use new dataset and save best checkpoints
- introduce temperature/top-k decoding and JSON solver script
- allow training script config override and export dataset helpers

## Testing
- `isort . --profile black --check`
- `black . --check`
- `flake8 src/inference/decode_temp.py src/training/datasets/__init__.py src/training/datasets/json_boards.py src/training/train.py scripts/solve_json.py tests/test_json_boards_dataset.py tests/test_decode_temp.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e82942b483248f6ed738318f62a3