### PR TITLE
Add pad collate and vectorized training loss

### DIFF
--- a/src/training/datasets/__init__.py
+++ b/src/training/datasets/__init__.py
@@ -1,5 +1,14 @@
 """Dataset utilities for training."""
 
-from .json_boards import MASK_TOKEN, JsonBoardsDataset, MaskConfig, collate_batch
+# isort: skip_file
 
-__all__ = ["MASK_TOKEN", "JsonBoardsDataset", "MaskConfig", "collate_batch"]
+from .json_boards import MASK_TOKEN, JsonBoardsDataset, MaskConfig, collate_batch
+from .pad_collate import pad_collate
+
+__all__ = [
+    "MASK_TOKEN",
+    "JsonBoardsDataset",
+    "MaskConfig",
+    "collate_batch",
+    "pad_collate",
+]

--- a/src/training/datasets/pad_collate.py
+++ b/src/training/datasets/pad_collate.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import torch
+
+
+def pad_collate(samples):
+    """Pad variable-length samples into a batch.
+
+    Each sample is a dict with keys ``tokens``, ``target``, ``attn_mask`` and
+    metadata ``rows``, ``cols`` and ``N``. ``tokens`` and ``target`` are padded
+    with zeros to the maximum length in the batch. ``attn_mask`` is padded with
+    ``False``. ``rows``, ``cols`` and ``N`` are stacked without padding.
+    """
+
+    max_len = max(s["tokens"].numel() for s in samples)
+    batch = {}
+
+    for key in ("tokens", "target", "attn_mask"):
+        padded = []
+        for s in samples:
+            t = s[key]
+            if t.numel() < max_len:
+                pad = torch.zeros(max_len - t.numel(), dtype=t.dtype)
+                t = torch.cat([t, pad], dim=0)
+            padded.append(t)
+        batch[key] = torch.stack(padded, dim=0)
+
+    for key in ("rows", "cols", "N"):
+        batch[key] = torch.tensor([s[key] for s in samples], dtype=torch.long)
+
+    return batch

--- a/src/training/loss_vec.py
+++ b/src/training/loss_vec.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def clip_logits_by_N_batched(logits: torch.Tensor, N: torch.Tensor) -> torch.Tensor:
+    """Mask logits so that values beyond each sample's N are ignored.
+
+    Args:
+        logits: Tensor of shape [B, L, V].
+        N: Tensor of shape [B] containing the maximum valid token per sample.
+    """
+
+    B, L, V = logits.shape
+    ar = torch.arange(V, device=logits.device).view(1, 1, V)
+    Nv = N.view(B, 1, 1)
+    valid = ar <= Nv
+    return torch.where(valid, logits, torch.full_like(logits, -1e9))
+
+
+def compute_loss_vectorized(
+    logits: torch.Tensor, target: torch.Tensor, N: torch.Tensor
+) -> torch.Tensor:
+    """Cross-entropy loss over variable-N vocabularies without Python loops."""
+
+    logits = clip_logits_by_N_batched(logits, N)
+    B, L, V = logits.shape
+    loss = F.cross_entropy(logits.reshape(-1, V), target.reshape(-1), ignore_index=0)
+    return loss

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -11,8 +11,8 @@ from torch.utils.data import DataLoader
 
 from src.config import load_config
 from src.models.maskgit import MaskGit
-from src.models.vocab import masked_logits_clip
-from src.training.datasets import JsonBoardsDataset, MaskConfig, collate_batch
+from src.training.datasets import JsonBoardsDataset, MaskConfig, pad_collate
+from src.training.loss_vec import compute_loss_vectorized
 
 
 def set_seed(seed: int = 42) -> None:
@@ -23,21 +23,6 @@ def set_seed(seed: int = 42) -> None:
     random.seed(seed)
     torch.manual_seed(seed)
     np.random.seed(seed)
-
-
-def compute_loss(
-    logits: torch.Tensor, target: torch.Tensor, N: torch.Tensor
-) -> torch.Tensor:
-    B, L, V = logits.shape
-    loss = torch.tensor(0.0, device=logits.device)
-    for b in range(B):
-        n = int(N[b].item())
-        logit_b = masked_logits_clip(logits[b : b + 1], n)
-        ce = nn.functional.cross_entropy(
-            logit_b.view(-1, V), target[b].view(-1), ignore_index=0
-        )
-        loss = loss + ce
-    return loss / B
 
 
 def evaluate(model: nn.Module, loader: DataLoader, device: str) -> dict:
@@ -51,7 +36,7 @@ def evaluate(model: nn.Module, loader: DataLoader, device: str) -> dict:
             attn = batch["attn_mask"].to(device)
             N = batch["N"].to(device)
             logits = model(tokens, attn)
-            loss = compute_loss(logits, target, N)
+            loss = compute_loss_vectorized(logits, target, N)
             cnt = (target != 0).sum().item()
             total_loss += loss.item() * cnt
             total_tok += cnt
@@ -91,7 +76,7 @@ def main() -> None:  # pragma: no cover - CLI
         batch_size=args.bsz,
         shuffle=True,
         num_workers=2,
-        collate_fn=collate_batch,
+        collate_fn=pad_collate,
         pin_memory=True,
     )
     val_loader = DataLoader(
@@ -99,7 +84,7 @@ def main() -> None:  # pragma: no cover - CLI
         batch_size=args.bsz,
         shuffle=False,
         num_workers=2,
-        collate_fn=collate_batch,
+        collate_fn=pad_collate,
         pin_memory=True,
     )
 
@@ -119,7 +104,7 @@ def main() -> None:  # pragma: no cover - CLI
             N = batch["N"].to(args.device)
 
             logits = model(tokens, attn)
-            loss = compute_loss(logits, target, N)
+            loss = compute_loss_vectorized(logits, target, N)
             opt.zero_grad(set_to_none=True)
             loss.backward()
             nn.utils.clip_grad_norm_(model.parameters(), 1.0)

--- a/tests/test_loss_vec.py
+++ b/tests/test_loss_vec.py
@@ -1,0 +1,40 @@
+"""Tests for vectorized loss functions."""
+
+# isort: skip_file
+
+import torch
+import torch.nn.functional as F
+
+from src.training.loss_vec import clip_logits_by_N_batched, compute_loss_vectorized
+
+
+def test_clip_logits_by_n_batched_masks_invalid():
+    logits = torch.zeros(1, 1, 5)
+    N = torch.tensor([2])
+    clipped = clip_logits_by_N_batched(logits, N)
+    assert clipped[0, 0, 3:].eq(torch.full((2,), -1e9)).all()
+
+
+def test_compute_loss_vectorized_matches_loop():
+    torch.manual_seed(0)
+    B, L, V = 2, 3, 5
+    logits = torch.randn(B, L, V, dtype=torch.float32)
+    target = torch.tensor([[1, 2, 3], [2, 0, 1]])
+    N = torch.tensor([4, 2])
+
+    loss_vec = compute_loss_vectorized(logits, target, N)
+
+    # manual loop version for verification
+    clipped = []
+    for b in range(B):
+        n = int(N[b].item())
+        mask = torch.arange(V) <= n
+        logits_b = logits[b : b + 1].clone()
+        logits_b[..., ~mask] = -1e9
+        clipped.append(logits_b)
+    logits_clipped = torch.cat(clipped, dim=0)
+    loss_manual = F.cross_entropy(
+        logits_clipped.reshape(-1, V), target.reshape(-1), ignore_index=0
+    )
+
+    assert torch.isclose(loss_vec, loss_manual)

--- a/tests/test_pad_collate.py
+++ b/tests/test_pad_collate.py
@@ -1,0 +1,33 @@
+import torch
+
+from src.training.datasets.pad_collate import pad_collate
+
+
+def test_pad_collate_pads_and_stacks():
+    sample1 = {
+        "tokens": torch.tensor([1, 2, 3], dtype=torch.long),
+        "target": torch.tensor([1, 2, 3], dtype=torch.long),
+        "attn_mask": torch.ones(3, dtype=torch.bool),
+        "rows": 1,
+        "cols": 3,
+        "N": 3,
+    }
+    sample2 = {
+        "tokens": torch.tensor([4, 5], dtype=torch.long),
+        "target": torch.tensor([4, 5], dtype=torch.long),
+        "attn_mask": torch.ones(2, dtype=torch.bool),
+        "rows": 1,
+        "cols": 2,
+        "N": 2,
+    }
+    batch = pad_collate([sample1, sample2])
+    assert batch["tokens"].shape == (2, 3)
+    assert batch["target"].shape == (2, 3)
+    assert batch["attn_mask"].shape == (2, 3)
+    # second sample padded with zeros/False at last position
+    assert batch["tokens"][1, 2] == 0
+    assert batch["target"][1, 2] == 0
+    assert batch["attn_mask"][1, 2].item() == 0
+    assert torch.equal(batch["rows"], torch.tensor([1, 1]))
+    assert torch.equal(batch["cols"], torch.tensor([3, 2]))
+    assert torch.equal(batch["N"], torch.tensor([3, 2]))


### PR DESCRIPTION
## Summary
- add `pad_collate` to batch variable-sized grids
- introduce vectorized loss utilities and wire into training loop
- test padding collate and loss behaviour

## Testing
- `black --check .`
- `isort --check-only -v src/training/loss_vec.py src/training/train.py tests/test_pad_collate.py tests/test_loss_vec.py`
- `flake8 src/training/datasets/__init__.py src/training/loss_vec.py src/training/train.py tests/test_pad_collate.py tests/test_loss_vec.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897091bf6c08324a21aa7b708b7e0a1