### PR TITLE
feat: diversify top-k predictions

### DIFF
--- a/src/inference/topk.py
+++ b/src/inference/topk.py
@@ -31,8 +31,16 @@ def compute_topk_positions(
     # ``probs`` already contains normalized probabilities. Avoid applying an
     # additional softmax which would flatten the distribution and yield nearly
     # uniform confidences. Instead, sort by the raw probability for the target
-    # number and return the top-k entries.
+    # number and return the top-k entries. To avoid returning identical
+    # positions for every ``query_num`` when the model emits a uniform
+    # distribution, add a tiny amount of deterministic noise based on the
+    # queried number as a tie breaker. This distributes results across holes
+    # while remaining fully reproducible for a given ``query_num``.
     p_num = probs[hole_idxs, query_num]
+    g = torch.Generator()
+    g.manual_seed(int(query_num))
+    noise = torch.rand(p_num.shape, generator=g, device=p_num.device)
+    p_num = p_num + noise * 1e-6
     k = min(k, num_holes)
     vals, order = torch.sort(p_num, descending=True, stable=True)
     topk = []

--- a/tests/test_topk_positions.py
+++ b/tests/test_topk_positions.py
@@ -24,3 +24,35 @@ def test_compute_topk_positions_basic():
         assert item["row"] == exp["row"]
         assert item["col"] == exp["col"]
         assert item["prob"] == pytest.approx(exp["prob"], rel=1e-3)
+
+
+def _expected_from_seed(seed: int, cols: int) -> list[dict[str, float]]:
+    g = torch.Generator().manual_seed(seed)
+    noise = torch.rand(4, generator=g)
+    vals, order = torch.sort(noise, descending=True, stable=True)
+    expected = []
+    for v, idx in zip(vals[:2].tolist(), order[:2].tolist()):
+        r, c = divmod(idx, cols)
+        expected.append({"row": r, "col": c, "prob": v * 1e-6})
+    return expected
+
+
+def test_compute_topk_positions_tie_breaker():
+    probs = torch.zeros(4, 6)
+    holes = torch.ones(4, dtype=torch.bool)
+
+    topk1 = compute_topk_positions(probs, holes, query_num=1, k=2, cols=2)
+    topk2 = compute_topk_positions(probs, holes, query_num=2, k=2, cols=2)
+
+    expected1 = _expected_from_seed(1, cols=2)
+    expected2 = _expected_from_seed(2, cols=2)
+
+    for item, exp in zip(topk1, expected1):
+        assert item["row"] == exp["row"]
+        assert item["col"] == exp["col"]
+        assert item["prob"] == pytest.approx(exp["prob"], rel=1e-6)
+
+    for item, exp in zip(topk2, expected2):
+        assert item["row"] == exp["row"]
+        assert item["col"] == exp["col"]
+        assert item["prob"] == pytest.approx(exp["prob"], rel=1e-6)


### PR DESCRIPTION
## Summary
- diversify top-k inference by adding deterministic noise per queried number
- test deterministic tie-breaking to ensure spread of positions

## Testing
- `isort . --check-only`
- `black --check .`
- `flake8`
- `flake8 agent.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689947da566c8324877e29beb08f207d