### PR TITLE
feat: add top-k query script with Chinese logs

### DIFF
--- a/scripts/locate_number_topk.py
+++ b/scripts/locate_number_topk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 功能：在含 -1 的盤面上查詢「指定數字」在空格中的 Top-K 位置與機率。
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+from src.inference.model_loader import load_model
+from src.inference.topk import compute_topk_positions
+from src.models.vocab import masked_logits_clip
+
+
+def main() -> None:  # pragma: no cover - CLI
+    p = argparse.ArgumentParser(description="查詢指定數字在空格中的 Top-K 位置與機率")
+    p.add_argument("ckpt", help="模型權重檔路徑")
+    p.add_argument("in_json", help="輸入 JSON（boards:[{grid:[[...], ...]}]）")
+    p.add_argument("out_json", help="輸出 JSON")
+    p.add_argument("--query_num", type=int, required=True, help="要評分的數字（1..N）")
+    p.add_argument("--topk_pos", type=int, default=3, help="回傳前 K 個最可能位置")
+    p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    args = p.parse_args()
+
+    print("【載入資料】讀取輸入 JSON ...")
+    data = json.loads(Path(args.in_json).read_text())
+    boards = data["boards"]
+
+    print(f"【載入模型】路徑: {args.ckpt}  裝置: {args.device}")
+    model = load_model(args.ckpt, device=args.device)
+
+    outputs = []
+    for bi, b in enumerate(boards):
+        grid = b["grid"]
+        rows, cols = len(grid), len(grid[0])
+        N = rows * cols
+        print(f"\n=== 盤面 {bi} ===")
+        print(f"尺寸：{rows}x{cols}（N={N}）；-1 視為空格")
+
+        flat = []
+        for r in range(rows):
+            for c in range(cols):
+                v = grid[r][c]
+                if v == -1:
+                    v = 0
+                flat.append(v)
+        tokens = torch.tensor(flat, dtype=torch.long, device=args.device).unsqueeze(0)
+        attn = torch.ones_like(tokens, dtype=torch.bool)
+
+        print(f"【查詢】評分指定數字：{args.query_num}（僅在空格位置）")
+        with torch.no_grad():
+            logits = model(tokens, attn)
+            logits = masked_logits_clip(logits, N)
+            probs = torch.softmax(logits, dim=-1)[0]
+            topk = compute_topk_positions(
+                probs, tokens[0], args.query_num, args.topk_pos, cols
+            )
+        print("【TopK 位置（row, col, prob）】")
+        for item in topk:
+            print(f"  -> ({item['row']}, {item['col']}) 機率={item['prob']:.6f}")
+
+        outputs.append({"query_num": int(args.query_num), "topk_positions": topk})
+
+    Path(args.out_json).write_text(
+        json.dumps({"boards": outputs}, ensure_ascii=False, indent=2)
+    )
+    print(f"\n【輸出完成】寫入 -> {args.out_json}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/scripts/solve_json.py
+++ b/scripts/solve_json.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 功能：讀取含 -1 的盤面（-1 視為空格=MASK=0），查詢「指定數字」在空格中的 Top-K 位置與機率，
+#      並同場輸出完整解（使用既有 iterative_decode_temp）。全程印出中文 log。
+
 from __future__ import annotations
 
 import argparse
@@ -9,30 +13,42 @@ import torch
 
 from src.inference.decode_temp import iterative_decode_temp
 from src.inference.model_loader import load_model
+from src.inference.topk import compute_topk_positions
+from src.models.vocab import masked_logits_clip
 
 
 def main() -> None:  # pragma: no cover - CLI
-    p = argparse.ArgumentParser()
-    p.add_argument("ckpt")
-    p.add_argument("in_json")
-    p.add_argument("out_json")
+    p = argparse.ArgumentParser(
+        description="根據盤面查詢指定數字在空格中的 Top-K 位置與機率（含完整解）"
+    )
+    p.add_argument("ckpt", help="模型權重檔路徑")
+    p.add_argument("in_json", help="輸入 JSON（boards:[{grid:[[...], ...]}]）")
+    p.add_argument("out_json", help="輸出 JSON")
     p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
-    p.add_argument("--steps", type=int, default=8)
-    p.add_argument("--fill_ratio", type=float, default=0.3)
-    p.add_argument("--temperature", type=float, default=1.0)
-    p.add_argument("--topk", type=int, default=None)
-    p.add_argument("--topp", type=float, default=None)
+    p.add_argument("--steps", type=int, default=8, help="迭代填格步數")
+    p.add_argument("--fill_ratio", type=float, default=0.3, help="每步填入比例（0~1）")
+    p.add_argument("--temperature", type=float, default=1.0, help="取樣溫度")
+    p.add_argument("--topk", type=int, default=None, help="解碼時的 top-k（可選）")
+    p.add_argument("--topp", type=float, default=None, help="解碼時的 top-p（可選）")
+    p.add_argument("--query_num", type=int, default=None, help="要評分的數字（1..N）")
+    p.add_argument("--topk_pos", type=int, default=3, help="回傳前 K 個最可能位置")
     args = p.parse_args()
 
+    print("【載入資料】讀取輸入 JSON ...")
     data = json.loads(Path(args.in_json).read_text())
     boards = data["boards"]
+
+    print(f"【載入模型】路徑: {args.ckpt}  裝置: {args.device}")
     model = load_model(args.ckpt, device=args.device)
 
     outputs = []
-    for b in boards:
+    for bi, b in enumerate(boards):
         grid = b["grid"]
         rows, cols = len(grid), len(grid[0])
         N = rows * cols
+        print(f"\n=== 盤面 {bi} ===")
+        print(f"尺寸：{rows}x{cols}（N={N}）；-1 視為空格")
+
         flat = []
         for r in range(rows):
             for c in range(cols):
@@ -42,6 +58,30 @@ def main() -> None:  # pragma: no cover - CLI
                 flat.append(v)
         tokens = torch.tensor(flat, dtype=torch.long, device=args.device).unsqueeze(0)
         attn = torch.ones_like(tokens, dtype=torch.bool)
+
+        query_topk = None
+        if args.query_num is not None:
+            if 1 <= args.query_num <= N:
+                print(f"【查詢】評分指定數字：{args.query_num}（僅在空格位置）")
+                with torch.no_grad():
+                    logits = model(tokens, attn)
+                    logits = masked_logits_clip(logits, N)
+                    probs = torch.softmax(logits, dim=-1)[0]
+                    query_topk = compute_topk_positions(
+                        probs, tokens[0], args.query_num, args.topk_pos, cols
+                    )
+                if query_topk:
+                    print("【TopK 位置（row, col, prob）】")
+                    for item in query_topk:
+                        print(
+                            f"  -> ({item['row']}, {item['col']}) 機率={item['prob']:.6f}"
+                        )
+                else:
+                    print("（沒有空格，略過查詢）")
+            else:
+                print(f"（query_num={args.query_num} 超出範圍 1..{N}，略過查詢）")
+
+        print("【解碼】開始迭代填格（可能使用 temperature/topk/topp） ...")
         out = iterative_decode_temp(
             model,
             tokens,
@@ -54,12 +94,18 @@ def main() -> None:  # pragma: no cover - CLI
             topp=args.topp,
         )
         solved = out.view(rows, cols).tolist()
-        outputs.append({"grid": solved})
+        print("【完成】本盤面已解出。")
+
+        item = {"grid": solved}
+        if query_topk is not None:
+            item["query_num"] = int(args.query_num)
+            item["topk_positions"] = query_topk
+        outputs.append(item)
 
     Path(args.out_json).write_text(
         json.dumps({"boards": outputs}, ensure_ascii=False, indent=2)
     )
-    print(f"wrote -> {args.out_json}")
+    print(f"\n【輸出完成】寫入 -> {args.out_json}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI

--- a/src/inference/topk.py
+++ b/src/inference/topk.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+
+
+def compute_topk_positions(
+    probs: torch.Tensor, tokens: torch.Tensor, query_num: int, k: int, cols: int
+) -> List[Dict[str, float]]:
+    """Compute top-k positions for ``query_num`` on masked tokens.
+
+    Parameters
+    ----------
+    probs: torch.Tensor
+        Probability tensor of shape ``[L, V]``.
+    tokens: torch.Tensor
+        Token tensor of shape ``[L]`` where ``0`` indicates a hole.
+    query_num: int
+        The number to query.
+    k: int
+        Return up to ``k`` positions.
+    cols: int
+        Number of columns in the board for converting flat index.
+    """
+    holes = tokens == 0
+    num_holes = int(holes.sum().item())
+    if num_holes == 0:
+        return []
+    p_num = probs[:, query_num]
+    p_masked = torch.where(holes, p_num, torch.full_like(p_num, float("-inf")))
+    k = min(k, num_holes)
+    vals, idxs = torch.topk(p_masked, k)
+    topk = []
+    for v, idx in zip(vals.tolist(), idxs.tolist()):
+        r, c = divmod(idx, cols)
+        topk.append({"row": r, "col": c, "prob": float(probs[idx, query_num].item())})
+    return topk

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -111,17 +111,17 @@ def main() -> None:  # pragma: no cover - CLI
             opt.step()
 
             if step % 50 == 0:
-                print(f"[epoch {epoch}] step {step} loss {loss.item():.4f}")
+                print(f"[訓練] 第 {epoch} 代，第 {step} 步，損失={loss.item():.4f}")
 
         val = evaluate(model, val_loader, args.device)
         print(
-            f"[epoch {epoch}] val_loss/token: {val['loss']:.6f} (elapsed {time.time()-t0:.1f}s)"
+            f"[驗證] 第 {epoch} 代，驗證每 token 損失={val['loss']:.6f}（耗時 {time.time()-t0:.1f} 秒）"
         )
 
         if val["loss"] < best_val:
             best_val = val["loss"]
             torch.save(model.state_dict(), best_ckpt)
-            print(f"  -> saved {best_ckpt}")
+            print(f"[保存] 目前最佳，已儲存權重：{best_ckpt}")
 
     torch.save(model.state_dict(), outdir / "final.ckpt")
 

--- a/tests/test_topk_positions.py
+++ b/tests/test_topk_positions.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+
+from src.inference.topk import compute_topk_positions
+
+
+def test_compute_topk_positions_basic():
+    probs = torch.zeros(4, 6)
+    probs[:, :] = 0.0
+    # Set probabilities for number 2 at different positions
+    probs[0, 2] = 0.8
+    probs[1, 2] = 0.1
+    probs[2, 2] = 0.4
+    probs[3, 2] = 0.05
+    tokens = torch.tensor([0, 0, 3, 0])  # holes at 0,1,3
+
+    topk = compute_topk_positions(probs, tokens, query_num=2, k=3, cols=2)
+    expected = [
+        {"row": 0, "col": 0, "prob": 0.8},
+        {"row": 0, "col": 1, "prob": 0.1},
+        {"row": 1, "col": 1, "prob": 0.05},
+    ]
+    for item, exp in zip(topk, expected):
+        assert item["row"] == exp["row"]
+        assert item["col"] == exp["col"]
+        assert item["prob"] == pytest.approx(exp["prob"], rel=1e-6)


### PR DESCRIPTION
## Summary
- support top-k location query in `solve_json.py` with detailed Chinese logs
- add standalone `locate_number_topk.py` for querying number positions
- log training progress in Chinese and provide helper for top-k computation

## Testing
- `isort --check src/inference/topk.py scripts/locate_number_topk.py scripts/solve_json.py src/training/train.py tests/test_topk_positions.py`
- `black --check src/inference/topk.py scripts/locate_number_topk.py scripts/solve_json.py src/training/train.py tests/test_topk_positions.py`
- `flake8 src/inference/topk.py scripts/locate_number_topk.py scripts/solve_json.py src/training/train.py tests/test_topk_positions.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68971640d03c83248b5eff8e52218425