### PR TITLE
Normalize top-k predictions for filled cells

### DIFF
--- a/src/inference/api.py
+++ b/src/inference/api.py
@@ -100,8 +100,8 @@ def predict(
     if N > vocab:
         raise HTTPException(status_code=400, detail="grid too large for model")
 
-    # Replace -1 with 0 for model input
-    processed_grid = [[0 if v == -1 else v for v in r] for r in grid]
+    # Replace non-positive values with 0 for model input
+    processed_grid = [[0 if v <= 0 else v for v in r] for r in grid]
     max_val = max(max(r) for r in processed_grid)
     if max_val > vocab:
         raise HTTPException(

--- a/src/inference/topk.py
+++ b/src/inference/topk.py
@@ -27,12 +27,14 @@ def compute_topk_positions(
     num_holes = int(holes.sum().item())
     if num_holes == 0:
         return []
-    p_num = probs[:, query_num]
-    p_masked = torch.where(holes, p_num, torch.full_like(p_num, float("-inf")))
+    hole_idxs = torch.nonzero(holes, as_tuple=False).squeeze(1)
+    p_num = probs[hole_idxs, query_num]
+    p_rel = torch.softmax(p_num, dim=0)
     k = min(k, num_holes)
-    vals, idxs = torch.topk(p_masked, k)
+    vals, order = torch.topk(p_rel, k)
     topk = []
-    for v, idx in zip(vals.tolist(), idxs.tolist()):
+    for v, ord_idx in zip(vals.tolist(), order.tolist()):
+        idx = hole_idxs[ord_idx].item()
         r, c = divmod(idx, cols)
-        topk.append({"row": r, "col": c, "prob": float(probs[idx, query_num].item())})
+        topk.append({"row": r, "col": c, "prob": float(v)})
     return topk

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,3 +60,13 @@ def test_predict_with_target_topk():
         for item in preds:
             assert {"row", "col", "prob"} <= item.keys()
         assert "[步驟1]" in data["log"]
+
+
+def test_predict_with_target_excludes_filled():
+    with TestClient(app) as client:
+        grid = [[1, -1], [-1, 2]]
+        resp = client.post("/predict", json={"grid": grid, "target": 1})
+        assert resp.status_code == 200
+        preds = resp.json()["predictions"]
+        for item in preds:
+            assert grid[item["row"]][item["col"]] <= 0

--- a/tests/test_topk_positions.py
+++ b/tests/test_topk_positions.py
@@ -16,11 +16,11 @@ def test_compute_topk_positions_basic():
 
     topk = compute_topk_positions(probs, tokens, query_num=2, k=3, cols=2)
     expected = [
-        {"row": 0, "col": 0, "prob": 0.8},
-        {"row": 0, "col": 1, "prob": 0.1},
-        {"row": 1, "col": 1, "prob": 0.05},
+        {"row": 0, "col": 0, "prob": 0.507884},
+        {"row": 0, "col": 1, "prob": 0.252235},
+        {"row": 1, "col": 1, "prob": 0.239881},
     ]
     for item, exp in zip(topk, expected):
         assert item["row"] == exp["row"]
         assert item["col"] == exp["col"]
-        assert item["prob"] == pytest.approx(exp["prob"], rel=1e-6)
+        assert item["prob"] == pytest.approx(exp["prob"], rel=1e-3)


### PR DESCRIPTION
## Summary
- compute top-k probabilities only across empty cells
- ensure API treats non-positive grid values as empty
- add regression tests for filled-cell exclusion

## Testing
- `isort src/inference/api.py src/inference/topk.py tests/test_api.py tests/test_topk_positions.py --check --diff`
- `black src/inference/api.py src/inference/topk.py tests/test_api.py tests/test_topk_positions.py --check`
- `flake8 src/inference/api.py src/inference/topk.py tests/test_api.py tests/test_topk_positions.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689807dd8d5c8324a77c26de38732b8f