### PR TITLE
feat: support board alias in predict

### DIFF
--- a/src/inference/api.py
+++ b/src/inference/api.py
@@ -7,14 +7,14 @@ import subprocess
 import torch
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, StrictInt, field_validator
+from pydantic import AliasChoices, BaseModel, Field, StrictInt, field_validator
 
 from .decode import iterative_decode
 from .model_loader import MODEL_CACHE, load_model_for_size
 
 
 class PredictRequest(BaseModel):
-    grid: list[list[StrictInt]]
+    grid: list[list[StrictInt]] = Field(validation_alias=AliasChoices("grid", "board"))
 
     @field_validator("grid")
     @classmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,3 +40,7 @@ def test_predict_validation_and_output():
         assert resp.status_code == 200
         data = resp.json()
         assert data["rows"] == 2 and data["cols"] == 2 and len(data["grid"]) == 2
+
+        # alias "board" should behave the same as "grid"
+        resp = client.post("/predict", json={"board": [[0, 0], [0, 0]]})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- accept "grid" or "board" in PredictRequest
- test board alias handling

## Testing
- `isort --check src/inference/api.py tests/test_api.py`
- `black --check src/inference/api.py tests/test_api.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897ea8f55a88324a4d42e6020303d13