### PR TITLE
Integrate size and neighborhood priors into training

### DIFF
--- a/src/training/datasets/json_boards.py
+++ b/src/training/datasets/json_boards.py
@@ -1,5 +1,3 @@
-
-
 from __future__ import annotations
 
 import json

--- a/tests/test_size_nbr_bias.py
+++ b/tests/test_size_nbr_bias.py
@@ -1,0 +1,50 @@
+import torch
+
+from train import SizePriorCache, apply_nbr3x3_bias, apply_size_bias
+
+
+def test_apply_size_bias() -> None:
+    V = 10
+    logits = torch.zeros(1, 4, V)
+    tokens = torch.tensor([[0, 2, 3, 4]])
+    target = torch.tensor([[1, 2, 3, 4]])
+    rows = torch.tensor([2])
+    cols = torch.tensor([2])
+    N = torch.tensor([5])
+
+    cache = SizePriorCache(vocab_max=9, alpha=0.5)
+    cache.update_batch(rows, cols, target, N)
+    apply_size_bias(logits, tokens, target, rows, cols, N, cache, beta=1.0)
+
+    H = cache.get(2, 2, logits.device)
+    prior = H[: N.item() + 1, 0, 0]
+    expected = torch.full((V,), -1e9)
+    log_prior = torch.log(prior + 1e-6)
+    expected[: log_prior.numel()] = log_prior
+    assert torch.allclose(logits[0, 0], expected)
+    assert torch.all(logits[0, 1:].eq(0))
+
+
+def test_apply_nbr3x3_bias() -> None:
+    V = 10
+    tokens = torch.tensor([[1, 2, 3, 4, 0, 1, 2, 3, 4]])
+    target = torch.tensor([[1, 2, 3, 4, 5, 1, 2, 3, 4]])
+    rows = torch.tensor([3])
+    cols = torch.tensor([3])
+    N = torch.tensor([5])
+    logits = torch.zeros(1, 9, V)
+
+    apply_nbr3x3_bias(logits, tokens, target, rows, cols, N, beta=1.0)
+
+    grid = tokens.view(3, 3)
+    patch = grid[0:3, 0:3].reshape(-1)
+    hist = torch.bincount(patch, minlength=min(V - 1, N.item()) + 1)
+    hist[0] = 0
+    prior = hist.float()
+    prior = prior / prior.sum()
+    log_prior = torch.log(prior + 1e-6)
+    expected = torch.full((V,), -1e9)
+    expected[: log_prior.numel()] = log_prior
+    assert torch.allclose(logits[0, 4], expected)
+    mask = torch.arange(9) != 4
+    assert torch.all(logits[0, mask] == 0)

--- a/train.py
+++ b/train.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 import torch
+from torch import nn
 from torch.utils.data import DataLoader, random_split
 
 from src.config import load_config
@@ -13,7 +14,160 @@ from src.models.maskgit import MaskGit
 from src.training.datasets import JsonBoardsDataset, pad_collate
 from src.training.dep_bias import apply_dep_bias
 from src.training.loss_vec import compute_loss_vectorized
-from src.training.train import evaluate, set_seed
+from src.training.train import set_seed
+
+
+# ----------------------------
+# 位置大小分布先驗（EMA 緩存）
+class SizePriorCache:
+    def __init__(self, vocab_max: int, alpha: float) -> None:
+        self.alpha = alpha
+        self.vocab_max = vocab_max
+        self.maps: dict[tuple[int, int], torch.Tensor] = {}
+
+    def get(self, R: int, C: int, device: torch.device) -> torch.Tensor:
+        key = (int(R), int(C))
+        if key not in self.maps:
+            # [V+1, R, C]；用極小值避免 log(0)
+            self.maps[key] = torch.full((self.vocab_max + 1, R, C), 1e-6, device=device)
+        return self.maps[key]
+
+    def update_batch(
+        self,
+        rows: torch.Tensor,
+        cols: torch.Tensor,
+        targets: torch.Tensor,
+        N: torch.Tensor,
+    ) -> None:
+        # 簡潔實作：全圖衰減，再對命中位置加 α
+        B, _ = targets.shape
+        device = targets.device
+        for b in range(B):
+            R = int(rows[b].item())
+            C = int(cols[b].item())
+            Nb = int(N[b].item())
+            H = self.get(R, C, device)
+            H.mul_(1.0 - self.alpha)  # EMA 衰減
+            t = targets[b, : R * C].view(R, C)
+            # 逐格加權（可後續向量化優化）
+            for r in range(R):
+                for c in range(C):
+                    v = int(t[r, c].item())
+                    if 1 <= v <= Nb:
+                        H[v, r, c] += self.alpha
+
+
+def apply_size_bias(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    target: torch.Tensor,
+    rows: torch.Tensor,
+    cols: torch.Tensor,
+    N: torch.Tensor,
+    cache: SizePriorCache,
+    beta: float,
+) -> None:
+    """對被遮蔽位置加入『大小×座標』先驗 bias（log(heatmap)×beta）。"""
+    device = logits.device
+    V = logits.size(-1)
+    mask_pos = ((tokens == 0) & (target != 0)).nonzero(as_tuple=False)
+    eps = 1e-6
+    for b, lidx in mask_pos.tolist():
+        R = int(rows[b].item())
+        C = int(cols[b].item())
+        r = lidx // C
+        c = lidx % C
+        Nb = int(N[b].item())
+        H = cache.get(R, C, device)
+        prior = H[: Nb + 1, r, c]  # [Nb+1]
+        log_prior = torch.log(prior + eps) * beta
+        bias = torch.full((V,), -1e9, device=device)
+        bias[: log_prior.numel()] = log_prior
+        logits[b, lidx, :] += bias
+
+
+def apply_nbr3x3_bias(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    target: torch.Tensor,
+    rows: torch.Tensor,
+    cols: torch.Tensor,
+    N: torch.Tensor,
+    beta: float,
+) -> None:
+    """對被遮蔽位置加入 3×3 鄰域直方圖先驗（log(鄰域分布)×beta）。"""
+    device = logits.device
+    V = logits.size(-1)
+    eps = 1e-6
+    mask_pos = ((tokens == 0) & (target != 0)).nonzero(as_tuple=False)
+    for b, lidx in mask_pos.tolist():
+        R = int(rows[b].item())
+        C = int(cols[b].item())
+        r = int(lidx // C)
+        c = int(lidx % C)
+        Nb = int(N[b].item())
+        Vmax = min(V - 1, Nb)
+        grid = tokens[b, : R * C].view(R, C)
+        r0 = max(0, r - 1)
+        r1 = min(R - 1, r + 1)
+        c0 = max(0, c - 1)
+        c1 = min(C - 1, c + 1)
+        patch = grid[r0 : r1 + 1, c0 : c1 + 1].reshape(-1)
+        hist = torch.bincount(patch, minlength=Vmax + 1).to(device)
+        hist[0] = 0  # 忽略 MASK=0
+        prior = hist.float()
+        if prior.sum() > 0:
+            prior = prior / prior.sum()
+        log_prior = torch.log(prior + eps) * beta
+        bias = torch.full((V,), -1e9, device=device)
+        bias[: log_prior.numel()] = log_prior
+        logits[b, lidx, :] += bias
+
+
+# ----------------------------
+
+
+def evaluate(
+    model: nn.Module,
+    loader: DataLoader,
+    device: str,
+    *,
+    use_dep_bias: bool = False,
+    dep_alpha: float = 0.5,
+    use_size_bias: bool = False,
+    size_cache: SizePriorCache | None = None,
+    size_beta: float = 0.5,
+    use_nbr3x3: bool = False,
+    nbr_beta: float = 0.3,
+) -> dict:
+    model.eval()
+    total_loss = 0.0
+    total_tok = 0
+    with torch.no_grad():
+        for batch in loader:
+            tokens = batch["tokens"].to(device)
+            target = batch["target"].to(device)
+            attn = batch["attn_mask"].to(device)
+            N = batch["N"].to(device)
+            rows = batch["rows"].to(device)
+            cols = batch["cols"].to(device)
+
+            logits = model(tokens, attn)
+            if use_dep_bias:
+                apply_dep_bias(logits, tokens, target, rows, cols, N, dep_alpha)
+            if use_nbr3x3:
+                apply_nbr3x3_bias(logits, tokens, target, rows, cols, N, nbr_beta)
+            if use_size_bias and size_cache is not None:
+                size_cache.update_batch(rows, cols, target, N)
+                apply_size_bias(
+                    logits, tokens, target, rows, cols, N, size_cache, size_beta
+                )
+
+            loss = compute_loss_vectorized(logits, target, N)
+            cnt = (target != 0).sum().item()
+            total_loss += loss.item() * cnt
+            total_tok += cnt
+    return {"loss": total_loss / max(1, total_tok)}
 
 
 def find_datasets(
@@ -43,6 +197,11 @@ def train_one(
     target_loss: float | None = None,  # 門檻：達標後「等到 epoch 結束」才早停
     use_dep_bias: bool = False,
     dep_alpha: float = 0.5,
+    use_size_bias: bool = False,
+    size_alpha: float = 0.02,
+    size_beta: float = 0.5,
+    use_nbr3x3: bool = False,
+    nbr_beta: float = 0.3,
 ) -> None:
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
     print(f"[資料] 使用 {path} 訓練 {rows}x{cols} 模型")
@@ -87,6 +246,9 @@ def train_one(
     outdir.mkdir(parents=True, exist_ok=True)
     ckpt_path = outdir / f"{rows}x{cols}.ckpt"
 
+    size_cache = (
+        SizePriorCache(cfg["vocab_size"] - 1, size_alpha) if use_size_bias else None
+    )
     for epoch in range(1, epochs + 1):
         model.train()
         hit_threshold_this_epoch = False  # 做法B：本 epoch 內是否曾達標
@@ -100,8 +262,17 @@ def train_one(
             cols_t = batch["cols"].to(device)
 
             logits = model(tokens, attn)
+            # 先驗（可並用）
             if use_dep_bias:
                 apply_dep_bias(logits, tokens, target, rows_t, cols_t, N, dep_alpha)
+            if use_nbr3x3:
+                apply_nbr3x3_bias(logits, tokens, target, rows_t, cols_t, N, nbr_beta)
+            if use_size_bias and size_cache is not None:
+                size_cache.update_batch(rows_t, cols_t, target, N)
+                apply_size_bias(
+                    logits, tokens, target, rows_t, cols_t, N, size_cache, size_beta
+                )
+
             loss = compute_loss_vectorized(logits, target, N)
             opt.zero_grad(set_to_none=True)
             loss.backward()
@@ -124,6 +295,11 @@ def train_one(
             device,
             use_dep_bias=use_dep_bias,
             dep_alpha=dep_alpha,
+            use_size_bias=use_size_bias,
+            size_cache=size_cache,
+            size_beta=size_beta,
+            use_nbr3x3=use_nbr3x3,
+            nbr_beta=nbr_beta,
         )
         print(f"[驗證] {rows}x{cols} 第 {epoch} 代 損失={val['loss']:.6f}")
         if val["loss"] < best_val:
@@ -166,6 +342,28 @@ def parse_args() -> argparse.Namespace:
         default=0.5,
         help="依賴偏置權重（加入 logits 前的縮放係數）",
     )
+    # 新增：大小×座標先驗
+    p.add_argument("--use_size_bias", action="store_true")
+    p.add_argument(
+        "--size_alpha",
+        type=float,
+        default=0.02,
+        help="大小分布 EMA 係數",
+    )
+    p.add_argument(
+        "--size_beta",
+        type=float,
+        default=0.5,
+        help="加入 logits 的權重",
+    )
+    # 新增：3×3 鄰域先驗
+    p.add_argument("--use_nbr3x3", action="store_true")
+    p.add_argument(
+        "--nbr_beta",
+        type=float,
+        default=0.3,
+        help="加入 logits 的權重",
+    )
     return p.parse_args()
 
 
@@ -189,6 +387,11 @@ def main() -> None:  # pragma: no cover - CLI
             target_loss=args.target_loss,
             use_dep_bias=args.use_dep_bias,
             dep_alpha=args.dep_alpha,
+            use_size_bias=args.use_size_bias,
+            size_alpha=args.size_alpha,
+            size_beta=args.size_beta,
+            use_nbr3x3=args.use_nbr3x3,
+            nbr_beta=args.nbr_beta,
         )
 
 


### PR DESCRIPTION
## Summary
- add SizePriorCache with size and 3x3 neighborhood priors and integrate them into training and evaluation
- expose new CLI flags for size and neighborhood priors alongside existing dep bias
- cover the new bias functions with dedicated unit tests

## Testing
- `python -m black --check .`
- `python -m isort --check .`
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b538c14483249d782890008a2e12