### PR TITLE
Fix top-k prediction masking

### DIFF
--- a/scripts/locate_number_topk.py
+++ b/scripts/locate_number_topk.py
@@ -41,13 +41,18 @@ def main() -> None:  # pragma: no cover - CLI
         print(f"尺寸：{rows}x{cols}（N={N}）；-1 視為空格")
 
         flat = []
+        holes = []
         for r in range(rows):
             for c in range(cols):
                 v = grid[r][c]
                 if v == -1:
-                    v = 0
-                flat.append(v)
+                    flat.append(0)
+                    holes.append(True)
+                else:
+                    flat.append(v)
+                    holes.append(False)
         tokens = torch.tensor(flat, dtype=torch.long, device=args.device).unsqueeze(0)
+        hole_mask = torch.tensor(holes, dtype=torch.bool, device=args.device)
         attn = torch.ones_like(tokens, dtype=torch.bool)
 
         print(f"【查詢】評分指定數字：{args.query_num}（僅在空格位置）")
@@ -56,7 +61,7 @@ def main() -> None:  # pragma: no cover - CLI
             logits = masked_logits_clip(logits, N)
             probs = torch.softmax(logits, dim=-1)[0]
             topk = compute_topk_positions(
-                probs, tokens[0], args.query_num, args.topk_pos, cols
+                probs, hole_mask, args.query_num, args.topk_pos, cols
             )
         print("【TopK 位置（row, col, prob）】")
         for item in topk:

--- a/scripts/solve_json.py
+++ b/scripts/solve_json.py
@@ -50,13 +50,18 @@ def main() -> None:  # pragma: no cover - CLI
         print(f"尺寸：{rows}x{cols}（N={N}）；-1 視為空格")
 
         flat = []
+        holes = []
         for r in range(rows):
             for c in range(cols):
                 v = grid[r][c]
                 if v == -1:
-                    v = 0
-                flat.append(v)
+                    flat.append(0)
+                    holes.append(True)
+                else:
+                    flat.append(v)
+                    holes.append(False)
         tokens = torch.tensor(flat, dtype=torch.long, device=args.device).unsqueeze(0)
+        hole_mask = torch.tensor(holes, dtype=torch.bool, device=args.device)
         attn = torch.ones_like(tokens, dtype=torch.bool)
 
         query_topk = None
@@ -68,7 +73,7 @@ def main() -> None:  # pragma: no cover - CLI
                     logits = masked_logits_clip(logits, N)
                     probs = torch.softmax(logits, dim=-1)[0]
                     query_topk = compute_topk_positions(
-                        probs, tokens[0], args.query_num, args.topk_pos, cols
+                        probs, hole_mask, args.query_num, args.topk_pos, cols
                     )
                 if query_topk:
                     print("【TopK 位置（row, col, prob）】")

--- a/src/inference/api.py
+++ b/src/inference/api.py
@@ -100,8 +100,19 @@ def predict(
     if N > vocab:
         raise HTTPException(status_code=400, detail="grid too large for model")
 
-    # Replace -1 with 0 for model input
-    processed_grid = [[0 if v == -1 else v for v in r] for r in grid]
+    # Replace -1 with 0 for model input and build hole mask
+    processed_grid = []
+    hole_mask = []
+    for row in grid:
+        proc_row = []
+        for v in row:
+            if v == -1:
+                proc_row.append(0)
+                hole_mask.append(True)
+            else:
+                proc_row.append(v)
+                hole_mask.append(False)
+        processed_grid.append(proc_row)
     max_val = max(max(r) for r in processed_grid)
     if max_val > vocab:
         raise HTTPException(
@@ -109,20 +120,21 @@ def predict(
         )
 
     tokens = torch.tensor(processed_grid, dtype=torch.long).view(1, -1)
+    holes = torch.tensor(hole_mask, dtype=torch.bool)
     attn = torch.ones_like(tokens, dtype=torch.bool)
 
     if req.target is not None:
         target = int(req.target)
         if not 1 <= target <= N:
             raise HTTPException(status_code=400, detail="target out of range")
-        num_holes = int((tokens == 0).sum().item())
+        num_holes = int(holes.sum().item())
         log_lines = [f"[步驟1] 找到 {num_holes} 個空格。"]
         log_lines.append(f"[步驟2] 開始計算每個空格填入 {target} 的機率。")
         with torch.no_grad():
             logits = model(tokens, attn)
             logits = masked_logits_clip(logits, N)
             probs = torch.softmax(logits, dim=-1)[0]
-            topk = compute_topk_positions(probs, tokens[0], target, 3, cols)
+            topk = compute_topk_positions(probs, holes, target, 3, cols)
         log_lines.append("[步驟3] 計算完成，取 Top3：")
         for item in topk:
             log_lines.append(

--- a/src/inference/topk.py
+++ b/src/inference/topk.py
@@ -6,16 +6,16 @@ import torch
 
 
 def compute_topk_positions(
-    probs: torch.Tensor, tokens: torch.Tensor, query_num: int, k: int, cols: int
+    probs: torch.Tensor, holes: torch.Tensor, query_num: int, k: int, cols: int
 ) -> List[Dict[str, float]]:
-    """Compute top-k positions for ``query_num`` on masked tokens.
+    """Compute top-k positions for ``query_num`` on available holes.
 
     Parameters
     ----------
     probs: torch.Tensor
         Probability tensor of shape ``[L, V]``.
-    tokens: torch.Tensor
-        Token tensor of shape ``[L]`` where ``0`` indicates a hole.
+    holes: torch.Tensor
+        Boolean tensor of shape ``[L]`` where ``True`` indicates a hole.
     query_num: int
         The number to query.
     k: int
@@ -23,16 +23,22 @@ def compute_topk_positions(
     cols: int
         Number of columns in the board for converting flat index.
     """
-    holes = tokens == 0
+    holes = holes.bool()
     num_holes = int(holes.sum().item())
     if num_holes == 0:
         return []
+
     p_num = probs[:, query_num]
-    p_masked = torch.where(holes, p_num, torch.full_like(p_num, float("-inf")))
+    p_masked = torch.where(holes, p_num, torch.zeros_like(p_num))
+    total = p_masked.sum().item()
+    if total == 0:
+        return []
+    p_masked = p_masked / total
+
     k = min(k, num_holes)
     vals, idxs = torch.topk(p_masked, k)
     topk = []
     for v, idx in zip(vals.tolist(), idxs.tolist()):
         r, c = divmod(idx, cols)
-        topk.append({"row": r, "col": c, "prob": float(probs[idx, query_num].item())})
+        topk.append({"row": r, "col": c, "prob": float(v)})
     return topk

--- a/tests/test_topk_positions.py
+++ b/tests/test_topk_positions.py
@@ -12,15 +12,26 @@ def test_compute_topk_positions_basic():
     probs[1, 2] = 0.1
     probs[2, 2] = 0.4
     probs[3, 2] = 0.05
-    tokens = torch.tensor([0, 0, 3, 0])  # holes at 0,1,3
+    holes = torch.tensor([True, True, False, True])  # holes at 0,1,3
 
-    topk = compute_topk_positions(probs, tokens, query_num=2, k=3, cols=2)
+    topk = compute_topk_positions(probs, holes, query_num=2, k=3, cols=2)
     expected = [
-        {"row": 0, "col": 0, "prob": 0.8},
-        {"row": 0, "col": 1, "prob": 0.1},
-        {"row": 1, "col": 1, "prob": 0.05},
+        {"row": 0, "col": 0, "prob": 0.8421052632},
+        {"row": 0, "col": 1, "prob": 0.1052631579},
+        {"row": 1, "col": 1, "prob": 0.0526315789},
     ]
     for item, exp in zip(topk, expected):
         assert item["row"] == exp["row"]
         assert item["col"] == exp["col"]
         assert item["prob"] == pytest.approx(exp["prob"], rel=1e-6)
+
+
+def test_existing_zero_not_hole():
+    probs = torch.zeros(2, 3)
+    probs[0, 1] = 0.9
+    probs[1, 1] = 0.1
+    holes = torch.tensor([True, False])
+    topk = compute_topk_positions(probs, holes, query_num=1, k=2, cols=1)
+    assert len(topk) == 1
+    assert topk[0]["row"] == 0 and topk[0]["col"] == 0
+    assert topk[0]["prob"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- avoid recommending already filled cells when scoring a target number
- normalize probabilities across holes for clearer top-k results
- update scripts and tests accordingly

## Testing
- `black --check scripts/locate_number_topk.py scripts/solve_json.py src/inference/api.py src/inference/topk.py tests/test_topk_positions.py`
- `isort --check-only scripts/locate_number_topk.py scripts/solve_json.py src/inference/api.py src/inference/topk.py tests/test_topk_positions.py`
- `flake8 scripts/locate_number_topk.py scripts/solve_json.py src/inference/api.py src/inference/topk.py tests/test_topk_positions.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689807dd8d5c8324a77c26de38732b8f