### PR TITLE
feat: add row/col prior bias during training

### DIFF
--- a/src/training/dep_bias.py
+++ b/src/training/dep_bias.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import torch
+
+
+def apply_dep_bias(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    target: torch.Tensor,
+    rows: torch.Tensor,
+    cols: torch.Tensor,
+    N: torch.Tensor,
+    dep_alpha: float,
+) -> None:
+    """Add row/column dependency bias to masked positions in-place."""
+    device = logits.device
+    B, _, V = logits.shape
+    Vmax = int(N.max().item())
+    mask_pos = ((tokens == 0) & (target != 0)).nonzero(as_tuple=False)
+    grids = []
+    for b in range(B):
+        R = int(rows[b].item())
+        C = int(cols[b].item())
+        grids.append(tokens[b, : R * C].view(R, C))
+    eps = 1e-6
+    for b, lidx in mask_pos.tolist():
+        R = int(rows[b].item())
+        C = int(cols[b].item())
+        r = lidx // C
+        c = lidx % C
+        grid_b = grids[b]
+        row_vals = grid_b[r, :]
+        col_vals = grid_b[:, c]
+        vec = torch.cat([row_vals, col_vals], dim=0)
+        hist = torch.bincount(vec, minlength=Vmax + 1).to(device)
+        hist[0] = 0
+        prior = hist.float()
+        if hist.sum() > 0:
+            prior = prior / hist.sum()
+        else:
+            prior.zero_()
+        log_prior = torch.log(prior + eps) * dep_alpha
+        bias = torch.full((V,), -1e9, device=device)
+        length = min(int(N[b].item()) + 1, V, log_prior.numel())
+        bias[:length] = log_prior[:length]
+        logits[b, lidx, :] += bias

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -12,6 +12,7 @@ from torch.utils.data import DataLoader
 from src.config import load_config
 from src.models.maskgit import MaskGit
 from src.training.datasets import JsonBoardsDataset, MaskConfig, pad_collate
+from src.training.dep_bias import apply_dep_bias
 from src.training.loss_vec import compute_loss_vectorized
 
 
@@ -25,7 +26,13 @@ def set_seed(seed: int = 42) -> None:
     np.random.seed(seed)
 
 
-def evaluate(model: nn.Module, loader: DataLoader, device: str) -> dict:
+def evaluate(
+    model: nn.Module,
+    loader: DataLoader,
+    device: str,
+    use_dep_bias: bool = False,
+    dep_alpha: float = 0.5,
+) -> dict:
     model.eval()
     total_loss = 0.0
     total_tok = 0
@@ -35,7 +42,11 @@ def evaluate(model: nn.Module, loader: DataLoader, device: str) -> dict:
             target = batch["target"].to(device)
             attn = batch["attn_mask"].to(device)
             N = batch["N"].to(device)
+            rows = batch["rows"].to(device)
+            cols = batch["cols"].to(device)
             logits = model(tokens, attn)
+            if use_dep_bias:
+                apply_dep_bias(logits, tokens, target, rows, cols, N, dep_alpha)
             loss = compute_loss_vectorized(logits, target, N)
             cnt = (target != 0).sum().item()
             total_loss += loss.item() * cnt
@@ -56,6 +67,17 @@ def main() -> None:  # pragma: no cover - CLI
     p.add_argument(
         "--config",
         default=os.environ.get("GRIDFILL_CFG", "configs/train_small_mix.yaml"),
+    )
+    p.add_argument(
+        "--use_dep_bias",
+        action="store_true",
+        help="計算同行+同列直方圖先驗並加到被遮蔽位置的 logits",
+    )
+    p.add_argument(
+        "--dep_alpha",
+        type=float,
+        default=0.5,
+        help="依賴偏置權重（加入 logits 前的縮放係數）",
     )
     args = p.parse_args()
 
@@ -102,8 +124,12 @@ def main() -> None:  # pragma: no cover - CLI
             target = batch["target"].to(args.device)
             attn = batch["attn_mask"].to(args.device)
             N = batch["N"].to(args.device)
+            rows = batch["rows"].to(args.device)
+            cols = batch["cols"].to(args.device)
 
             logits = model(tokens, attn)
+            if args.use_dep_bias:
+                apply_dep_bias(logits, tokens, target, rows, cols, N, args.dep_alpha)
             loss = compute_loss_vectorized(logits, target, N)
             opt.zero_grad(set_to_none=True)
             loss.backward()
@@ -113,7 +139,13 @@ def main() -> None:  # pragma: no cover - CLI
             if step % 50 == 0:
                 print(f"[訓練] 第 {epoch} 代，第 {step} 步，損失={loss.item():.4f}")
 
-        val = evaluate(model, val_loader, args.device)
+        val = evaluate(
+            model,
+            val_loader,
+            args.device,
+            use_dep_bias=args.use_dep_bias,
+            dep_alpha=args.dep_alpha,
+        )
         print(
             f"[驗證] 第 {epoch} 代，驗證每 token 損失={val['loss']:.6f}（耗時 {time.time()-t0:.1f} 秒）"
         )

--- a/tests/test_dep_bias.py
+++ b/tests/test_dep_bias.py
@@ -1,0 +1,54 @@
+import math
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from src.training.dep_bias import apply_dep_bias
+from src.training.train import evaluate
+
+
+def test_apply_dep_bias_row_col_hist():
+    # Grid: [[1, 2], [3, 4]] with position (0,1) masked
+    tokens = torch.tensor([[1, 0, 3, 4]])
+    target = torch.tensor([[1, 2, 3, 4]])
+    rows = torch.tensor([2])
+    cols = torch.tensor([2])
+    N = torch.tensor([4])
+    logits = torch.zeros(1, 4, 6)
+
+    apply_dep_bias(logits, tokens, target, rows, cols, N, dep_alpha=1.0)
+
+    bias = math.log(0.5)
+    # Masked position index 1 should receive bias on numbers 1 and 4
+    assert torch.isclose(logits[0, 1, 1], torch.tensor(bias))
+    assert torch.isclose(logits[0, 1, 4], torch.tensor(bias))
+    # Other numbers receive log(eps) bias
+    other = math.log(1e-6)
+    assert torch.isclose(logits[0, 1, 0], torch.tensor(other))
+    assert torch.isclose(logits[0, 1, 2], torch.tensor(other))
+
+
+def test_evaluate_dep_bias_applied():
+    class DummyModel(nn.Module):
+        def forward(self, tokens, attn):  # type: ignore[override]
+            B, L = tokens.shape
+            return torch.zeros(B, L, 6)
+
+    sample = {
+        "tokens": torch.tensor([1, 0, 3, 4], dtype=torch.long),
+        "target": torch.tensor([1, 2, 3, 4], dtype=torch.long),
+        "attn_mask": torch.ones(4, dtype=torch.long),
+        "N": torch.tensor(4, dtype=torch.long),
+        "rows": torch.tensor(2, dtype=torch.long),
+        "cols": torch.tensor(2, dtype=torch.long),
+    }
+
+    def collate(batch):
+        return {k: torch.stack([b[k] for b in batch], dim=0) for k in batch[0]}
+
+    loader = DataLoader([sample], batch_size=1, collate_fn=collate)
+    model = DummyModel()
+    no_bias = evaluate(model, loader, "cpu")
+    with_bias = evaluate(model, loader, "cpu", use_dep_bias=True, dep_alpha=1.0)
+    assert with_bias["loss"] > no_bias["loss"]

--- a/train.py
+++ b/train.py
@@ -11,6 +11,7 @@ from torch.utils.data import DataLoader, random_split
 from src.config import load_config
 from src.models.maskgit import MaskGit
 from src.training.datasets import JsonBoardsDataset, pad_collate
+from src.training.dep_bias import apply_dep_bias
 from src.training.loss_vec import compute_loss_vectorized
 from src.training.train import evaluate, set_seed
 
@@ -40,6 +41,8 @@ def train_one(
     seed: int = 42,
     device: str | None = None,
     target_loss: float | None = None,  # 門檻：達標後「等到 epoch 結束」才早停
+    use_dep_bias: bool = False,
+    dep_alpha: float = 0.5,
 ) -> None:
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
     print(f"[資料] 使用 {path} 訓練 {rows}x{cols} 模型")
@@ -93,8 +96,12 @@ def train_one(
             target = batch["target"].to(device)
             attn = batch["attn_mask"].to(device)
             N = batch["N"].to(device)
+            rows_t = batch["rows"].to(device)
+            cols_t = batch["cols"].to(device)
 
             logits = model(tokens, attn)
+            if use_dep_bias:
+                apply_dep_bias(logits, tokens, target, rows_t, cols_t, N, dep_alpha)
             loss = compute_loss_vectorized(logits, target, N)
             opt.zero_grad(set_to_none=True)
             loss.backward()
@@ -111,7 +118,13 @@ def train_one(
                 hit_threshold_this_epoch = True
 
         # ---- 一個 epoch 結束後才評估與可能早停 ----
-        val = evaluate(model, val_loader, device)
+        val = evaluate(
+            model,
+            val_loader,
+            device,
+            use_dep_bias=use_dep_bias,
+            dep_alpha=dep_alpha,
+        )
         print(f"[驗證] {rows}x{cols} 第 {epoch} 代 損失={val['loss']:.6f}")
         if val["loss"] < best_val:
             best_val = val["loss"]
@@ -142,6 +155,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="達到此訓練 loss 門檻時，不中斷步數；等該 epoch 結束後早停",
     )
+    p.add_argument(
+        "--use_dep_bias",
+        action="store_true",
+        help="計算同行+同列直方圖先驗並加到被遮蔽位置的 logits",
+    )
+    p.add_argument(
+        "--dep_alpha",
+        type=float,
+        default=0.5,
+        help="依賴偏置權重（加入 logits 前的縮放係數）",
+    )
     return p.parse_args()
 
 
@@ -163,6 +187,8 @@ def main() -> None:  # pragma: no cover - CLI
             seed=args.seed,
             device=args.device,
             target_loss=args.target_loss,
+            use_dep_bias=args.use_dep_bias,
+            dep_alpha=args.dep_alpha,
         )
 
 


### PR DESCRIPTION
## Summary
- allow evaluation to apply the same row/column histogram bias used in training
- refactor dependency-bias logic into its own module for reuse
- cover evaluation path with tests

## Testing
- `isort src/training/dep_bias.py src/training/train.py train.py tests/test_dep_bias.py --check-only`
- `black src/training/dep_bias.py src/training/train.py train.py tests/test_dep_bias.py --check`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68982f48ee308324a693463f40a1616a