### PR TITLE
feat: multi-size training and model autoload

### DIFF
--- a/src/inference/api.py
+++ b/src/inference/api.py
@@ -10,7 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, StrictInt, field_validator
 
 from .decode import iterative_decode
-from .model_loader import load_model
+from .model_loader import MODEL_CACHE, load_model_for_size
 
 
 class PredictRequest(BaseModel):
@@ -47,13 +47,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-model = None
-
-
-@app.on_event("startup")
-def _load() -> None:  # pragma: no cover - server startup
-    global model
-    model = load_model("weights/best.ckpt")
 
 
 @app.get("/health")
@@ -74,6 +67,7 @@ def version() -> dict[str, object]:  # pragma: no cover - HTTP interface
         )
     except Exception:  # pragma: no cover - best effort
         pass
+    model = next(iter(MODEL_CACHE.values()), None)
     vocab = model.embed.num_embeddings - 1 if model is not None else 0
     device = str(next(model.parameters()).device) if model is not None else "cpu"
     return {"git_sha": sha, "vocab_size": vocab, "device": device}
@@ -85,6 +79,7 @@ def predict(
 ) -> PredictResponse:  # pragma: no cover - HTTP interface
     grid = req.grid
     rows, cols = len(grid), len(grid[0])
+    model = load_model_for_size(rows, cols)
     vocab = model.embed.num_embeddings - 1
     N = rows * cols
     if N > vocab:

--- a/src/inference/model_loader.py
+++ b/src/inference/model_loader.py
@@ -3,11 +3,28 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Dict, Tuple
 
 import torch
 
 from ..config import load_config
 from ..models.maskgit import MaskGit
+
+
+def get_weight_path(rows: int, cols: int, base: str | Path = "weights") -> Path:
+    """Return the checkpoint path for a given grid size.
+
+    If ``{rows}x{cols}.ckpt`` exists under ``base`` that path is returned,
+    otherwise the fallback ``best.ckpt`` is used.  This allows部署時根據尺寸
+    自動選擇對應的模型權重。
+    """
+
+    base_path = Path(base)
+    specific = base_path / f"{rows}x{cols}.ckpt"
+    return specific if specific.exists() else base_path / "best.ckpt"
+
+
+MODEL_CACHE: Dict[Tuple[int, int, str], MaskGit] = {}
 
 
 def load_model(path: str | Path, *, device: str | torch.device = "cpu") -> MaskGit:
@@ -29,3 +46,26 @@ def load_model(path: str | Path, *, device: str | torch.device = "cpu") -> MaskG
     model.to(device)
     model.eval()
     return model
+
+
+def load_model_for_size(
+    rows: int,
+    cols: int,
+    *,
+    base: str | Path = "weights",
+    device: str | torch.device = "cpu",
+) -> MaskGit:
+    """Load (and cache) a model for a specific grid size.
+
+    依照 ``rows`` 與 ``cols`` 自動尋找對應的模型檔並載入，如同名的
+    ``{rows}x{cols}.ckpt`` 不存在則回退到 ``best.ckpt``。載入後會緩存，
+    再次呼叫相同尺寸時會直接回傳快取的模型。所有關鍵訊息皆以中文
+    輸出方便追蹤。
+    """
+
+    key = (rows, cols, str(device))
+    if key not in MODEL_CACHE:
+        path = get_weight_path(rows, cols, base)
+        print(f"[載入模型] 尺寸 {rows}x{cols} 使用權重 {path}")
+        MODEL_CACHE[key] = load_model(path, device=device)
+    return MODEL_CACHE[key]

--- a/src/training/datasets/json_boards.py
+++ b/src/training/datasets/json_boards.py
@@ -46,16 +46,29 @@ class MaskConfig:
 
 
 class JsonBoardsDataset(Dataset):
-    """Training dataset loading full grids and masking them."""
+    """Training dataset loading full grids and masking them.
+
+    If ``mask_target`` is ``True`` the dataset will mask exactly one value per
+    sample. When a board entry provides a ``target`` number and that number
+    exists on the grid, the corresponding position will be masked. Otherwise a
+    random single position is masked.
+    """
 
     def __init__(
-        self, json_path: str | Path, mask_cfg: MaskConfig | None = None, seed: int = 42
+        self,
+        json_path: str | Path,
+        mask_cfg: MaskConfig | None = None,
+        seed: int = 42,
+        *,
+        mask_target: bool = False,
     ) -> None:
         self.path = Path(json_path)
         data = json.loads(self.path.read_text())
         self.boards = [b["grid"] for b in data["boards"]]
+        self.targets = [b.get("target") for b in data["boards"]]
         self.meta = [_validate_full_grid(g) for g in self.boards]
         self.mask_cfg = mask_cfg or MaskConfig()
+        self.mask_target = mask_target
         random.seed(seed)
 
     def __len__(self) -> int:  # pragma: no cover - trivial
@@ -90,10 +103,29 @@ class JsonBoardsDataset(Dataset):
                     break
         return masked
 
+    def _mask_single(
+        self, grid: List[List[int]], target: int | None
+    ) -> List[List[int]]:
+        rows, cols = len(grid), len(grid[0])
+        masked = [row[:] for row in grid]
+        flat = [v for row in grid for v in row]
+        if target is not None and target in flat:
+            idx = flat.index(target)
+            r, c = divmod(idx, cols)
+            masked[r][c] = MASK_TOKEN
+            return masked
+        r = random.randrange(rows)
+        c = random.randrange(cols)
+        masked[r][c] = MASK_TOKEN
+        return masked
+
     def __getitem__(self, i: int) -> Dict[str, Any]:
         grid = self.boards[i]
         rows, cols, N = self.meta[i]
-        masked = self._mask_grid(grid)
+        if self.mask_target:
+            masked = self._mask_single(grid, self.targets[i])
+        else:
+            masked = self._mask_grid(grid)
 
         target = torch.tensor([v for row in grid for v in row], dtype=torch.long)
         tokens = torch.tensor([v for row in masked for v in row], dtype=torch.long)

--- a/tests/test_json_boards_dataset.py
+++ b/tests/test_json_boards_dataset.py
@@ -16,3 +16,22 @@ def test_json_boards_dataset_mask(tmp_path):
     assert (sample["target"] > 0).all()
     collated = collate_batch([sample])
     assert collated["tokens"].shape == (1, 4)
+
+
+def test_json_boards_dataset_target_mask(tmp_path):
+    data = {"boards": [{"grid": [[1, 2], [3, 4]], "target": 3}]}
+    path = tmp_path / "train.json"
+    path.write_text(json.dumps(data))
+    ds = JsonBoardsDataset(path, mask_target=True, seed=0)
+    sample = ds[0]
+    tokens = sample["tokens"].view(2, 2)
+    assert tokens[1, 0].item() == 0
+
+
+def test_json_boards_dataset_target_random(tmp_path):
+    data = {"boards": [{"grid": [[1, 2], [3, 4]]}]}
+    path = tmp_path / "train.json"
+    path.write_text(json.dumps(data))
+    ds = JsonBoardsDataset(path, mask_target=True, seed=0)
+    sample = ds[0]
+    assert sample["tokens"].tolist().count(0) == 1

--- a/tests/test_model_loader_size.py
+++ b/tests/test_model_loader_size.py
@@ -1,0 +1,17 @@
+from src.inference import model_loader
+
+
+def test_get_weight_path(tmp_path):
+    (tmp_path / "best.ckpt").touch()
+    specific = tmp_path / "3x3.ckpt"
+    specific.touch()
+    assert model_loader.get_weight_path(3, 3, tmp_path) == specific
+    assert model_loader.get_weight_path(4, 4, tmp_path) == tmp_path / "best.ckpt"
+
+
+def test_load_model_for_size_caches(tmp_path):
+    model_loader.MODEL_CACHE.clear()
+    (tmp_path / "best.ckpt").touch()
+    m1 = model_loader.load_model_for_size(4, 4, base=tmp_path)
+    m2 = model_loader.load_model_for_size(4, 4, base=tmp_path)
+    assert m1 is m2

--- a/tests/test_train_discovery.py
+++ b/tests/test_train_discovery.py
@@ -1,0 +1,12 @@
+from train import find_datasets
+
+
+def test_find_datasets(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    good = data_dir / "4x5.json"
+    good.write_text("{}")
+    (data_dir / "bad.json").write_text("{}")
+
+    datasets = find_datasets(data_dir)
+    assert datasets == [(4, 5, good)]

--- a/train.py
+++ b/train.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+import torch
+from torch.utils.data import DataLoader, random_split
+
+from src.config import load_config
+from src.models.maskgit import MaskGit
+from src.training.datasets import JsonBoardsDataset, pad_collate
+from src.training.loss_vec import compute_loss_vectorized
+from src.training.train import evaluate, set_seed
+
+
+def find_datasets(
+    data_dir: Path = Path(__file__).parent / "src" / "data",
+) -> List[Tuple[int, int, Path]]:
+    """Find dataset JSON files like ``4x5.json`` under ``data_dir``."""
+
+    pattern = re.compile(r"^(\d+)x(\d+)\.json$")
+    out: List[Tuple[int, int, Path]] = []
+    for p in data_dir.glob("*.json"):
+        m = pattern.match(p.name)
+        if m:
+            out.append((int(m.group(1)), int(m.group(2)), p))
+    return out
+
+
+def train_one(
+    path: Path,
+    rows: int,
+    cols: int,
+    *,
+    epochs: int = 10,
+    bsz: int = 32,
+    lr: float = 3e-4,
+    seed: int = 42,
+    device: str | None = None,
+) -> None:
+    device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[資料] 使用 {path} 訓練 {rows}x{cols} 模型")
+    set_seed(seed)
+    cfg = load_config("configs/train_small_mix.yaml")
+    model = MaskGit(
+        cfg["vocab_size"],
+        cfg["model"]["d_model"],
+        cfg["model"]["n_head"],
+        cfg["model"]["num_layers"],
+    ).to(device)
+
+    dataset = JsonBoardsDataset(path, mask_target=True, seed=seed)
+    if len(dataset) < 2:
+        raise ValueError("dataset 太小，至少需 2 筆資料")
+    val_size = max(1, int(0.1 * len(dataset)))
+    train_size = len(dataset) - val_size
+    train_ds, val_ds = random_split(dataset, [train_size, val_size])
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=bsz,
+        shuffle=True,
+        num_workers=2,
+        collate_fn=pad_collate,
+        pin_memory=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=bsz,
+        shuffle=False,
+        num_workers=2,
+        collate_fn=pad_collate,
+        pin_memory=True,
+    )
+
+    opt = torch.optim.AdamW(model.parameters(), lr=lr)
+    best_val = float("inf")
+    outdir = Path("weights")
+    outdir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = outdir / f"{rows}x{cols}.ckpt"
+
+    for epoch in range(1, epochs + 1):
+        model.train()
+        for step, batch in enumerate(train_loader, 1):
+            tokens = batch["tokens"].to(device)
+            target = batch["target"].to(device)
+            attn = batch["attn_mask"].to(device)
+            N = batch["N"].to(device)
+
+            logits = model(tokens, attn)
+            loss = compute_loss_vectorized(logits, target, N)
+            opt.zero_grad(set_to_none=True)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            opt.step()
+
+            if step % 50 == 0:
+                print(
+                    f"[訓練] {rows}x{cols} 第 {epoch} 代 第 {step} 步 損失={loss.item():.4f}"
+                )
+
+        val = evaluate(model, val_loader, device)
+        print(f"[驗證] {rows}x{cols} 第 {epoch} 代 損失={val['loss']:.6f}")
+        if val["loss"] < best_val:
+            best_val = val["loss"]
+            torch.save(model.state_dict(), ckpt_path)
+            print(f"[保存] {rows}x{cols} 新最佳模型 -> {ckpt_path}")
+
+
+def main() -> None:  # pragma: no cover - CLI
+    datasets = find_datasets()
+    if not datasets:
+        print("[警告] 未找到任何資料集，請將 NxY.json 放於 src/data 目錄下")
+        return
+    for rows, cols, path in datasets:
+        print(f"[開始] 訓練 {rows}x{cols} 模型")
+        train_one(path, rows, cols)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- add mask_target option to JsonBoardsDataset to mask specified number or random cell
- one-shot training script uses targeted masking for NxY datasets
- extend dataset tests for targeted and fallback single masking

## Testing
- `isort --check .`
- `black --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68975a5924708324b2884a46fd149a04