### PR TITLE
Restrict target predictions to empty board cells

### DIFF
--- a/scripts/locate_number_topk.py
+++ b/scripts/locate_number_topk.py
@@ -41,13 +41,16 @@ def main() -> None:  # pragma: no cover - CLI
         print(f"尺寸：{rows}x{cols}（N={N}）；-1 視為空格")
 
         flat = []
+        holes = []
         for r in range(rows):
             for c in range(cols):
                 v = grid[r][c]
+                holes.append(v == -1)
                 if v == -1:
                     v = 0
                 flat.append(v)
         tokens = torch.tensor(flat, dtype=torch.long, device=args.device).unsqueeze(0)
+        hole_mask = torch.tensor(holes, dtype=torch.bool, device=args.device)
         attn = torch.ones_like(tokens, dtype=torch.bool)
 
         print(f"【查詢】評分指定數字：{args.query_num}（僅在空格位置）")
@@ -56,7 +59,7 @@ def main() -> None:  # pragma: no cover - CLI
             logits = masked_logits_clip(logits, N)
             probs = torch.softmax(logits, dim=-1)[0]
             topk = compute_topk_positions(
-                probs, tokens[0], args.query_num, args.topk_pos, cols
+                probs, hole_mask, args.query_num, args.topk_pos, cols
             )
         print("【TopK 位置（row, col, prob）】")
         for item in topk:

--- a/scripts/solve_json.py
+++ b/scripts/solve_json.py
@@ -50,13 +50,16 @@ def main() -> None:  # pragma: no cover - CLI
         print(f"尺寸：{rows}x{cols}（N={N}）；-1 視為空格")
 
         flat = []
+        holes = []
         for r in range(rows):
             for c in range(cols):
                 v = grid[r][c]
+                holes.append(v == -1)
                 if v == -1:
                     v = 0
                 flat.append(v)
         tokens = torch.tensor(flat, dtype=torch.long, device=args.device).unsqueeze(0)
+        hole_mask = torch.tensor(holes, dtype=torch.bool, device=args.device)
         attn = torch.ones_like(tokens, dtype=torch.bool)
 
         query_topk = None
@@ -68,7 +71,7 @@ def main() -> None:  # pragma: no cover - CLI
                     logits = masked_logits_clip(logits, N)
                     probs = torch.softmax(logits, dim=-1)[0]
                     query_topk = compute_topk_positions(
-                        probs, tokens[0], args.query_num, args.topk_pos, cols
+                        probs, hole_mask, args.query_num, args.topk_pos, cols
                     )
                 if query_topk:
                     print("【TopK 位置（row, col, prob）】")

--- a/src/inference/api.py
+++ b/src/inference/api.py
@@ -100,8 +100,9 @@ def predict(
     if N > vocab:
         raise HTTPException(status_code=400, detail="grid too large for model")
 
-    # Replace non-positive values with 0 for model input
-    processed_grid = [[0 if v <= 0 else v for v in r] for r in grid]
+    # Replace -1 with 0 for model input but keep track of holes
+    holes = [v == -1 for r in grid for v in r]
+    processed_grid = [[0 if v == -1 else v for v in r] for r in grid]
     max_val = max(max(r) for r in processed_grid)
     if max_val > vocab:
         raise HTTPException(
@@ -109,21 +110,23 @@ def predict(
         )
 
     tokens = torch.tensor(processed_grid, dtype=torch.long).view(1, -1)
+    hole_mask = torch.tensor(holes, dtype=torch.bool)
     attn = torch.ones_like(tokens, dtype=torch.bool)
 
     if req.target is not None:
         target = int(req.target)
         if not 1 <= target <= N:
             raise HTTPException(status_code=400, detail="target out of range")
-        num_holes = int((tokens == 0).sum().item())
-        log_lines = [f"[步驟1] 找到 {num_holes} 個空格。"]
-        log_lines.append(f"[步驟2] 開始計算每個空格填入 {target} 的機率。")
+        num_holes = int(hole_mask.sum().item())
+        log_lines = [f"[步驟1] 盤面共有 {num_holes} 個空格。"]
+        log_lines.append("[步驟2] 剔除已開數字，保留空格作為候選點。")
+        log_lines.append(f"[步驟3] 根據已開數字佈局計算各候選點填入 {target} 的機率。")
         with torch.no_grad():
             logits = model(tokens, attn)
             logits = masked_logits_clip(logits, N)
             probs = torch.softmax(logits, dim=-1)[0]
-            topk = compute_topk_positions(probs, tokens[0], target, 3, cols)
-        log_lines.append("[步驟3] 計算完成，取 Top3：")
+            topk = compute_topk_positions(probs, hole_mask, target, 3, cols)
+        log_lines.append("[步驟4] 取機率最高的 Top3：")
         for item in topk:
             log_lines.append(
                 f"  (row={item['row']},col={item['col']}) 機率={item['prob']:.3f}"

--- a/src/inference/topk.py
+++ b/src/inference/topk.py
@@ -6,7 +6,7 @@ import torch
 
 
 def compute_topk_positions(
-    probs: torch.Tensor, tokens: torch.Tensor, query_num: int, k: int, cols: int
+    probs: torch.Tensor, holes: torch.Tensor, query_num: int, k: int, cols: int
 ) -> List[Dict[str, float]]:
     """Compute top-k positions for ``query_num`` on masked tokens.
 
@@ -14,8 +14,9 @@ def compute_topk_positions(
     ----------
     probs: torch.Tensor
         Probability tensor of shape ``[L, V]``.
-    tokens: torch.Tensor
-        Token tensor of shape ``[L]`` where ``0`` indicates a hole.
+    holes: torch.Tensor
+        Boolean mask of shape ``[L]`` where ``True`` indicates a candidate hole
+        (original value ``-1`` in the board).
     query_num: int
         The number to query.
     k: int
@@ -23,7 +24,6 @@ def compute_topk_positions(
     cols: int
         Number of columns in the board for converting flat index.
     """
-    holes = tokens == 0
     num_holes = int(holes.sum().item())
     if num_holes == 0:
         return []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,9 +64,9 @@ def test_predict_with_target_topk():
 
 def test_predict_with_target_excludes_filled():
     with TestClient(app) as client:
-        grid = [[1, -1], [-1, 2]]
+        grid = [[0, -1], [-1, 2]]
         resp = client.post("/predict", json={"grid": grid, "target": 1})
         assert resp.status_code == 200
         preds = resp.json()["predictions"]
         for item in preds:
-            assert grid[item["row"]][item["col"]] <= 0
+            assert grid[item["row"]][item["col"]] == -1

--- a/tests/test_topk_positions.py
+++ b/tests/test_topk_positions.py
@@ -12,9 +12,9 @@ def test_compute_topk_positions_basic():
     probs[1, 2] = 0.1
     probs[2, 2] = 0.4
     probs[3, 2] = 0.05
-    tokens = torch.tensor([0, 0, 3, 0])  # holes at 0,1,3
+    holes = torch.tensor([True, True, False, True])
 
-    topk = compute_topk_positions(probs, tokens, query_num=2, k=3, cols=2)
+    topk = compute_topk_positions(probs, holes, query_num=2, k=3, cols=2)
     expected = [
         {"row": 0, "col": 0, "prob": 0.507884},
         {"row": 0, "col": 1, "prob": 0.252235},


### PR DESCRIPTION
## Summary
- limit top-k target predictions to cells with -1 on the board
- add Chinese step-by-step log explaining filtering and evaluation
- test that predictions ignore pre-filled numbers, including 0

## Testing
- `isort src/inference/api.py src/inference/topk.py scripts/locate_number_topk.py scripts/solve_json.py tests/test_api.py tests/test_topk_positions.py --check-only`
- `black src/inference/api.py src/inference/topk.py scripts/locate_number_topk.py scripts/solve_json.py tests/test_api.py tests/test_topk_positions.py --check`
- `flake8 src/inference/api.py src/inference/topk.py scripts/locate_number_topk.py scripts/solve_json.py tests/test_api.py tests/test_topk_positions.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898178409808324a6083c262dbb6774