### PR TITLE
Enforce 1–5 recent-window mainline across runtime, search and validation

### DIFF
--- a/scripts/final_holdout_validation.py
+++ b/scripts/final_holdout_validation.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import requests
 
-from winwin_service.config import AppConfig
+from winwin_service.config import AppConfig, RECENT_WINDOW_MAX, RECENT_WINDOW_MIN, normalize_recent_window
 from winwin_service.fetcher import parse_draws_from_json
 from winwin_service.scoring import PredictError, predict_top3
 
@@ -194,10 +194,14 @@ def previous_neighbor_baseline(prev_draw: list[int], k: int = 3) -> list[int]:
 
 
 def build_config(params: dict[str, int]) -> AppConfig:
+    recent, max_recent = normalize_recent_window(
+        params["recent_draws_count"],
+        params["max_recent_draws_count"],
+    )
     return AppConfig(
         min_prediction_draws=10,
-        recent_draws_count=params["recent_draws_count"],
-        max_recent_draws_count=params["max_recent_draws_count"],
+        recent_draws_count=recent,
+        max_recent_draws_count=max_recent,
         min_score_threshold=params["min_score_threshold"],
         skip_kill_threshold=params["skip_kill_threshold"],
         streak_kill_threshold=params["streak_kill_threshold"],
@@ -214,9 +218,13 @@ def sample_params(rng: random.Random) -> dict[str, int]:
     warm_max = rng.randint(max(4, warm_min + 1), 8)
     streak_min = rng.randint(1, 2)
     streak_max = rng.randint(max(2, streak_min + 1), 5)
+    recent, max_recent = normalize_recent_window(
+        rng.randint(RECENT_WINDOW_MIN, RECENT_WINDOW_MAX),
+        rng.randint(RECENT_WINDOW_MIN, RECENT_WINDOW_MAX),
+    )
     return {
-        "recent_draws_count": rng.randint(20, 90),
-        "max_recent_draws_count": rng.randint(20, 90),
+        "recent_draws_count": recent,
+        "max_recent_draws_count": max_recent if max_recent is not None else RECENT_WINDOW_MAX,
         "min_score_threshold": rng.randint(35, 85),
         "skip_kill_threshold": rng.randint(6, 15),
         "streak_kill_threshold": rng.randint(3, 7),
@@ -237,9 +245,14 @@ def refine_params(base: dict[str, int], rng: random.Random, scale: int) -> dict[
     streak_min = clamp(base["streak_min"] + rng.randint(-1, 1), 1, 3)
     streak_max = clamp(base["streak_max"] + rng.randint(-scale, scale), streak_min + 1, 6)
 
+    recent, max_recent = normalize_recent_window(
+        clamp(base["recent_draws_count"] + rng.randint(-1, 1), RECENT_WINDOW_MIN, RECENT_WINDOW_MAX),
+        clamp(base["max_recent_draws_count"] + rng.randint(-1, 1), RECENT_WINDOW_MIN, RECENT_WINDOW_MAX),
+    )
+
     return {
-        "recent_draws_count": clamp(base["recent_draws_count"] + rng.randint(-scale * 4, scale * 4), 15, 100),
-        "max_recent_draws_count": clamp(base["max_recent_draws_count"] + rng.randint(-scale * 4, scale * 4), 15, 100),
+        "recent_draws_count": recent,
+        "max_recent_draws_count": max_recent if max_recent is not None else RECENT_WINDOW_MAX,
         "min_score_threshold": clamp(base["min_score_threshold"] + rng.randint(-scale * 3, scale * 3), 20, 95),
         "skip_kill_threshold": clamp(base["skip_kill_threshold"] + rng.randint(-scale, scale), 4, 20),
         "streak_kill_threshold": clamp(base["streak_kill_threshold"] + rng.randint(-1, 1), 2, 8),

--- a/scripts/strict_walkforward_search.py
+++ b/scripts/strict_walkforward_search.py
@@ -12,7 +12,7 @@ from statistics import mean
 
 import requests
 
-from winwin_service.config import AppConfig
+from winwin_service.config import AppConfig, RECENT_WINDOW_MAX, RECENT_WINDOW_MIN, normalize_recent_window
 from winwin_service.fetcher import parse_draws_from_json
 from winwin_service.scoring import PredictError, predict_top3
 
@@ -121,10 +121,14 @@ def paired_permutation_pvalue(diffs: list[float], rng: random.Random, n: int = 3
 
 
 def build_config(params: dict[str, int]) -> AppConfig:
+    recent, max_recent = normalize_recent_window(
+        params["recent_draws_count"],
+        params["max_recent_draws_count"],
+    )
     return AppConfig(
         min_prediction_draws=10,
-        recent_draws_count=params["recent_draws_count"],
-        max_recent_draws_count=params["max_recent_draws_count"],
+        recent_draws_count=recent,
+        max_recent_draws_count=max_recent,
         min_score_threshold=params["min_score_threshold"],
         skip_kill_threshold=params["skip_kill_threshold"],
         streak_kill_threshold=params["streak_kill_threshold"],
@@ -141,8 +145,8 @@ def random_param(rng: random.Random) -> dict[str, int]:
     warm_max = rng.randint(max(warm_min + 1, 4), 8)
     streak_min = rng.randint(1, 2)
     streak_max = rng.randint(max(streak_min + 1, 2), 5)
-    rc = rng.randint(20, 90)
-    mrc = rng.randint(20, 90)
+    rc = rng.randint(RECENT_WINDOW_MIN, RECENT_WINDOW_MAX)
+    mrc = rng.randint(rc, RECENT_WINDOW_MAX)
     return {
         "recent_draws_count": rc,
         "max_recent_draws_count": mrc,

--- a/src/winwin_service/api.py
+++ b/src/winwin_service/api.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException
 
 from .fetcher import FetchError, fetch_latest_draws
-from .config import AppConfig, DEFAULT_CONFIG
+from .config import (
+    AppConfig,
+    DEFAULT_CONFIG,
+    RECENT_WINDOW_MAX,
+    RECENT_WINDOW_MIN,
+    normalize_recent_window,
+)
 from .scoring import PredictError, predict_top3
 from .schemas import PredictionResponse
 
@@ -44,10 +50,42 @@ def _load_validated_config() -> tuple[AppConfig, str, bool]:
         payload = json.loads(_BEST_CONFIG_PATH.read_text(encoding="utf-8"))
         params = payload.get("params", payload)
         kwargs = {
-            key: int(params[key]) for key in _LIVE_PARAM_KEYS if key in params
+            key: int(params[key])
+            for key in _LIVE_PARAM_KEYS
+            if key in params
         }
         if not kwargs:
             return DEFAULT_CONFIG, "default_config_invalid_best_config", False
+        raw_recent = int(
+            kwargs.get(
+                "recent_draws_count",
+                DEFAULT_CONFIG.recent_draws_count,
+            )
+        )
+        raw_max = int(
+            kwargs.get(
+                "max_recent_draws_count",
+                DEFAULT_CONFIG.max_recent_draws_count
+                or RECENT_WINDOW_MAX,
+            )
+        )
+        normalized_recent, normalized_max = normalize_recent_window(
+            raw_recent,
+            raw_max,
+        )
+        if (
+            raw_recent != normalized_recent
+            or raw_max != normalized_max
+            or raw_recent < RECENT_WINDOW_MIN
+            or raw_recent > RECENT_WINDOW_MAX
+            or raw_max < RECENT_WINDOW_MIN
+            or raw_max > RECENT_WINDOW_MAX
+        ):
+            return (
+                DEFAULT_CONFIG,
+                "default_config_reject_long_window_best_config",
+                False,
+            )
         return AppConfig(**kwargs), "validated_best_config", True
     except Exception as exc:  # noqa: BLE001
         logger.warning("failed to load validated best config: %s", exc)

--- a/src/winwin_service/config.py
+++ b/src/winwin_service/config.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
+RECENT_WINDOW_MIN = 1
+RECENT_WINDOW_MAX = 5
+
+
 @dataclass(frozen=True)
 class ScoreWeights:
     streak_perfect: int = 15
@@ -88,9 +92,9 @@ class RegimeConfig:
 class AppConfig:
     source_url: str = "https://winwin.tw/Bingo"
     request_timeout: int = 15
-    recent_draws_count: int = 50
+    recent_draws_count: int = 3
     min_prediction_draws: int = 10
-    max_recent_draws_count: int | None = 50
+    max_recent_draws_count: int | None = 5
     history_lookback_days: int = 7
     skip_kill_threshold: int = 10
     streak_kill_threshold: int = 4
@@ -106,3 +110,21 @@ class AppConfig:
 
 
 DEFAULT_CONFIG = AppConfig()
+
+
+def clamp_recent_window_value(value: int | None) -> int | None:
+    if value is None:
+        return None
+    return max(RECENT_WINDOW_MIN, min(RECENT_WINDOW_MAX, int(value)))
+
+
+def normalize_recent_window(
+    recent_draws_count: int,
+    max_recent_draws_count: int | None,
+) -> tuple[int, int | None]:
+    normalized_recent = clamp_recent_window_value(recent_draws_count)
+    assert normalized_recent is not None
+    normalized_max = clamp_recent_window_value(max_recent_draws_count)
+    if normalized_max is None:
+        return normalized_recent, None
+    return min(normalized_recent, normalized_max), normalized_max

--- a/src/winwin_service/scoring.py
+++ b/src/winwin_service/scoring.py
@@ -4,7 +4,12 @@ import itertools
 import math
 from collections import Counter, defaultdict
 
-from .config import AppConfig, DEFAULT_CONFIG, RegimeConfig
+from .config import (
+    AppConfig,
+    DEFAULT_CONFIG,
+    RegimeConfig,
+    normalize_recent_window,
+)
 
 
 class PredictError(RuntimeError):
@@ -812,10 +817,14 @@ def predict_top3(
             f"{config.min_prediction_draws} draws, got {available_draws}"
         )
 
-    recent_window = max(config.min_prediction_draws, config.recent_draws_count)
-    if config.max_recent_draws_count is not None:
-        recent_window = min(recent_window, config.max_recent_draws_count)
-        recent_window = max(recent_window, config.min_prediction_draws)
+    normalized_recent, normalized_max_recent = normalize_recent_window(
+        config.recent_draws_count,
+        config.max_recent_draws_count,
+    )
+    recent_window = normalized_recent
+    if normalized_max_recent is not None:
+        recent_window = min(recent_window, normalized_max_recent)
+    recent_window = max(1, recent_window)
     recent_draws = past_draws[-recent_window:]
     effective_draws_used = len(recent_draws)
 
@@ -923,8 +932,9 @@ def predict_top3(
             "analyzed_draws": len(recent_draws),
             "available_draws": available_draws,
             "effective_draws_used": effective_draws_used,
+            "effective_recent_window": recent_window,
             "min_prediction_draws": config.min_prediction_draws,
-            "max_recent_draws_count": config.max_recent_draws_count,
+            "max_recent_draws_count": normalized_max_recent,
             "regime_min_history": config.regime.min_history,
             "regime_disabled_reason": regime_info["regime_disabled_reason"],
             "valid_pool_size": len(valid_pool),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 from winwin_service.api import app
@@ -192,3 +195,29 @@ def test_predict_debug_false_metadata_is_trimmed(monkeypatch) -> None:
     response = client.get('/predict')
     assert response.status_code == 200
     assert 'regime_metrics_raw' not in response.json()['metadata']
+
+
+def test_load_validated_config_rejects_legacy_long_window(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from winwin_service import api
+
+    payload = {
+        "params": {
+            "recent_draws_count": 50,
+            "max_recent_draws_count": 50,
+            "min_score_threshold": 60,
+        }
+    }
+    cfg_path = tmp_path / "best_config.json"
+    cfg_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(api, "_BEST_CONFIG_PATH", cfg_path)
+    loaded, source, matched = api._load_validated_config()
+
+    assert loaded.recent_draws_count <= 5
+    assert loaded.max_recent_draws_count is not None
+    assert loaded.max_recent_draws_count <= 5
+    assert source == "default_config_reject_long_window_best_config"
+    assert matched is False

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -64,9 +64,10 @@ def test_predict_with_48_draws_still_allowed() -> None:
         config=AppConfig(min_prediction_draws=10),
     )
     assert len(result["top3"]) == 3
-    assert result["metadata"]["analyzed_draws"] == 48
-    assert result["metadata"]["effective_draws_used"] == 48
-    assert result["metadata"]["regime_window"] == 48
+    assert result["metadata"]["analyzed_draws"] == 3
+    assert result["metadata"]["effective_draws_used"] == 3
+    assert result["metadata"]["effective_recent_window"] == 3
+    assert result["metadata"]["regime_window"] == 3
 
 
 def test_diversified_strict_overlap() -> None:
@@ -233,29 +234,31 @@ def test_recent_window_with_less_than_50_uses_available_draws() -> None:
         latest_period=10,
         config=AppConfig(
             min_prediction_draws=10,
-            recent_draws_count=50,
+            recent_draws_count=5,
         ),
     )
     assert result["metadata"]["available_draws"] == 48
-    assert result["metadata"]["analyzed_draws"] == 48
-    assert result["metadata"]["effective_draws_used"] == 48
-    assert result["metadata"]["regime_window"] == 48
+    assert result["metadata"]["analyzed_draws"] == 5
+    assert result["metadata"]["effective_draws_used"] == 5
+    assert result["metadata"]["effective_recent_window"] == 5
+    assert result["metadata"]["regime_window"] == 5
 
 
-def test_recent_window_50_uses_latest_50_when_history_is_large() -> None:
+def test_recent_window_uses_latest_5_when_history_is_large() -> None:
     draws = (_baseline_draws() * 27)[:1348]
     result = predict_top3(
         draws,
         latest_period=10,
         config=AppConfig(
             min_prediction_draws=10,
-            recent_draws_count=50,
+            recent_draws_count=5,
         ),
     )
     assert result["metadata"]["available_draws"] == 1348
-    assert result["metadata"]["analyzed_draws"] == 50
-    assert result["metadata"]["effective_draws_used"] == 50
-    assert result["metadata"]["regime_window"] == 50
+    assert result["metadata"]["analyzed_draws"] == 5
+    assert result["metadata"]["effective_draws_used"] == 5
+    assert result["metadata"]["effective_recent_window"] == 5
+    assert result["metadata"]["regime_window"] == 5
 
 
 def test_regime_disabled_when_insufficient_history_but_predict_ok() -> None:
@@ -335,16 +338,17 @@ def test_max_recent_draws_count_caps_effective_window() -> None:
         latest_period=10,
         config=AppConfig(
             min_prediction_draws=10,
-            recent_draws_count=80,
-            max_recent_draws_count=30,
+            recent_draws_count=5,
+            max_recent_draws_count=4,
             min_score_threshold=10,
         ),
     )
-    assert result["metadata"]["analyzed_draws"] == 30
-    assert result["metadata"]["effective_draws_used"] == 30
+    assert result["metadata"]["analyzed_draws"] == 4
+    assert result["metadata"]["effective_draws_used"] == 4
 
 
-def test_max_recent_draws_count_never_below_min_prediction_draws() -> None:
+def test_effective_recent_window_never_exceeds_five_even_for_long_inputs(
+) -> None:
     draws = (_baseline_draws() * 5)[:120]
     result = predict_top3(
         draws,
@@ -352,9 +356,10 @@ def test_max_recent_draws_count_never_below_min_prediction_draws() -> None:
         config=AppConfig(
             min_prediction_draws=12,
             recent_draws_count=80,
-            max_recent_draws_count=5,
+            max_recent_draws_count=80,
             min_score_threshold=10,
         ),
     )
-    assert result["metadata"]["analyzed_draws"] == 12
-    assert result["metadata"]["effective_draws_used"] == 12
+    assert result["metadata"]["analyzed_draws"] == 5
+    assert result["metadata"]["effective_draws_used"] == 5
+    assert result["metadata"]["effective_recent_window"] == 5


### PR DESCRIPTION
### Motivation
- Reduce noise from long-history windows by making 1–5 draws the true runtime/search/validation mainline so nothing can silently expand the effective recent window above 5 draws. 
- Prevent old `best_config.json` artifacts with long windows from being loaded into live `/predict` and reintroducing long-window behavior.

### Description
- Introduced hard bounds and normalization utilities `RECENT_WINDOW_MIN`, `RECENT_WINDOW_MAX`, `clamp_recent_window_value` and `normalize_recent_window` in `src/winwin_service/config.py` and set short-window defaults. 
- Enforced normalized 1..5 window in runtime by using `normalize_recent_window` inside `predict_top3` so `effective_recent_window` is derived from normalized values and surfaced in prediction metadata. 
- Hardened `/predict` validated-config loader in `src/winwin_service/api.py` to `reject` legacy long-window `best_config.json` (fallback to default short-window config) instead of silently accepting it. 
- Restricted search and validation sampling/ranges to the 1..5 neighborhood by changing parameter samplers and `build_config` callers in `scripts/strict_walkforward_search.py` and `scripts/final_holdout_validation.py`. 
- Added/updated tests in `tests/test_scoring.py` and `tests/test_api.py` to assert the effective recent window never exceeds 5, that the API rejects legacy long-window best-configs, and that `/predict` continues to operate.

### Testing
- Installed dev dependencies and ran lint/compilation checks using `flake8 src tests` and `python -m py_compile $(git ls-files '*.py')` which passed in the environment used for validation. 
- Ran unit test suite with `pytest -q` and observed: `41 passed` (all tests passed). 
- Verified specific automated checks: `test_effective_recent_window_never_exceeds_five_even_for_long_inputs` and `test_load_validated_config_rejects_legacy_long_window` pass to confirm effective window <=5 and best-config rejection behavior. 
- Note: full walk-forward and final-holdout end-to-end runs have not been re-executed here (the scripts were updated to use the 1–5 search space but a full re-run of the walk-forward/final holdout pipeline is required to produce new `reports/.../best_config.json` and final KPI numbers).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac0e865cc83248ada0dcce226696f)