### PR TITLE
Load size-specific checkpoints from outputs directory

### DIFF
--- a/src/inference/model_loader.py
+++ b/src/inference/model_loader.py
@@ -11,17 +11,19 @@ from ..config import load_config
 from ..models.maskgit import MaskGit
 
 
-def get_weight_path(rows: int, cols: int, base: str | Path = "weights") -> Path:
+def get_weight_path(
+    rows: int, cols: int, base: str | Path = "outputs/checkpoints"
+) -> Path:
     """Return the checkpoint path for a given grid size.
 
-    If ``{rows}x{cols}.ckpt`` exists under ``base`` that path is returned,
-    otherwise the fallback ``best.ckpt`` is used.  This allows部署時根據尺寸
+    If ``{rows}x{cols}/best.pth`` exists under ``base`` that path is returned,
+    otherwise the fallback ``best.pth`` is used.  This allows 部署時根據尺寸
     自動選擇對應的模型權重。
     """
 
     base_path = Path(base)
-    specific = base_path / f"{rows}x{cols}.ckpt"
-    return specific if specific.exists() else base_path / "best.ckpt"
+    specific = base_path / f"{rows}x{cols}" / "best.pth"
+    return specific if specific.exists() else base_path / "best.pth"
 
 
 MODEL_CACHE: Dict[Tuple[int, int, str], MaskGit] = {}
@@ -52,15 +54,15 @@ def load_model_for_size(
     rows: int,
     cols: int,
     *,
-    base: str | Path = "weights",
+    base: str | Path = "outputs/checkpoints",
     device: str | torch.device = "cpu",
 ) -> MaskGit:
     """Load (and cache) a model for a specific grid size.
 
-    依照 ``rows`` 與 ``cols`` 自動尋找對應的模型檔並載入，如同名的
-    ``{rows}x{cols}.ckpt`` 不存在則回退到 ``best.ckpt``。載入後會緩存，
-    再次呼叫相同尺寸時會直接回傳快取的模型。所有關鍵訊息皆以中文
-    輸出方便追蹤。
+    依照 ``rows`` 與 ``cols`` 自動尋找對應的模型檔並載入，如該尺寸的
+    ``{rows}x{cols}/best.pth`` 不存在則回退到 ``best.pth``。載入後會緩存，
+    再次呼叫相同尺寸時會直接回傳快取的模型。所有關鍵訊息皆以中文輸出
+    方便追蹤。
     """
 
     key = (rows, cols, str(device))

--- a/tests/test_model_loader_size.py
+++ b/tests/test_model_loader_size.py
@@ -2,16 +2,18 @@ from src.inference import model_loader
 
 
 def test_get_weight_path(tmp_path):
-    (tmp_path / "best.ckpt").touch()
-    specific = tmp_path / "3x3.ckpt"
+    (tmp_path / "best.pth").touch()
+    specific_dir = tmp_path / "3x3"
+    specific_dir.mkdir()
+    specific = specific_dir / "best.pth"
     specific.touch()
     assert model_loader.get_weight_path(3, 3, tmp_path) == specific
-    assert model_loader.get_weight_path(4, 4, tmp_path) == tmp_path / "best.ckpt"
+    assert model_loader.get_weight_path(4, 4, tmp_path) == tmp_path / "best.pth"
 
 
 def test_load_model_for_size_caches(tmp_path):
     model_loader.MODEL_CACHE.clear()
-    (tmp_path / "best.ckpt").touch()
+    (tmp_path / "best.pth").touch()
     m1 = model_loader.load_model_for_size(4, 4, base=tmp_path)
     m2 = model_loader.load_model_for_size(4, 4, base=tmp_path)
     assert m1 is m2


### PR DESCRIPTION
## Summary
- default checkpoint path now reads from `outputs/checkpoints/{rows}x{cols}/best.pth`
- adjust model loader and tests for new checkpoint layout

## Testing
- `black --check src/inference/model_loader.py tests/test_model_loader_size.py`
- `isort --check-only src/inference/model_loader.py tests/test_model_loader_size.py`
- `flake8 agent.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7540791883249b9a6deded05785d