### PR TITLE
Fix top-k prediction probabilities and skip filled cells

### DIFF
--- a/src/inference/topk.py
+++ b/src/inference/topk.py
@@ -27,12 +27,20 @@ def compute_topk_positions(
     num_holes = int(holes.sum().item())
     if num_holes == 0:
         return []
+
     p_num = probs[:, query_num]
-    p_masked = torch.where(holes, p_num, torch.full_like(p_num, float("-inf")))
+    # zero out filled cells for normalization
+    masked = torch.where(holes, p_num, torch.zeros_like(p_num))
+    total = masked.sum()
+    if total <= 0:
+        return []
+    norm = masked / total
+    # use -inf on filled cells to avoid selecting them
+    norm_masked = torch.where(holes, norm, torch.full_like(norm, float("-inf")))
     k = min(k, num_holes)
-    vals, idxs = torch.topk(p_masked, k)
-    topk = []
+    vals, idxs = torch.topk(norm_masked, k)
+    topk: List[Dict[str, float]] = []
     for v, idx in zip(vals.tolist(), idxs.tolist()):
         r, c = divmod(idx, cols)
-        topk.append({"row": r, "col": c, "prob": float(probs[idx, query_num].item())})
+        topk.append({"row": r, "col": c, "prob": float(v)})
     return topk

--- a/tests/test_topk_positions.py
+++ b/tests/test_topk_positions.py
@@ -16,11 +16,27 @@ def test_compute_topk_positions_basic():
 
     topk = compute_topk_positions(probs, tokens, query_num=2, k=3, cols=2)
     expected = [
-        {"row": 0, "col": 0, "prob": 0.8},
-        {"row": 0, "col": 1, "prob": 0.1},
-        {"row": 1, "col": 1, "prob": 0.05},
+        {"row": 0, "col": 0, "prob": 0.8 / 0.95},
+        {"row": 0, "col": 1, "prob": 0.1 / 0.95},
+        {"row": 1, "col": 1, "prob": 0.05 / 0.95},
     ]
     for item, exp in zip(topk, expected):
         assert item["row"] == exp["row"]
         assert item["col"] == exp["col"]
         assert item["prob"] == pytest.approx(exp["prob"], rel=1e-6)
+    assert pytest.approx(sum(i["prob"] for i in topk), rel=1e-6) == 1.0
+
+
+def test_compute_topk_positions_skips_filled_cells():
+    probs = torch.zeros(4, 6)
+    probs[:, :] = 0.0
+    probs[0, 2] = 0.8
+    probs[1, 2] = 0.1
+    probs[2, 2] = 0.4
+    probs[3, 2] = 0.05
+    tokens = torch.tensor([1, 0, 3, 0])  # filled at idx0, holes at 1 and 3
+
+    topk = compute_topk_positions(probs, tokens, query_num=2, k=3, cols=2)
+    assert len(topk) == 2
+    assert {(t["row"], t["col"]) for t in topk} == {(0, 1), (1, 1)}
+    assert pytest.approx(sum(i["prob"] for i in topk), rel=1e-6) == 1.0


### PR DESCRIPTION
## Summary
- normalize probabilities across candidate positions
- ignore already-filled cells when selecting top-k positions
- test normalized probabilities and filled-cell skipping

## Testing
- `black --check src/inference/topk.py tests/test_topk_positions.py`
- `isort --check-only src/inference/topk.py tests/test_topk_positions.py`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689807dd8d5c8324a77c26de38732b8f