### PR TITLE
Add hybrid/manual parsing, ticket specs, solver, API, and extensive refactor/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# coco
+
+## API Mainline SOP (Vision-first)
+
+正式主線以 API 自動解析為主，不要求使用者先提供 `rows/cols` 或 `manual-grid`。
+
+### Step 1: 呼叫 API
+- `POST /board/parse`：只上傳圖片（可選 `strict`）
+- `POST /board/predict-number-position`：上傳圖片 + `query_number`（可選 `strict`）
+
+### Step 2: 系統自動流程
+1. 自動偵測 board 外框
+2. 自動判斷 rows/cols（在已知票種 shape 中自動選擇最佳）
+3. 自動切格 + OCR
+4. 建立 `grid` / `numbers_all` / `value_to_position`
+5. 產生 `board_bbox` / `cell_boxes` / overlay
+6. 執行 contract 檢查，輸出低信心格與人工複核標記
+
+### Step 3: 回傳重點
+- `shape`, `grid`, `numbers_all`, `value_to_position`
+- `query_number`, `query_status`, `exact_positions`, `top5_position_candidates`
+- `overlay_image_base64`（若有產生 overlay）
+- `parse_confidence`, `confidence_summary`, `low_confidence_cells`

--- a/reports/api_mainline_e2e.json
+++ b/reports/api_mainline_e2e.json
@@ -1,0 +1,41 @@
+[
+  {
+    "tag": "20",
+    "status_code": 200,
+    "shape": "5x4",
+    "shape_ok": true,
+    "grid_complete_rate": 0.3,
+    "numbers_all_valid": true,
+    "value_to_position_count": 6,
+    "query_status": "exact_found",
+    "top5_count": 1,
+    "overlay_returned": true,
+    "needs_review": true
+  },
+  {
+    "tag": "80",
+    "status_code": 200,
+    "shape": "10x8",
+    "shape_ok": true,
+    "grid_complete_rate": 0.05,
+    "numbers_all_valid": true,
+    "value_to_position_count": 4,
+    "query_status": "predicted",
+    "top5_count": 5,
+    "overlay_returned": true,
+    "needs_review": true
+  },
+  {
+    "tag": "120",
+    "status_code": 200,
+    "shape": "12x10",
+    "shape_ok": true,
+    "grid_complete_rate": 0.1083,
+    "numbers_all_valid": true,
+    "value_to_position_count": 13,
+    "query_status": "predicted",
+    "top5_count": 5,
+    "overlay_returned": true,
+    "needs_review": true
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ lightgbm>=4.0
 scikit-learn==1.6.1
 joblib>=1.3
 pyarrow>=17.0
+
+opencv-python-headless>=4.10
+
+python-multipart>=0.0.9

--- a/scripts/parse_board_image.py
+++ b/scripts/parse_board_image.py
@@ -35,6 +35,7 @@ from src.manual_board_input import (
     load_manual_grid_with_states,
 )  # noqa: E402
 from src.ticket_specs import TicketSpec, resolve_ticket_spec  # noqa: E402
+from src.ticket_specs import TICKET_SPECS, get_ticket_spec  # noqa: E402
 
 
 def _manual_result_from_grid(
@@ -103,19 +104,108 @@ def _manual_result_from_grid(
 
 
 def parse_image_hybrid(args: argparse.Namespace) -> dict[str, object]:
-    spec = resolve_ticket_spec(
-        size_class=getattr(args, "size_class", None),
-        rows=getattr(args, "rows", None),
-        cols=getattr(args, "cols", None),
-        image_path=args.image,
-    )
     gray = cv2.imread(args.image, cv2.IMREAD_GRAYSCALE)
     if gray is None:
         raise ValueError(f"cannot_read_image:{args.image}")
-
     manual_grid, manual_states = load_manual_grid_with_states(
         getattr(args, "manual_grid", None)
     )
+    detection_pref: GridDetection | None = None
+    base_result_pref: BoardParseResult | None = None
+    if any(
+        getattr(args, key, None) is not None for key in ("size_class", "rows", "cols")
+    ):
+        spec = resolve_ticket_spec(
+            size_class=getattr(args, "size_class", None),
+            rows=getattr(args, "rows", None),
+            cols=getattr(args, "cols", None),
+            image_path=args.image,
+        )
+    else:
+        img_h, img_w = gray.shape[:2]
+        original_filename = str(getattr(args, "original_filename", "") or "")
+        size_class_candidates = list(TICKET_SPECS.keys())
+        preferred_size = None
+        if img_h <= 1300 and img_w <= 1900:
+            spec = get_ticket_spec("20")
+            try:
+                detection_pref = detect_grid(gray, spec)
+            except GridDetectionError:
+                detection_pref = None
+            candidates: list[
+                tuple[float, TicketSpec, GridDetection, BoardParseResult | None]
+            ] = []
+            if detection_pref is not None and manual_grid is None:
+                try:
+                    base_result_pref = structure_board(
+                        sample_id=Path(args.image).stem,
+                        image_path=args.image,
+                        detection=detection_pref,
+                        spec=spec,
+                        ticket_type=spec.size_class,
+                    )
+                except Exception:
+                    base_result_pref = None
+            # short-circuit for 20-shape paper format
+            if detection_pref is not None:
+                candidates = [(1.0, spec, detection_pref, base_result_pref)]
+                size_class_candidates = []
+        else:
+            is_multipage_hint = "頁面_" in original_filename or "頁面_" in str(args.image)
+            preferred_size = "120" if is_multipage_hint else "80"
+            size_class_candidates = [preferred_size] + [
+                x for x in TICKET_SPECS if x != preferred_size
+            ]
+            candidates = []
+        for size_class in size_class_candidates:
+            candidate_spec = get_ticket_spec(size_class)
+            try:
+                candidate_det = detect_grid(gray, candidate_spec)
+            except GridDetectionError:
+                continue
+            candidate_result: BoardParseResult | None = None
+            if manual_grid is None:
+                try:
+                    candidate_result = structure_board(
+                        sample_id=Path(args.image).stem,
+                        image_path=args.image,
+                        detection=candidate_det,
+                        spec=candidate_spec,
+                        ticket_type=candidate_spec.size_class,
+                    )
+                except Exception:
+                    candidate_result = None
+            if candidate_result is not None:
+                total = max(
+                    1, candidate_spec.expected_rows * candidate_spec.expected_cols
+                )
+                numbers = [int(v) for row in candidate_result.grid for v in row if v is not None]
+                complete_ratio = len(numbers) / float(total)
+                dup_count = min(
+                    len(candidate_result.parse_diagnostics.get("duplicates", [])), total
+                )
+                illegal_count = len([v for v in numbers if v < 1 or v > total])
+                low_count = min(len(candidate_result.low_confidence_cells), total)
+                score = (
+                    0.35 * float(candidate_result.final_parse_confidence)
+                    + 0.50 * complete_ratio
+                    - 0.25 * (dup_count / float(total))
+                    - 0.35 * (illegal_count / float(total))
+                    - 0.20 * (low_count / float(total))
+                )
+            else:
+                score = (
+                    0.4 * float(candidate_det.board_confidence)
+                    + 0.3 * float(candidate_det.warp_confidence)
+                    + 0.3 * float(candidate_det.shape_confidence)
+                )
+            if preferred_size is not None and size_class == preferred_size:
+                score += 0.03
+            candidates.append((score, candidate_spec, candidate_det, candidate_result))
+        if not candidates:
+            raise GridDetectionError("shape_resolution_failed")
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        _, spec, detection_pref, base_result_pref = candidates[0]
     override_path = getattr(args, "override", None)
     source_mode = "auto"
     base_result: BoardParseResult | None = None
@@ -127,20 +217,24 @@ def parse_image_hybrid(args: argparse.Namespace) -> dict[str, object]:
         source_mode = "manual"
         base_grid = manual_grid
         # optional detection for bbox/overlay only; never blocks manual flow
-        try:
-            detection = detect_grid(gray, spec)
-        except GridDetectionError:
-            detection = None
+        detection = detection_pref
+        if detection is None:
+            try:
+                detection = detect_grid(gray, spec)
+            except GridDetectionError:
+                detection = None
     else:
         try:
-            detection = detect_grid(gray, spec)
-            base_result = structure_board(
-                sample_id=Path(args.image).stem,
-                image_path=args.image,
-                detection=detection,
-                spec=spec,
-                ticket_type=spec.size_class,
-            )
+            detection = detection_pref or detect_grid(gray, spec)
+            base_result = base_result_pref
+            if base_result is None:
+                base_result = structure_board(
+                    sample_id=Path(args.image).stem,
+                    image_path=args.image,
+                    detection=detection,
+                    spec=spec,
+                    ticket_type=spec.size_class,
+                )
             base_grid = [row[:] for row in base_result.grid]
         except GridDetectionError as exc:
             auto_error = str(exc)
@@ -204,6 +298,17 @@ def parse_image_hybrid(args: argparse.Namespace) -> dict[str, object]:
     payload["bounding_boxes"] = {
         "board_bbox": detection.board_bbox if detection else None
     }
+    payload["confidence_summary"] = {
+        "board_confidence": float(final_result.board_confidence),
+        "warp_confidence": float(final_result.warp_confidence),
+        "shape_confidence": float(final_result.shape_confidence),
+        "cell_class_confidence_mean": float(final_result.cell_class_confidence_mean),
+        "digit_confidence_mean": float(final_result.digit_confidence_mean),
+        "global_consistency_confidence": float(
+            final_result.global_consistency_confidence
+        ),
+        "final_parse_confidence": float(final_result.final_parse_confidence),
+    }
 
     query_number = getattr(args, "query_number", None)
     if query_number is not None:
@@ -216,16 +321,16 @@ def parse_image_hybrid(args: argparse.Namespace) -> dict[str, object]:
         out_csv = getattr(args, "output_csv", "reports/parsed_board.csv")
         write_board_json(final_result, Path(out_json))
         write_board_csv(final_result, Path(out_csv))
-        output_overlay = getattr(
-            args, "output_overlay", "reports/parsed_board_overlay.png"
-        )
-        if (
-            not getattr(args, "no_overlay", False)
-            and output_overlay
-            and detection is not None
-        ):
-            write_overlay(final_result, detection, args.image, Path(output_overlay))
-            payload["overlay_path"] = output_overlay
+    output_overlay = getattr(
+        args, "output_overlay", "reports/parsed_board_overlay.png"
+    )
+    if (
+        not getattr(args, "no_overlay", False)
+        and output_overlay
+        and detection is not None
+    ):
+        write_overlay(final_result, detection, args.image, Path(output_overlay))
+        payload["overlay_path"] = output_overlay
 
     payload = json.loads(json.dumps(payload, default=lambda o: int(o)))
     return payload

--- a/scripts/parse_board_image.py
+++ b/scripts/parse_board_image.py
@@ -7,41 +7,266 @@ import sys
 from pathlib import Path
 
 import cv2
-import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.board_export import grid_to_text, write_board_csv, write_board_json, write_overlay  # noqa: E402
-from src.board_structurer import structure_board  # noqa: E402
-from src.grid_detector import detect_grid  # noqa: E402
+from src.board_contracts import (
+    build_output_schema,
+    evaluate_board_contract,
+)  # noqa: E402
+from src.board_export import (
+    grid_to_text,
+    write_board_csv,
+    write_board_json,
+    write_overlay,
+)  # noqa: E402
+from src.board_query import find_number_positions  # noqa: E402
+from src.board_structurer import BoardParseResult, structure_board  # noqa: E402
+from src.grid_detector import (
+    GridDetection,
+    GridDetectionError,
+    detect_grid,
+)  # noqa: E402
+from src.manual_board_input import (
+    ManualInputError,
+    apply_overrides,
+    load_manual_grid_with_states,
+)  # noqa: E402
+from src.ticket_specs import TicketSpec, resolve_ticket_spec  # noqa: E402
+
+
+def _manual_result_from_grid(
+    image_path: str,
+    spec: TicketSpec,
+    grid: list[list[int | None]],
+    manual_states: list[list[str]] | None = None,
+) -> BoardParseResult:
+    rows, cols = len(grid), len(grid[0]) if grid else 0
+    black_cells = []
+    cell_boxes = []
+    for r, row in enumerate(grid):
+        for c, v in enumerate(row):
+            state = (
+                manual_states[r][c]
+                if manual_states and r < len(manual_states) and c < len(manual_states[r])
+                else ("empty" if v is None else "confirmed_number")
+            )
+            if v is None and state == "black":
+                black_cells.append({"row": r + 1, "col": c + 1})
+            cell_boxes.append(
+                {
+                    "row_1based": r + 1,
+                    "col_1based": c + 1,
+                    "x0": 0,
+                    "y0": 0,
+                    "x1": 0,
+                    "y1": 0,
+                    "label": "manual",
+                    "value": v,
+                    "confidence": 1.0,
+                    "manual_state": state,
+                }
+            )
+    return BoardParseResult(
+        sample_id=Path(image_path).stem,
+        shape=f"{rows}x{cols}",
+        row_count=rows,
+        col_count=cols,
+        grid=grid,
+        cell_confidence=[[1.0 for _ in range(cols)] for _ in range(rows)],
+        low_confidence_cells=[],
+        parse_confidence=1.0,
+        image_path=image_path,
+        ticket_type=spec.size_class,
+        board_confidence=1.0,
+        warp_confidence=1.0,
+        shape_confidence=1.0,
+        cell_class_confidence_mean=1.0,
+        digit_confidence_mean=1.0,
+        global_consistency_confidence=1.0,
+        final_parse_confidence=1.0,
+        numbers_all=sorted([int(v) for row in grid for v in row if v is not None]),
+        value_to_position={},
+        missing_values=sorted(
+            list(
+                spec.legal_values
+                - {int(v) for row in grid for v in row if v is not None}
+            )
+        ),
+        black_cells=black_cells,
+        pending_cells=[],
+        parse_diagnostics={"manual_override": True, "ocr_backend": "manual"},
+        cell_boxes=cell_boxes,
+    )
+
+
+def parse_image_hybrid(args: argparse.Namespace) -> dict[str, object]:
+    spec = resolve_ticket_spec(
+        size_class=getattr(args, "size_class", None),
+        rows=getattr(args, "rows", None),
+        cols=getattr(args, "cols", None),
+        image_path=args.image,
+    )
+    gray = cv2.imread(args.image, cv2.IMREAD_GRAYSCALE)
+    if gray is None:
+        raise ValueError(f"cannot_read_image:{args.image}")
+
+    manual_grid, manual_states = load_manual_grid_with_states(
+        getattr(args, "manual_grid", None)
+    )
+    override_path = getattr(args, "override", None)
+    source_mode = "auto"
+    base_result: BoardParseResult | None = None
+    detection: GridDetection | None = None
+    auto_error: str | None = None
+
+    # manual-first: if manual-grid is provided, do not depend on auto parsing as the main source.
+    if manual_grid is not None:
+        source_mode = "manual"
+        base_grid = manual_grid
+        # optional detection for bbox/overlay only; never blocks manual flow
+        try:
+            detection = detect_grid(gray, spec)
+        except GridDetectionError:
+            detection = None
+    else:
+        try:
+            detection = detect_grid(gray, spec)
+            base_result = structure_board(
+                sample_id=Path(args.image).stem,
+                image_path=args.image,
+                detection=detection,
+                spec=spec,
+                ticket_type=spec.size_class,
+            )
+            base_grid = [row[:] for row in base_result.grid]
+        except GridDetectionError as exc:
+            auto_error = str(exc)
+            if override_path is None:
+                return {
+                    "status": auto_error or "needs_manual_review",
+                    "source_mode": "auto",
+                    "contract_passed": False,
+                    "needs_manual_review": True,
+                }
+            base_grid = [
+                [None for _ in range(spec.expected_cols)]
+                for _ in range(spec.expected_rows)
+            ]
+            manual_states = [
+                ["unknown" for _ in range(spec.expected_cols)]
+                for _ in range(spec.expected_rows)
+            ]
+            source_mode = "manual"
+
+    override_audit = []
+    if override_path:
+        base_grid, override_audit = apply_overrides(base_grid, override_path)
+        source_mode = "hybrid" if source_mode in ("manual", "auto") else source_mode
+
+    final_result = (
+        _manual_result_from_grid(args.image, spec, base_grid, manual_states=manual_states)
+        if source_mode in ("manual", "hybrid")
+        else base_result
+    )
+    assert final_result is not None
+
+    contract = evaluate_board_contract(
+        grid=final_result.grid,
+        spec=spec,
+        parse_confidence=float(final_result.final_parse_confidence),
+        low_confidence_cells=final_result.low_confidence_cells,
+        min_confidence=0.55,
+        max_low_conf_cells=8,
+        strict=getattr(args, "strict", False),
+    )
+    status = "ok" if contract.contract_passed else contract.status
+    payload = build_output_schema(
+        status=status,
+        source_mode=source_mode,
+        shape=final_result.shape,
+        grid=final_result.grid,
+        black_cells=final_result.black_cells,
+        low_confidence_cells=final_result.low_confidence_cells,
+        parse_confidence=float(final_result.final_parse_confidence),
+        contract=contract,
+        parse_diagnostics={
+            **final_result.parse_diagnostics,
+            "override_audit": override_audit,
+            "board_bbox": detection.board_bbox if detection else None,
+            "parse_policy": "manual_first",
+            "manual_cell_states": manual_states,
+        },
+    )
+    payload["cell_boxes"] = final_result.cell_boxes
+    payload["bounding_boxes"] = {
+        "board_bbox": detection.board_bbox if detection else None
+    }
+
+    query_number = getattr(args, "query_number", None)
+    if query_number is not None:
+        payload["query_result"] = find_number_positions(
+            final_result.grid, int(query_number)
+        )
+
+    if payload.get("contract_passed"):
+        out_json = getattr(args, "output_json", "reports/parsed_board.json")
+        out_csv = getattr(args, "output_csv", "reports/parsed_board.csv")
+        write_board_json(final_result, Path(out_json))
+        write_board_csv(final_result, Path(out_csv))
+        output_overlay = getattr(
+            args, "output_overlay", "reports/parsed_board_overlay.png"
+        )
+        if (
+            not getattr(args, "no_overlay", False)
+            and output_overlay
+            and detection is not None
+        ):
+            write_overlay(final_result, detection, args.image, Path(output_overlay))
+            payload["overlay_path"] = output_overlay
+
+    payload = json.loads(json.dumps(payload, default=lambda o: int(o)))
+    return payload
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--image", required=True)
-    parser.add_argument("--config", default="configs/board_parse.yaml")
+    parser.add_argument("--rows", type=int, default=None)
+    parser.add_argument("--cols", type=int, default=None)
+    parser.add_argument("--size-class", choices=["20", "80", "120"], default=None)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--manual-grid", default=None)
+    parser.add_argument("--override", default=None)
+    parser.add_argument("--query-number", type=int, default=None)
+    parser.add_argument("--output-json", default="reports/parsed_board.json")
+    parser.add_argument("--output-csv", default="reports/parsed_board.csv")
+    parser.add_argument("--output-overlay", default="reports/parsed_board_overlay.png")
+    parser.add_argument("--no-overlay", action="store_true")
     args = parser.parse_args()
 
-    cfg = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
-    gray = cv2.imread(args.image, cv2.IMREAD_GRAYSCALE)
-    if gray is None:
-        raise ValueError(f"cannot_read_image: {args.image}")
+    try:
+        payload = parse_image_hybrid(args)
+    except ManualInputError as exc:
+        print(
+            json.dumps(
+                {"status": str(exc), "needs_manual_review": True}, ensure_ascii=False
+            )
+        )
+        raise SystemExit(2)
 
-    det = detect_grid(gray)
-    result = structure_board(sample_id=Path(args.image).stem, image_path=args.image, detection=det)
-
-    write_board_json(result, Path(cfg["outputs"]["json"]))
-    write_board_csv(result, Path(cfg["outputs"]["csv"]))
-    write_overlay(result, det, args.image, Path(cfg["outputs"]["overlay"]))
-
-    print(grid_to_text(result.grid))
-    print(json.dumps({
-        "shape": result.shape,
-        "parse_confidence": result.parse_confidence,
-        "low_confidence_cells": len(result.low_confidence_cells),
-    }, ensure_ascii=False))
+    print("=== GRID ===")
+    print(grid_to_text(payload.get("grid", [])))
+    print("=== NUMBERS ===")
+    print(payload.get("numbers_all", []))
+    if "query_result" in payload:
+        print("=== QUERY ===")
+        print(json.dumps(payload["query_result"], ensure_ascii=False))
+    print(json.dumps(payload, ensure_ascii=False, default=lambda o: int(o)))
+    if not payload.get("contract_passed"):
+        raise SystemExit(2)
 
 
 if __name__ == "__main__":

--- a/scripts/run_single_image_predict.py
+++ b/scripts/run_single_image_predict.py
@@ -6,71 +6,116 @@ import json
 import sys
 from pathlib import Path
 
-import cv2
 import numpy as np
-import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.board_export import grid_to_text, write_board_csv, write_board_json, write_overlay  # noqa: E402
-from src.board_structurer import structure_board  # noqa: E402
-from src.grid_detector import detect_grid  # noqa: E402
-from src.masking_eval.candidate_scoring import legal_candidates, score_candidate  # noqa: E402
+from scripts.parse_board_image import parse_image_hybrid  # noqa: E402
+from src.board_export import grid_to_text  # noqa: E402
+from src.masking_eval.candidate_scoring import (
+    legal_candidates,
+    score_candidate,
+)  # noqa: E402
 from src.masking_eval.modules import BASE_MODULES  # noqa: E402
+from src.number_position_predictor import predict_number_positions  # noqa: E402
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--image", required=True)
-    parser.add_argument("--target-row", type=int, required=True)
-    parser.add_argument("--target-col", type=int, required=True)
-    parser.add_argument("--config", default="configs/board_parse.yaml")
+    parser.add_argument("--rows", type=int, default=None)
+    parser.add_argument("--cols", type=int, default=None)
+    parser.add_argument("--size-class", choices=["20", "80", "120"], default=None)
+    parser.add_argument("--manual-grid", default=None)
+    parser.add_argument("--override", default=None)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--target-row", type=int)
+    parser.add_argument("--target-col", type=int)
+    parser.add_argument("--query-number", type=int)
     args = parser.parse_args()
 
-    cfg = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
-    gray = cv2.imread(args.image, cv2.IMREAD_GRAYSCALE)
-    if gray is None:
-        raise ValueError(f"cannot_read_image: {args.image}")
-    det = detect_grid(gray)
-    result = structure_board(sample_id=Path(args.image).stem, image_path=args.image, detection=det)
+    mode_a = args.target_row is not None or args.target_col is not None
+    mode_b = args.query_number is not None
+    if mode_a and mode_b:
+        raise ValueError("mode_conflict")
+    if not mode_a and not mode_b:
+        raise ValueError("mode_required")
+    if mode_a and (args.target_row is None or args.target_col is None):
+        raise ValueError("target_row_col_required")
 
-    write_board_json(result, Path(cfg["outputs"]["json"]))
-    write_board_csv(result, Path(cfg["outputs"]["csv"]))
-    write_overlay(result, det, args.image, Path(cfg["outputs"]["overlay"]))
+    payload = parse_image_hybrid(args)
+    if not payload.get("contract_passed"):
+        print(
+            json.dumps(
+                {
+                    "status": "reject_prediction",
+                    "reason": payload.get("status"),
+                    "source_mode": payload.get("source_mode"),
+                    "contract_passed": False,
+                },
+                ensure_ascii=False,
+            )
+        )
+        raise SystemExit(2)
 
-    grid = np.array([[v if v is not None else -1 for v in row] for row in result.grid], dtype=int)
-    tr, tc = args.target_row, args.target_col
-    if not (0 <= tr < grid.shape[0] and 0 <= tc < grid.shape[1]):
-        raise ValueError("target out of range")
-    if grid[tr, tc] != -1:
-        grid[tr, tc] = -1
-
-    if result.parse_confidence < float(cfg["parser"]["min_confidence"]):
-        low = {"status": "parse_confidence_too_low", "parse_confidence": result.parse_confidence}
-        Path("reports/predict_summary.json").write_text(json.dumps(low, indent=2, ensure_ascii=False), encoding="utf-8")
-        print(json.dumps(low, ensure_ascii=False))
+    if mode_b:
+        query = predict_number_positions(
+            grid=payload["grid"],
+            query_number=int(args.query_number),
+            missing_values=payload.get("missing_values", []),
+            low_confidence_cells=payload.get("low_confidence_cells", []),
+            black_cells=payload.get("black_cells", []),
+            manual_override_cells={
+                (x["row"] + 1, x["col"] + 1)
+                for x in payload.get("parse_diagnostics", {}).get("override_audit", [])
+                if "row" in x and "col" in x
+            },
+        )
+        out = {
+            "mode": "query_number_position",
+            "source_mode": payload.get("source_mode"),
+            "contract_passed": payload.get("contract_passed"),
+            "grid_preview": grid_to_text(payload["grid"]),
+            **query,
+        }
+        print(json.dumps(out, indent=2, ensure_ascii=False))
         return
 
+    grid = np.array(
+        [[v if v is not None else -1 for v in row] for row in payload["grid"]],
+        dtype=int,
+    )
+    tr, tc = int(args.target_row), int(args.target_col)
+    if not (0 <= tr < grid.shape[0] and 0 <= tc < grid.shape[1]):
+        raise ValueError("target_out_of_range")
+    if grid[tr, tc] != -1:
+        grid[tr, tc] = -1
     candidates = legal_candidates(grid)
     weights = {m: 1.0 for m in BASE_MODULES}
     scored = []
     for cand in candidates:
-        feats = score_candidate(grid, (tr, tc), cand, heatmap_prior=None, modules=BASE_MODULES)
-        scored.append({"candidate": cand, "score": float(sum(feats[k] * weights[k] for k in feats))})
+        feats = score_candidate(
+            grid, (tr, tc), cand, heatmap_prior=None, modules=BASE_MODULES
+        )
+        scored.append(
+            {
+                "candidate": cand,
+                "score": float(sum(feats[k] * weights[k] for k in feats)),
+            }
+        )
     scored.sort(key=lambda x: x["score"], reverse=True)
 
     out = {
-        "shape": result.shape,
-        "parse_confidence": result.parse_confidence,
-        "target_cell": [tr, tc],
+        "mode": "target_cell_digit",
+        "source_mode": payload.get("source_mode"),
+        "contract_passed": payload.get("contract_passed"),
+        "grid_preview": grid_to_text(payload["grid"]),
         "top1": scored[:1],
         "top3": scored[:3],
         "top5": scored[:5],
-        "grid_preview": grid_to_text(result.grid),
     }
-    Path("reports/predict_summary.json").write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
     print(json.dumps(out, indent=2, ensure_ascii=False))
 
 

--- a/src/board_contracts.py
+++ b/src/board_contracts.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from .board_query import build_value_to_position
+from .ticket_specs import TicketSpec
+
+
+@dataclass
+class ContractResult:
+    status: str
+    contract_passed: bool
+    needs_manual_review: bool
+    shape_ok: bool
+    confidence_ok: bool
+    low_conf_ok: bool
+    complete_grid: bool
+    missing_values: List[int]
+    duplicate_values: List[int]
+    rows: int
+    cols: int
+
+
+def evaluate_board_contract(
+    grid: List[List[Optional[int]]],
+    spec: TicketSpec,
+    parse_confidence: float,
+    low_confidence_cells: List[Dict[str, object]],
+    min_confidence: float = 0.55,
+    max_low_conf_cells: int = 8,
+    strict: bool = False,
+) -> ContractResult:
+    rows = len(grid)
+    cols = len(grid[0]) if rows else 0
+    shape_ok = (rows, cols) == spec.expected_shape
+    numbers = [int(v) for row in grid for v in row if v is not None]
+    legal = spec.legal_values
+    illegal = sorted({v for v in numbers if v not in legal})
+    dupes = sorted({v for v in numbers if numbers.count(v) > 1})
+    missing = sorted(list(legal - set(numbers)))
+    complete = len(missing) == 0
+    confidence_ok = parse_confidence >= min_confidence
+    low_conf_ok = len(low_confidence_cells) <= max_low_conf_cells
+
+    if not shape_ok:
+        status = "shape_mismatch"
+    elif not confidence_ok:
+        status = "low_confidence_parse"
+    elif strict and (dupes or illegal):
+        status = "contract_violation"
+    elif strict and not complete:
+        status = "incomplete_grid"
+    elif not low_conf_ok:
+        status = "needs_manual_review"
+    else:
+        status = "ok"
+
+    needs_review = status in (
+        "shape_mismatch",
+        "low_confidence_parse",
+        "incomplete_grid",
+        "needs_manual_review",
+        "contract_violation",
+    )
+    return ContractResult(
+        status=status,
+        contract_passed=(status == "ok"),
+        needs_manual_review=needs_review,
+        shape_ok=shape_ok,
+        confidence_ok=confidence_ok,
+        low_conf_ok=low_conf_ok,
+        complete_grid=complete,
+        missing_values=missing,
+        duplicate_values=dupes + illegal,
+        rows=rows,
+        cols=cols,
+    )
+
+
+def build_output_schema(
+    *,
+    status: str,
+    source_mode: str,
+    shape: str,
+    grid: List[List[Optional[int]]],
+    black_cells: List[Dict[str, int]],
+    low_confidence_cells: List[Dict[str, object]],
+    parse_confidence: float,
+    contract: ContractResult,
+    parse_diagnostics: Dict[str, object],
+) -> Dict[str, object]:
+    value_to_position = build_value_to_position(grid)
+    numbers_all = sorted([int(v) for row in grid for v in row if v is not None])
+    return {
+        "status": status,
+        "source_mode": source_mode,
+        "shape": shape,
+        "rows": contract.rows,
+        "cols": contract.cols,
+        "grid": grid,
+        "numbers_all": numbers_all,
+        "value_to_position": value_to_position,
+        "black_cells": black_cells,
+        "missing_values": contract.missing_values,
+        "legal_value_min": 1,
+        "legal_value_max": contract.rows * contract.cols,
+        "low_confidence_cells": low_confidence_cells,
+        "parse_confidence": parse_confidence,
+        "contract_passed": contract.contract_passed,
+        "needs_manual_review": contract.needs_manual_review,
+        "parse_diagnostics": parse_diagnostics,
+    }

--- a/src/board_export.py
+++ b/src/board_export.py
@@ -21,7 +21,9 @@ def grid_to_text(grid: List[List[Optional[int]]]) -> str:
 
 def write_board_json(result: BoardParseResult, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(asdict(result), indent=2, ensure_ascii=False), encoding="utf-8")
+    path.write_text(
+        json.dumps(asdict(result), indent=2, ensure_ascii=False), encoding="utf-8"
+    )
 
 
 def write_board_csv(result: BoardParseResult, path: Path) -> None:
@@ -31,7 +33,9 @@ def write_board_csv(result: BoardParseResult, path: Path) -> None:
         writer.writerows(result.grid)
 
 
-def write_overlay(result: BoardParseResult, det: GridDetection, image_path: str, output_path: Path) -> None:
+def write_overlay(
+    result: BoardParseResult, det: GridDetection, image_path: str, output_path: Path
+) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     img = cv2.imread(image_path)
     if img is None:
@@ -39,13 +43,32 @@ def write_overlay(result: BoardParseResult, det: GridDetection, image_path: str,
     x, y, bw, bh = det.board_bbox
     vis = img.copy()
     cv2.rectangle(vis, (x, y), (x + bw, y + bh), (0, 255, 0), 2)
-    for r in range(result.row_count):
-        for c in range(result.col_count):
-            yy0, yy1 = det.row_lines[r], det.row_lines[r + 1]
-            xx0, xx1 = det.col_lines[c], det.col_lines[c + 1]
-            p0 = (x + xx0, y + yy0)
-            p1 = (x + xx1, y + yy1)
-            cv2.rectangle(vis, p0, p1, (255, 120, 0), 1)
-            txt = str(result.grid[r][c]) if result.grid[r][c] is not None else "□"
-            cv2.putText(vis, txt, (p0[0] + 3, p0[1] + 15), cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 0, 255), 1)
+
+    pending = {
+        (int(c.get("row", -1)), int(c.get("col", -1))) for c in result.pending_cells
+    }
+    for box in result.cell_boxes:
+        r0 = int(box["row_1based"]) - 1
+        c0 = int(box["col_1based"]) - 1
+        p0 = (x + int(box["x0"]), y + int(box["y0"]))
+        p1 = (x + int(box["x1"]), y + int(box["y1"]))
+        color = (255, 120, 0)
+        if (r0, c0) in pending:
+            color = (0, 0, 255)
+        cv2.rectangle(vis, p0, p1, color, 1)
+        if box.get("label") == "solid_black":
+            txt = "#"
+        elif box.get("value") is None:
+            txt = "?"
+        else:
+            txt = str(box["value"])
+        cv2.putText(
+            vis,
+            txt,
+            (p0[0] + 3, p0[1] + 15),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.45,
+            (0, 0, 255),
+            1,
+        )
     cv2.imwrite(str(output_path), vis)

--- a/src/board_export.py
+++ b/src/board_export.py
@@ -56,12 +56,17 @@ def write_overlay(
         if (r0, c0) in pending:
             color = (0, 0, 255)
         cv2.rectangle(vis, p0, p1, color, 1)
-        if box.get("label") == "solid_black":
-            txt = "#"
+        label = str(box.get("label", "unknown"))
+        if label == "black":
+            txt = f"r{r0+1}c{c0+1} #"
         elif box.get("value") is None:
-            txt = "?"
+            txt = f"r{r0+1}c{c0+1} ? {label}"
         else:
-            txt = str(box["value"])
+            txt = (
+                f"r{r0+1}c{c0+1} "
+                f"{box['value']} "
+                f"{float(box.get('confidence', 0.0)):.2f}"
+            )
         cv2.putText(
             vis,
             txt,

--- a/src/board_manifest.py
+++ b/src/board_manifest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Literal
+from typing import Dict, List, Literal, Optional
 
 SizeClass = Literal["20", "80", "120"]
 
@@ -17,6 +17,8 @@ class ManifestEntry:
     source_folder: str
     valid: bool
     invalid_reason: str | None = None
+    manual_grid: Optional[str] = None
+    override: Optional[str] = None
 
 
 @dataclass

--- a/src/board_query.py
+++ b/src/board_query.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+
+def build_value_to_position(
+    grid: List[List[Optional[int]]],
+) -> Dict[str, List[Dict[str, int]]]:
+    out: Dict[str, List[Dict[str, int]]] = {}
+    for r, row in enumerate(grid):
+        for c, v in enumerate(row):
+            if v is None:
+                continue
+            key = str(int(v))
+            out.setdefault(key, []).append(
+                {
+                    "row_1based": r + 1,
+                    "col_1based": c + 1,
+                    "row_0based": r,
+                    "col_0based": c,
+                }
+            )
+    return out
+
+
+def find_number_positions(
+    grid: List[List[Optional[int]]], value: int
+) -> Dict[str, object]:
+    value_to_position = build_value_to_position(grid)
+    positions = value_to_position.get(str(value), [])
+    return {
+        "value": value,
+        "positions": positions,
+        "found": len(positions) > 0,
+        "contract_violation": len(positions) > 1,
+        "status": "found" if positions else "not_found",
+    }

--- a/src/board_solver.py
+++ b/src/board_solver.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from .ticket_specs import TicketSpec
+
+
+@dataclass
+class SolverResult:
+    grid: List[List[Optional[int]]]
+    pending_cells: List[Dict[str, object]]
+    consistency_confidence: float
+    duplicates: List[int]
+    missing_values: List[int]
+
+
+def solve_board(
+    grid: List[List[Optional[int]]],
+    cell_candidates: Dict[tuple[int, int], List[int]],
+    cell_labels: Dict[tuple[int, int], str],
+    spec: TicketSpec,
+) -> SolverResult:
+    legal = spec.legal_values
+    out = [row[:] for row in grid]
+    pending: List[Dict[str, object]] = []
+
+    seen: Dict[int, tuple[int, int]] = {}
+    duplicates: List[int] = []
+    for r, row in enumerate(out):
+        for c, v in enumerate(row):
+            if v is None:
+                continue
+            if v not in legal:
+                out[r][c] = None
+                pending.append({"row": r, "col": c, "reason": "illegal_value"})
+                continue
+            if v in seen:
+                duplicates.append(v)
+                out[r][c] = None
+                pending.append({"row": r, "col": c, "reason": "duplicate_value"})
+            else:
+                seen[v] = (r, c)
+
+    present = {v for row in out for v in row if v is not None}
+    missing = sorted(list(legal - present))
+
+    for r, row in enumerate(out):
+        for c, v in enumerate(row):
+            label = cell_labels.get((r, c), "printed_number")
+            if label == "solid_black":
+                out[r][c] = None
+                continue
+            if v is not None:
+                continue
+            cands = [x for x in cell_candidates.get((r, c), []) if x in missing]
+            if len(cands) == 1:
+                out[r][c] = cands[0]
+                missing.remove(cands[0])
+            else:
+                pending.append({"row": r, "col": c, "reason": "pending_review", "candidates": cands[:3]})
+
+    final_present = {v for row in out for v in row if v is not None}
+    final_missing = sorted(list(legal - final_present))
+    conf = max(0.0, min(1.0, 1.0 - len(final_missing) / max(len(legal), 1)))
+    return SolverResult(
+        grid=out,
+        pending_cells=pending,
+        consistency_confidence=conf,
+        duplicates=sorted(set(duplicates)),
+        missing_values=final_missing,
+    )

--- a/src/board_structurer.py
+++ b/src/board_structurer.py
@@ -90,6 +90,12 @@ def structure_board(
             cell = _cell_crop(detection.board_image, y0, y1, x0, x1)
             cls = classify_cell(cell)
             class_conf.append(cls.confidence)
+            normalized_label = {
+                "blank": "empty",
+                "solid_black": "black",
+                "scratched_or_occluded": "unknown",
+                "printed_number": "number",
+            }.get(cls.label, "unknown")
             cell_boxes.append(
                 {
                     "row_1based": r + 1,
@@ -98,9 +104,10 @@ def structure_board(
                     "y0": y0,
                     "x1": x1,
                     "y1": y1,
-                    "label": cls.label,
+                    "label": normalized_label,
                     "value": None,
                     "confidence": float(cls.confidence),
+                    "top_candidates": [],
                 }
             )
             cell_labels[(r, c)] = cls.label
@@ -114,6 +121,7 @@ def structure_board(
             ocr_backend = digit.ocr_backend
             digit_conf.append(digit.confidence)
             cell_candidates[(r, c)] = [int(x["value"]) for x in digit.top_candidates]
+            cell_boxes[-1]["top_candidates"] = digit.top_candidates
             conf[r][c] = 0.4 * cls.confidence + 0.6 * digit.confidence
             if digit.value is None:
                 low.append(
@@ -124,6 +132,7 @@ def structure_board(
                         "needs_review": True,
                     }
                 )
+                cell_boxes[-1]["label"] = "unknown"
                 continue
             grid[r][c] = int(digit.value)
             cell_boxes[-1]["value"] = int(digit.value)

--- a/src/board_structurer.py
+++ b/src/board_structurer.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import numpy as np
 
-from .cell_classifier import classify_cell_empty_or_filled
+from .board_solver import solve_board
+from .cell_classifier import classify_cell
 from .cell_digit_reader import read_cell_digit
 from .grid_detector import GridDetection
+from .ticket_specs import TicketSpec
 
 
 @dataclass
@@ -22,6 +24,24 @@ class BoardParseResult:
     parse_confidence: float
     image_path: str
     ticket_type: str | None
+    board_confidence: float
+    warp_confidence: float
+    shape_confidence: float
+    cell_class_confidence_mean: float
+    digit_confidence_mean: float
+    global_consistency_confidence: float
+    final_parse_confidence: float
+    numbers_all: List[int]
+    value_to_position: Dict[str, List[Dict[str, int]]]
+    missing_values: List[int]
+    black_cells: List[Dict[str, int]]
+    pending_cells: List[Dict[str, object]]
+    parse_diagnostics: Dict[str, object]
+    cell_boxes: List[Dict[str, object]]
+
+
+class BoardStructureError(ValueError):
+    pass
 
 
 def _cell_crop(board: np.ndarray, y0: int, y1: int, x0: int, x1: int) -> np.ndarray:
@@ -30,71 +50,146 @@ def _cell_crop(board: np.ndarray, y0: int, y1: int, x0: int, x1: int) -> np.ndar
     return board[y0 + pad_y : y1 - pad_y, x0 + pad_x : x1 - pad_x]
 
 
+def find_number_positions(
+    grid: List[List[Optional[int]]], value: int
+) -> List[Dict[str, int]]:
+    out: List[Dict[str, int]] = []
+    for r, row in enumerate(grid):
+        for c, v in enumerate(row):
+            if v == value:
+                out.append({"row": r + 1, "col": c + 1, "row0": r, "col0": c})
+    return out
+
+
 def structure_board(
     sample_id: str,
     image_path: str,
     detection: GridDetection,
+    spec: TicketSpec,
     ticket_type: str | None = None,
 ) -> BoardParseResult:
     rows, cols = detection.row_count, detection.col_count
+    if (rows, cols) != spec.expected_shape:
+        raise BoardStructureError("shape_mismatch")
     max_value = rows * cols
     grid: List[List[Optional[int]]] = [[None for _ in range(cols)] for _ in range(rows)]
     conf: List[List[float]] = [[0.0 for _ in range(cols)] for _ in range(rows)]
     low: List[Dict[str, object]] = []
+    class_conf: List[float] = []
+    digit_conf: List[float] = []
+    black_cells: List[Dict[str, int]] = []
+    cell_candidates: Dict[tuple[int, int], List[int]] = {}
+    cell_labels: Dict[tuple[int, int], str] = {}
+    ocr_backend = "fallback_template"
+    cell_boxes: List[Dict[str, object]] = []
 
     for r in range(rows):
         for c in range(cols):
             y0, y1 = detection.row_lines[r], detection.row_lines[r + 1]
             x0, x1 = detection.col_lines[c], detection.col_lines[c + 1]
             cell = _cell_crop(detection.board_image, y0, y1, x0, x1)
-            filled = classify_cell_empty_or_filled(cell)
-            if not filled.is_filled:
-                conf[r][c] = filled.confidence
+            cls = classify_cell(cell)
+            class_conf.append(cls.confidence)
+            cell_boxes.append(
+                {
+                    "row_1based": r + 1,
+                    "col_1based": c + 1,
+                    "x0": x0,
+                    "y0": y0,
+                    "x1": x1,
+                    "y1": y1,
+                    "label": cls.label,
+                    "value": None,
+                    "confidence": float(cls.confidence),
+                }
+            )
+            cell_labels[(r, c)] = cls.label
+            conf[r][c] = cls.confidence
+            if cls.label == "blank":
+                continue
+            if cls.label == "solid_black":
+                black_cells.append({"row": r + 1, "col": c + 1})
                 continue
             digit = read_cell_digit(cell, max_value=max_value)
-            comb_conf = 0.5 * filled.confidence + 0.5 * digit.confidence
-            conf[r][c] = comb_conf
+            ocr_backend = digit.ocr_backend
+            digit_conf.append(digit.confidence)
+            cell_candidates[(r, c)] = [int(x["value"]) for x in digit.top_candidates]
+            conf[r][c] = 0.4 * cls.confidence + 0.6 * digit.confidence
             if digit.value is None:
-                low.append({"row": r, "col": c, "reason": "digit_low_confidence"})
+                low.append(
+                    {
+                        "row": r,
+                        "col": c,
+                        "reason": "digit_low_confidence",
+                        "needs_review": True,
+                    }
+                )
                 continue
             grid[r][c] = int(digit.value)
+            cell_boxes[-1]["value"] = int(digit.value)
+            cell_boxes[-1]["confidence"] = float(conf[r][c])
+            if cls.needs_review:
+                low.append(
+                    {
+                        "row": r,
+                        "col": c,
+                        "reason": "classification_low_confidence",
+                        "needs_review": True,
+                    }
+                )
 
-    # structural correction: duplicates beyond one occurrence become low confidence nulls
-    seen: Dict[int, Tuple[int, int, float]] = {}
-    for r in range(rows):
-        for c in range(cols):
-            v = grid[r][c]
-            if v is None:
-                continue
-            if v < 1 or v > max_value:
-                grid[r][c] = None
-                low.append({"row": r, "col": c, "reason": "out_of_range"})
-                continue
-            if v in seen:
-                pr, pc, pconf = seen[v]
-                if conf[r][c] > pconf:
-                    grid[pr][pc] = None
-                    low.append({"row": pr, "col": pc, "reason": "duplicate_value"})
-                    seen[v] = (r, c, conf[r][c])
-                else:
-                    grid[r][c] = None
-                    low.append({"row": r, "col": c, "reason": "duplicate_value"})
-            else:
-                seen[v] = (r, c, conf[r][c])
+    solved = solve_board(
+        grid=grid, cell_candidates=cell_candidates, cell_labels=cell_labels, spec=spec
+    )
+    final_grid = solved.grid
+    low.extend(solved.pending_cells)
 
-    filled_ratio = float(np.mean([[1.0 if x is not None else 0.0 for x in row] for row in grid]))
+    numbers_all = sorted([int(v) for row in final_grid for v in row if v is not None])
+    value_to_position: Dict[str, List[Dict[str, int]]] = {}
+    for v in numbers_all:
+        key = str(v)
+        if key not in value_to_position:
+            value_to_position[key] = find_number_positions(final_grid, v)
+
+    c_class = float(np.mean(class_conf)) if class_conf else 0.0
+    d_conf = float(np.mean(digit_conf)) if digit_conf else 0.0
     mean_conf = float(np.mean(np.array(conf))) if rows and cols else 0.0
-    parse_conf = max(0.0, min(1.0, 0.5 * detection.confidence + 0.3 * mean_conf + 0.2 * filled_ratio))
+    final_parse_conf = max(
+        0.0,
+        min(
+            1.0,
+            0.16 * detection.board_confidence
+            + 0.16 * detection.warp_confidence
+            + 0.16 * detection.shape_confidence
+            + 0.16 * c_class
+            + 0.16 * d_conf
+            + 0.20 * solved.consistency_confidence,
+        ),
+    )
 
     return BoardParseResult(
         sample_id=sample_id,
         shape=f"{rows}x{cols}",
         row_count=rows,
         col_count=cols,
-        grid=grid,
+        grid=final_grid,
         cell_confidence=conf,
         low_confidence_cells=low,
-        parse_confidence=parse_conf,
+        parse_confidence=mean_conf,
         image_path=image_path,
         ticket_type=ticket_type,
+        board_confidence=detection.board_confidence,
+        warp_confidence=detection.warp_confidence,
+        shape_confidence=detection.shape_confidence,
+        cell_class_confidence_mean=c_class,
+        digit_confidence_mean=d_conf,
+        global_consistency_confidence=solved.consistency_confidence,
+        final_parse_confidence=final_parse_conf,
+        numbers_all=numbers_all,
+        value_to_position=value_to_position,
+        missing_values=solved.missing_values,
+        black_cells=black_cells,
+        pending_cells=solved.pending_cells,
+        parse_diagnostics={"ocr_backend": ocr_backend, "duplicates": solved.duplicates},
+        cell_boxes=cell_boxes,
     )

--- a/src/cell_classifier.py
+++ b/src/cell_classifier.py
@@ -8,19 +8,44 @@ import numpy as np
 
 @dataclass
 class CellClassifyResult:
-    is_filled: bool
+    label: str
     confidence: float
-    ink_ratio: float
+    features: dict[str, float]
+    needs_review: bool
 
 
-def classify_cell_empty_or_filled(cell: np.ndarray) -> CellClassifyResult:
+LABELS = ("blank", "printed_number", "scratched_or_occluded", "solid_black")
+
+
+def classify_cell(cell: np.ndarray) -> CellClassifyResult:
     if cell.size == 0:
-        return CellClassifyResult(is_filled=False, confidence=0.0, ink_ratio=0.0)
+        return CellClassifyResult("blank", 0.0, {"ink_ratio": 0.0}, True)
+
     blur = cv2.GaussianBlur(cell, (3, 3), 0)
     _, bw = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
     ink_ratio = float(np.mean(bw > 0))
-    # conservative threshold: mostly blank stays empty
-    is_filled = ink_ratio > 0.035
-    margin = abs(ink_ratio - 0.035)
-    conf = max(0.0, min(1.0, margin / 0.10))
-    return CellClassifyResult(is_filled=is_filled, confidence=conf, ink_ratio=ink_ratio)
+    ncc, _labels, stats, _ = cv2.connectedComponentsWithStats(bw, 8)
+    comp_areas = stats[1:, cv2.CC_STAT_AREA] if ncc > 1 else np.array([])
+    comp_count = float(len(comp_areas))
+    max_comp = float(np.max(comp_areas)) / float(cell.size) if len(comp_areas) else 0.0
+
+    if ink_ratio < 0.02:
+        label = "blank"
+        conf = 1.0 - min(1.0, ink_ratio / 0.02)
+    elif ink_ratio > 0.75 or max_comp > 0.7:
+        label = "solid_black"
+        conf = min(1.0, ink_ratio)
+    elif comp_count >= 6 or (ink_ratio > 0.30 and max_comp < 0.25):
+        label = "scratched_or_occluded"
+        conf = 0.55
+    else:
+        label = "printed_number"
+        conf = max(0.4, min(0.95, 1.0 - abs(ink_ratio - 0.16) * 3.5))
+
+    needs_review = conf < 0.65 or label == "scratched_or_occluded"
+    return CellClassifyResult(
+        label=label,
+        confidence=conf,
+        features={"ink_ratio": ink_ratio, "component_count": comp_count, "max_component_ratio": max_comp},
+        needs_review=needs_review,
+    )

--- a/src/cell_digit_reader.py
+++ b/src/cell_digit_reader.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Dict, Tuple
 
 import cv2
 import numpy as np
@@ -12,62 +11,62 @@ import numpy as np
 class DigitReadResult:
     value: int | None
     confidence: float
+    top_candidates: list[dict[str, float | int]]
+    ocr_backend: str
 
 
-def _prep(img: np.ndarray, size: int = 40) -> np.ndarray:
+def _normalize_cell(img: np.ndarray, size: int = 56) -> np.ndarray:
     if img.size == 0:
         return np.zeros((size, size), dtype=np.uint8)
-    _, bw = cv2.threshold(img, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+    den = cv2.fastNlMeansDenoising(img, h=12)
+    _, bw = cv2.threshold(den, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+    bw = cv2.morphologyEx(bw, cv2.MORPH_CLOSE, np.ones((2, 2), dtype=np.uint8))
     ys, xs = np.where(bw > 0)
-    if len(xs) == 0 or len(ys) == 0:
+    if len(xs) == 0:
         return np.zeros((size, size), dtype=np.uint8)
-    x0, x1 = max(0, int(xs.min()) - 1), min(bw.shape[1], int(xs.max()) + 2)
-    y0, y1 = max(0, int(ys.min()) - 1), min(bw.shape[0], int(ys.max()) + 2)
+    x0, x1 = max(0, int(xs.min()) - 2), min(bw.shape[1], int(xs.max()) + 3)
+    y0, y1 = max(0, int(ys.min()) - 2), min(bw.shape[0], int(ys.max()) + 3)
     crop = bw[y0:y1, x0:x1]
     canvas = np.zeros((size, size), dtype=np.uint8)
     scale = min((size - 4) / max(crop.shape[0], 1), (size - 4) / max(crop.shape[1], 1))
-    nh = max(1, int(crop.shape[0] * scale))
-    nw = max(1, int(crop.shape[1] * scale))
+    nh, nw = max(1, int(crop.shape[0] * scale)), max(1, int(crop.shape[1] * scale))
     resized = cv2.resize(crop, (nw, nh), interpolation=cv2.INTER_AREA)
-    yoff = (size - nh) // 2
-    xoff = (size - nw) // 2
+    yoff, xoff = (size - nh) // 2, (size - nw) // 2
     canvas[yoff : yoff + nh, xoff : xoff + nw] = resized
     return canvas
 
 
 @lru_cache(maxsize=16)
-def _templates(max_value: int, size: int = 40) -> Dict[int, np.ndarray]:
-    templates: Dict[int, np.ndarray] = {}
-    for val in range(1, max_value + 1):
-        canvas = np.zeros((size, size), dtype=np.uint8)
-        txt = str(val)
-        font = cv2.FONT_HERSHEY_SIMPLEX
-        fs = 0.6 if val < 100 else 0.45
-        thick = 1
-        ts, _ = cv2.getTextSize(txt, font, fs, thick)
+def _fallback_templates(max_value: int, size: int = 56) -> dict[int, np.ndarray]:
+    tmps: dict[int, np.ndarray] = {}
+    for v in range(1, max_value + 1):
+        c = np.zeros((size, size), dtype=np.uint8)
+        txt = str(v)
+        fs = 0.75 if v < 100 else 0.55
+        ts, _ = cv2.getTextSize(txt, cv2.FONT_HERSHEY_SIMPLEX, fs, 2)
         x = max(1, (size - ts[0]) // 2)
         y = max(ts[1] + 1, (size + ts[1]) // 2)
-        cv2.putText(canvas, txt, (x, y), font, fs, 255, thick, cv2.LINE_AA)
-        templates[val] = canvas
-    return templates
+        cv2.putText(c, txt, (x, y), cv2.FONT_HERSHEY_SIMPLEX, fs, 255, 2, cv2.LINE_AA)
+        tmps[v] = c
+    return tmps
 
 
 def read_cell_digit(cell: np.ndarray, max_value: int) -> DigitReadResult:
-    obs = _prep(cell)
+    obs = _normalize_cell(cell)
     if np.sum(obs) < 20:
-        return DigitReadResult(value=None, confidence=0.0)
-    tpls = _templates(max_value)
-    best: Tuple[int | None, float] = (None, -1.0)
-    second = -1.0
-    for val, tpl in tpls.items():
-        score = float(cv2.matchTemplate(obs, tpl, cv2.TM_CCOEFF_NORMED)[0][0])
-        if score > best[1]:
-            second = best[1]
-            best = (val, score)
-        elif score > second:
-            second = score
-    margin = best[1] - max(second, -1.0)
-    conf = max(0.0, min(1.0, (best[1] + 1.0) / 2.0 * 0.7 + max(margin, 0.0) * 0.3))
-    if conf < 0.55:
-        return DigitReadResult(value=None, confidence=conf)
-    return DigitReadResult(value=best[0], confidence=conf)
+        return DigitReadResult(None, 0.0, [], "fallback_template")
+
+    templates = _fallback_templates(max_value)
+    scored: list[tuple[int, float]] = []
+    for v, tmp in templates.items():
+        score = float(cv2.matchTemplate(obs, tmp, cv2.TM_CCOEFF_NORMED)[0][0])
+        scored.append((v, score))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    top = scored[:5]
+    best_v, best_s = top[0]
+    second_s = top[1][1] if len(top) > 1 else -1.0
+    margin = best_s - second_s
+    conf = max(0.0, min(1.0, ((best_s + 1.0) / 2.0) * 0.75 + max(0.0, margin) * 0.25))
+    top_candidates = [{"value": int(v), "score": float(s)} for v, s in top]
+    value = int(best_v) if conf >= 0.50 else None
+    return DigitReadResult(value=value, confidence=conf, top_candidates=top_candidates, ocr_backend="fallback_template")

--- a/src/grid_detector.py
+++ b/src/grid_detector.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Tuple
 
 import cv2
 import numpy as np
+
+from .ticket_specs import TicketSpec
 
 
 @dataclass
@@ -13,138 +15,126 @@ class GridDetection:
     board_bbox: Tuple[int, int, int, int]
     row_count: int
     col_count: int
-    row_lines: List[int]
-    col_lines: List[int]
-    confidence: float
+    row_lines: list[int]
+    col_lines: list[int]
+    board_confidence: float
+    warp_confidence: float
+    shape_confidence: float
+    cell_boxes: list[dict[str, int]]
 
 
-def _cluster_positions(values: np.ndarray, min_gap: int = 8) -> List[int]:
-    if values.size == 0:
-        return []
-    values = np.sort(values)
-    groups: List[List[int]] = [[int(values[0])]]
-    for v in values[1:]:
-        if int(v) - groups[-1][-1] <= min_gap:
-            groups[-1].append(int(v))
-        else:
-            groups.append([int(v)])
-    return [int(np.mean(g)) for g in groups]
+class GridDetectionError(ValueError):
+    pass
 
 
-def _coarsen_centers(values: np.ndarray, base_gap: int, max_groups: int) -> List[int]:
-    gap = max(base_gap, 4)
-    centers = _cluster_positions(values.astype(int), min_gap=gap)
-    while len(centers) > max_groups and gap < 200:
-        gap = int(gap * 1.35) + 1
-        centers = _cluster_positions(values.astype(int), min_gap=gap)
-    return centers
-
-
-def _detect_board_region(gray: np.ndarray) -> Tuple[np.ndarray, Tuple[int, int, int, int], float]:
+def _find_board_quad(
+    gray: np.ndarray,
+) -> tuple[np.ndarray, tuple[int, int, int, int], float]:
     blur = cv2.GaussianBlur(gray, (5, 5), 0)
-    edges = cv2.Canny(blur, 60, 180)
+    edges = cv2.Canny(blur, 50, 180)
     contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-    h, w = gray.shape
-    area_img = float(h * w)
     if not contours:
-        return gray, (0, 0, w, h), 0.25
+        raise GridDetectionError("perspective_unstable")
 
+    h, w = gray.shape
+    img_area = float(h * w)
     best = max(contours, key=cv2.contourArea)
+    peri = cv2.arcLength(best, True)
+    approx = cv2.approxPolyDP(best, 0.02 * peri, True)
     x, y, bw, bh = cv2.boundingRect(best)
-    area_ratio = (bw * bh) / max(area_img, 1.0)
-    # 80/120 images often have weak outer contour; fallback to full image instead of fail-fast.
-    if area_ratio < 0.05:
-        return gray, (0, 0, w, h), 0.35
-    board = gray[y : y + bh, x : x + bw]
-    conf = min(1.0, max(0.0, area_ratio))
-    return board, (x, y, bw, bh), conf
+    area_ratio = float((bw * bh) / max(img_area, 1.0))
+    if area_ratio < 0.08:
+        _, bw2 = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        ys, xs = np.where(bw2 > 0)
+        if len(xs) < 50 or len(ys) < 50:
+            raise GridDetectionError("perspective_unstable")
+        x0, x1 = int(xs.min()), int(xs.max())
+        y0, y1 = int(ys.min()), int(ys.max())
+        approx = np.array(
+            [[[x0, y0]], [[x1, y0]], [[x1, y1]], [[x0, y1]]], dtype=np.int32
+        )
+        x, y, bw, bh = x0, y0, x1 - x0, y1 - y0
+    if len(approx) != 4:
+        hull = cv2.convexHull(best)
+        peri2 = cv2.arcLength(hull, True)
+        approx = cv2.approxPolyDP(hull, 0.02 * peri2, True)
+    if len(approx) != 4:
+        raise GridDetectionError("perspective_unstable")
+    pts = approx.reshape(4, 2).astype(np.float32)
+    return pts, (x, y, bw, bh), min(1.0, area_ratio + 0.1)
 
 
-def _infer_lines_from_components(bin_img: np.ndarray) -> Tuple[List[int], List[int], float]:
-    n, _labels, stats, cent = cv2.connectedComponentsWithStats(bin_img, 8)
-    if n <= 1:
-        return [], [], 0.0
-    heights = stats[1:, cv2.CC_STAT_HEIGHT]
-    widths = stats[1:, cv2.CC_STAT_WIDTH]
-    areas = stats[1:, cv2.CC_STAT_AREA]
-    valid = (areas > 20) & (areas < 5000) & (heights > 6) & (widths > 3)
-    if np.sum(valid) < 20:
-        return [], [], 0.0
-
-    cx = cent[1:, 0][valid]
-    cy = cent[1:, 1][valid]
-    h_med = float(np.median(heights[valid]))
-    w_med = float(np.median(widths[valid]))
-    row_centers = _coarsen_centers(cy, base_gap=max(6, int(h_med * 0.9)), max_groups=20)
-    col_centers = _coarsen_centers(cx, base_gap=max(8, int(w_med * 1.6)), max_groups=20)
-    if len(row_centers) < 2 or len(col_centers) < 2:
-        return [], [], 0.0
-
-    def centers_to_lines(cs: List[int], limit: int) -> List[int]:
-        cs = sorted(cs)
-        mids = [0]
-        for i in range(len(cs) - 1):
-            mids.append((cs[i] + cs[i + 1]) // 2)
-        mids.append(limit - 1)
-        return mids
-
-    row_lines = centers_to_lines(row_centers, bin_img.shape[0])
-    col_lines = centers_to_lines(col_centers, bin_img.shape[1])
-    conf = min(0.75, 0.3 + 0.01 * len(row_centers) + 0.01 * len(col_centers))
-    return row_lines, col_lines, conf
+def _order_quad(pts: np.ndarray) -> np.ndarray:
+    s = pts.sum(axis=1)
+    d = np.diff(pts, axis=1).reshape(-1)
+    ordered = np.zeros((4, 2), dtype=np.float32)
+    ordered[0] = pts[np.argmin(s)]
+    ordered[2] = pts[np.argmax(s)]
+    ordered[1] = pts[np.argmin(d)]
+    ordered[3] = pts[np.argmax(d)]
+    return ordered
 
 
-def detect_grid(gray: np.ndarray) -> GridDetection:
-    board, bbox, board_conf = _detect_board_region(gray)
-    bin_img = cv2.adaptiveThreshold(
-        board,
-        255,
-        cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
-        cv2.THRESH_BINARY_INV,
-        31,
-        5,
+def _warp_to_expected(
+    gray: np.ndarray, quad: np.ndarray, expected_rows: int, expected_cols: int
+) -> tuple[np.ndarray, float]:
+    quad = _order_quad(quad)
+    cell = 64
+    out_w = expected_cols * cell
+    out_h = expected_rows * cell
+    dst = np.array(
+        [[0, 0], [out_w - 1, 0], [out_w - 1, out_h - 1], [0, out_h - 1]],
+        dtype=np.float32,
     )
-    h, w = board.shape
-    hk = cv2.getStructuringElement(cv2.MORPH_RECT, (max(10, w // 20), 1))
-    vk = cv2.getStructuringElement(cv2.MORPH_RECT, (1, max(10, h // 20)))
-    hlines = cv2.morphologyEx(bin_img, cv2.MORPH_OPEN, hk)
-    vlines = cv2.morphologyEx(bin_img, cv2.MORPH_OPEN, vk)
+    m = cv2.getPerspectiveTransform(quad, dst)
+    warped = cv2.warpPerspective(gray, m, (out_w, out_h))
+    det = float(abs(np.linalg.det(m[:2, :2])))
+    conf = max(0.0, min(1.0, 1.0 / (1.0 + abs(np.log(max(det, 1e-6))))))
+    return warped, conf
 
-    row_strength = np.sum(hlines > 0, axis=1)
-    col_strength = np.sum(vlines > 0, axis=0)
-    row_idx = np.where(row_strength > 0.35 * np.max(row_strength))[0] if np.max(row_strength) > 0 else np.array([])
-    col_idx = np.where(col_strength > 0.35 * np.max(col_strength))[0] if np.max(col_strength) > 0 else np.array([])
-    row_lines = _cluster_positions(row_idx, min_gap=max(4, h // 120))
-    col_lines = _cluster_positions(col_idx, min_gap=max(4, w // 120))
-    line_conf = 0.7
 
-    if len(row_lines) < 3 or len(col_lines) < 3:
-        row_lines, col_lines, line_conf = _infer_lines_from_components(bin_img)
+def detect_grid(gray: np.ndarray, spec: TicketSpec) -> GridDetection:
+    quad, bbox, board_conf = _find_board_quad(gray)
+    warped, warp_conf = _warp_to_expected(
+        gray, quad, spec.expected_rows, spec.expected_cols
+    )
 
-    if len(row_lines) < 3 or len(col_lines) < 3:
-        raise ValueError("grid_lines_unstable")
-
-    row_lines = sorted(set([0] + row_lines + [h - 1]))
-    col_lines = sorted(set([0] + col_lines + [w - 1]))
-    row_lines = [x for i, x in enumerate(row_lines) if i == 0 or (x - row_lines[i - 1]) > 6]
-    col_lines = [x for i, x in enumerate(col_lines) if i == 0 or (x - col_lines[i - 1]) > 6]
-
+    row_lines = list(np.linspace(0, warped.shape[0], spec.expected_rows + 1, dtype=int))
+    col_lines = list(np.linspace(0, warped.shape[1], spec.expected_cols + 1, dtype=int))
     row_count = len(row_lines) - 1
     col_count = len(col_lines) - 1
-    if row_count < 2 or col_count < 2:
-        raise ValueError("grid_shape_invalid")
+    if (row_count, col_count) != spec.expected_shape:
+        raise GridDetectionError("shape_mismatch")
 
-    cell_h = np.diff(np.array(row_lines))
-    cell_w = np.diff(np.array(col_lines))
-    var_penalty = float(np.var(cell_h) / max(np.mean(cell_h), 1.0) + np.var(cell_w) / max(np.mean(cell_w), 1.0))
-    conf = max(0.0, min(1.0, (0.5 * board_conf + 0.5 * line_conf) * (1.0 / (1.0 + 0.002 * var_penalty))))
+    edges = cv2.Canny(warped, 60, 180)
+    edge_density = float(np.mean(edges > 0))
+    shape_conf = max(0.0, min(1.0, edge_density * 4.0))
+    if shape_conf < 0.05:
+        raise GridDetectionError("shape_mismatch")
+
+    cell_boxes = []
+    for r in range(row_count):
+        for c in range(col_count):
+            cell_boxes.append(
+                {
+                    "row_1based": r + 1,
+                    "col_1based": c + 1,
+                    "x0": col_lines[c],
+                    "y0": row_lines[r],
+                    "x1": col_lines[c + 1],
+                    "y1": row_lines[r + 1],
+                }
+            )
 
     return GridDetection(
-        board_image=board,
+        board_image=warped,
         board_bbox=bbox,
         row_count=row_count,
         col_count=col_count,
         row_lines=row_lines,
         col_lines=col_lines,
-        confidence=conf,
+        board_confidence=board_conf,
+        warp_confidence=warp_conf,
+        shape_confidence=shape_conf,
+        cell_boxes=cell_boxes,
     )

--- a/src/image_board_parser.py
+++ b/src/image_board_parser.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Optional
 
 import cv2
 import numpy as np
 
 from .board_manifest import ManifestEntry
 from .board_structurer import BoardParseResult, structure_board
-from .grid_detector import detect_grid
-
-SizeClass = Literal["20", "80", "120"]
+from .grid_detector import GridDetectionError, detect_grid
+from .manual_board_input import apply_overrides, load_manual_grid_with_states
+from .ticket_specs import SizeClass, get_ticket_spec, validate_page_contract
 
 
 @dataclass
@@ -22,7 +22,8 @@ class ParsedBoard:
     grid: List[List[Optional[int]]]
     shape: str
     numbers_all: List[int]
-    metadata: Dict[str, str | int | float | bool | list]
+    value_to_position: Dict[str, List[Dict[str, int]]]
+    metadata: Dict[str, str | int | float | bool | list | dict]
 
 
 @dataclass
@@ -32,60 +33,106 @@ class ParseAuditRow:
     parse_success: bool
     parse_confidence: float
     shape: str | None
+    expected_shape: str
+    detected_shape: str | None
+    shape_match: bool
+    complete_grid: bool
+    usable_for_backtest: bool
+    pending_review: bool
+    hard_fail: bool
     unique_values_ok: bool
     missing_values_ok: bool
     maskable_ok: bool
+    ocr_backend: str | None
+    hard_fail_reason: str | None
     invalid_reason: str | None
 
 
-def _merge_pages(image_paths: List[str]) -> np.ndarray:
+def _merge_pages(image_paths: List[str], size_class: str) -> np.ndarray:
+    validate_page_contract(get_ticket_spec(size_class), image_paths)
     imgs = [cv2.imread(p, cv2.IMREAD_GRAYSCALE) for p in image_paths]
     if any(im is None for im in imgs):
         raise ValueError("image_read_failed")
     if len(imgs) == 1:
         return imgs[0]  # type: ignore[return-value]
+
     widths = [im.shape[1] for im in imgs if im is not None]
     target_w = int(np.median(widths))
-    resized = [cv2.resize(im, (target_w, int(im.shape[0] * target_w / im.shape[1]))) for im in imgs if im is not None]
-    return np.vstack(resized)
+    aligned = []
+    for im in imgs:
+        assert im is not None
+        resized = cv2.resize(im, (target_w, int(im.shape[0] * target_w / im.shape[1])))
+        aligned.append(resized)
+    if aligned[0].shape[1] != aligned[1].shape[1]:
+        raise ValueError("page_merge_invalid")
+    merged = np.vstack(aligned)
+    return merged
 
 
-def _validate_board(grid: List[List[Optional[int]]]) -> tuple[bool, bool, bool, str | None]:
-    arr = np.array([[x if x is not None else -1 for x in row] for row in grid], dtype=int)
+def _validate_board(
+    grid: List[List[Optional[int]]], expected_shape: tuple[int, int], strict: bool
+) -> tuple[bool, bool, bool, bool, str | None]:
+    arr = np.array(
+        [[x if x is not None else -1 for x in row] for row in grid], dtype=int
+    )
     if arr.ndim != 2 or arr.size == 0:
-        return False, False, False, "invalid_grid_dim"
-    total = arr.shape[0] * arr.shape[1]
+        return False, False, False, False, "invalid_grid_dim"
+    shape_match = tuple(arr.shape) == expected_shape
     vals = [int(v) for v in arr.flatten().tolist() if v != -1]
     uniq_ok = len(set(vals)) == len(vals)
-    miss_ok = set(vals).issubset(set(range(1, total + 1)))
-    maskable_ok = total >= 2
-    reason = None if (uniq_ok and miss_ok and maskable_ok) else "grid_value_mismatch"
-    return uniq_ok, miss_ok, maskable_ok, reason
+    legal = set(range(1, expected_shape[0] * expected_shape[1] + 1))
+    miss_ok = set(vals).issubset(legal)
+    complete = all(v != -1 for v in arr.flatten().tolist())
+    reason = None
+    if not shape_match:
+        reason = "shape_mismatch"
+    elif not (uniq_ok and miss_ok):
+        reason = "grid_value_mismatch"
+    elif strict and not complete:
+        reason = "incomplete_grid"
+    return uniq_ok, miss_ok, complete, shape_match, reason
 
 
 def parse_manifest_entries(
     manifest: List[ManifestEntry],
     min_confidence: float,
     pending_path: Path | None = None,
-) -> tuple[List[ParsedBoard], List[ParseAuditRow], List[Dict[str, object]], Dict[str, BoardParseResult]]:
+    strict: bool = False,
+) -> tuple[
+    List[ParsedBoard],
+    List[ParseAuditRow],
+    List[Dict[str, object]],
+    Dict[str, BoardParseResult],
+]:
     boards: List[ParsedBoard] = []
     audits: List[ParseAuditRow] = []
     pending: List[Dict[str, object]] = []
     detailed: Dict[str, BoardParseResult] = {}
 
     for entry in manifest:
+        spec = get_ticket_spec(entry.size_class)
+        expected_shape_txt = f"{spec.expected_rows}x{spec.expected_cols}"
         if not entry.valid:
             audits.append(
                 ParseAuditRow(
-                    sample_id=entry.sample_id,
-                    size_class=entry.size_class,
-                    parse_success=False,
-                    parse_confidence=0.0,
-                    shape=None,
-                    unique_values_ok=False,
-                    missing_values_ok=False,
-                    maskable_ok=False,
-                    invalid_reason=entry.invalid_reason or "invalid_manifest_entry",
+                    entry.sample_id,
+                    entry.size_class,
+                    False,
+                    0.0,
+                    None,
+                    expected_shape_txt,
+                    None,
+                    False,
+                    False,
+                    False,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    None,
+                    entry.invalid_reason,
+                    entry.invalid_reason,
                 )
             )
             pending.append(
@@ -93,51 +140,118 @@ def parse_manifest_entries(
                     "sample_id": entry.sample_id,
                     "size_class": entry.size_class,
                     "reason": entry.invalid_reason,
+                    "hard_fail_reason": entry.invalid_reason,
                 }
             )
             continue
 
         try:
-            gray = _merge_pages(entry.image_paths)
-            det = detect_grid(gray)
-            result = structure_board(
-                sample_id=entry.sample_id,
-                image_path=entry.image_paths[0],
-                detection=det,
-                ticket_type=entry.size_class,
-            )
+            manual_grid, _ = load_manual_grid_with_states(entry.manual_grid)
+            if manual_grid is not None:
+                base_grid = manual_grid
+                parse_diag = {"parse_policy": "manual_first_batch", "ocr_backend": "manual"}
+                parse_conf = 1.0
+            else:
+                gray = _merge_pages(entry.image_paths, entry.size_class)
+                det = detect_grid(gray, spec)
+                result = structure_board(
+                    sample_id=entry.sample_id,
+                    image_path=entry.image_paths[0],
+                    detection=det,
+                    spec=spec,
+                    ticket_type=entry.size_class,
+                )
+                base_grid = [row[:] for row in result.grid]
+                parse_diag = result.parse_diagnostics
+                parse_conf = result.final_parse_confidence
+
+            if entry.override:
+                base_grid, _ = apply_overrides(base_grid, entry.override)
+
+            if manual_grid is not None or entry.override:
+                vals = [int(v) for row in base_grid for v in row if v is not None]
+                result = BoardParseResult(
+                    sample_id=entry.sample_id,
+                    shape=f"{spec.expected_rows}x{spec.expected_cols}",
+                    row_count=spec.expected_rows,
+                    col_count=spec.expected_cols,
+                    grid=base_grid,
+                    cell_confidence=[
+                        [1.0 for _ in range(spec.expected_cols)]
+                        for _ in range(spec.expected_rows)
+                    ],
+                    low_confidence_cells=[],
+                    parse_confidence=parse_conf,
+                    image_path=entry.image_paths[0] if entry.image_paths else "",
+                    ticket_type=entry.size_class,
+                    board_confidence=1.0,
+                    warp_confidence=1.0,
+                    shape_confidence=1.0,
+                    cell_class_confidence_mean=1.0,
+                    digit_confidence_mean=1.0,
+                    global_consistency_confidence=1.0,
+                    final_parse_confidence=parse_conf,
+                    numbers_all=sorted(vals),
+                    value_to_position={},
+                    missing_values=sorted(list(spec.legal_values - set(vals))),
+                    black_cells=[],
+                    pending_cells=[],
+                    parse_diagnostics=parse_diag,
+                    cell_boxes=[],
+                )
             detailed[entry.sample_id] = result
-            uniq_ok, miss_ok, maskable_ok, reason = _validate_board(result.grid)
-            if result.parse_confidence < min_confidence:
+            uniq_ok, miss_ok, complete, shape_match, reason = _validate_board(
+                result.grid, spec.expected_shape, strict
+            )
+            parse_conf = float(result.final_parse_confidence)
+            if parse_conf < min_confidence and reason is None:
                 reason = "parse_confidence_low"
             parse_success = reason is None
+            pending_review = len(result.pending_cells) > 0
+            usable_for_backtest = parse_success and complete and not pending_review
             audits.append(
                 ParseAuditRow(
                     sample_id=entry.sample_id,
                     size_class=entry.size_class,
                     parse_success=parse_success,
-                    parse_confidence=result.parse_confidence,
+                    parse_confidence=parse_conf,
                     shape=result.shape,
+                    expected_shape=expected_shape_txt,
+                    detected_shape=result.shape,
+                    shape_match=shape_match,
+                    complete_grid=complete,
+                    usable_for_backtest=usable_for_backtest,
+                    pending_review=pending_review,
+                    hard_fail=not parse_success,
                     unique_values_ok=uniq_ok,
                     missing_values_ok=miss_ok,
-                    maskable_ok=maskable_ok,
+                    maskable_ok=True,
+                    ocr_backend=str(result.parse_diagnostics.get("ocr_backend")),
+                    hard_fail_reason=reason,
                     invalid_reason=reason,
                 )
             )
             if parse_success:
-                nums = sorted([int(v) for row in result.grid for v in row if v is not None])
                 boards.append(
                     ParsedBoard(
                         sample_id=entry.sample_id,
                         size_class=entry.size_class,
                         grid=result.grid,
                         shape=result.shape,
-                        numbers_all=nums,
+                        numbers_all=result.numbers_all,
+                        value_to_position=result.value_to_position,
                         metadata={
-                            "parse_confidence": result.parse_confidence,
+                            "parse_confidence": parse_conf,
                             "page_count": entry.page_count,
                             "source_folder": entry.source_folder,
                             "low_confidence_cells": result.low_confidence_cells,
+                            "expected_shape": expected_shape_txt,
+                            "detected_shape": result.shape,
+                            "shape_match": shape_match,
+                            "complete_grid": complete,
+                            "usable_for_backtest": usable_for_backtest,
+                            "ocr_backend": result.parse_diagnostics.get("ocr_backend"),
+                            "hard_fail_reason": None,
                         },
                     )
                 )
@@ -147,22 +261,32 @@ def parse_manifest_entries(
                         "sample_id": entry.sample_id,
                         "size_class": entry.size_class,
                         "reason": reason,
-                        "parse_confidence": result.parse_confidence,
+                        "hard_fail_reason": reason,
+                        "parse_confidence": parse_conf,
                         "low_confidence_cells": result.low_confidence_cells,
                     }
                 )
-        except Exception as exc:  # fail-fast per sample
+        except (GridDetectionError, ValueError) as exc:
             audits.append(
                 ParseAuditRow(
-                    sample_id=entry.sample_id,
-                    size_class=entry.size_class,
-                    parse_success=False,
-                    parse_confidence=0.0,
-                    shape=None,
-                    unique_values_ok=False,
-                    missing_values_ok=False,
-                    maskable_ok=False,
-                    invalid_reason=str(exc),
+                    entry.sample_id,
+                    entry.size_class,
+                    False,
+                    0.0,
+                    None,
+                    expected_shape_txt,
+                    None,
+                    False,
+                    False,
+                    False,
+                    True,
+                    True,
+                    False,
+                    False,
+                    False,
+                    None,
+                    str(exc),
+                    str(exc),
                 )
             )
             pending.append(
@@ -170,27 +294,38 @@ def parse_manifest_entries(
                     "sample_id": entry.sample_id,
                     "size_class": entry.size_class,
                     "reason": str(exc),
+                    "hard_fail_reason": str(exc),
                     "parse_confidence": 0.0,
                 }
             )
 
     if pending_path is not None:
         pending_path.parent.mkdir(parents=True, exist_ok=True)
-        pending_path.write_text(json.dumps(pending, indent=2, ensure_ascii=False), encoding="utf-8")
+        pending_path.write_text(
+            json.dumps(pending, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
 
     return boards, audits, pending, detailed
 
 
 def write_boards(boards: List[ParsedBoard], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps([asdict(x) for x in boards], indent=2, ensure_ascii=False), encoding="utf-8")
+    output_path.write_text(
+        json.dumps([asdict(x) for x in boards], indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
 
 
 def write_parse_audit(rows: List[ParseAuditRow], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps([asdict(r) for r in rows], indent=2, ensure_ascii=False), encoding="utf-8")
+    output_path.write_text(
+        json.dumps([asdict(r) for r in rows], indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
 
 
 def write_pending(rows: List[Dict[str, object]], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8")
+    output_path.write_text(
+        json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8"
+    )

--- a/src/image_parse_api.py
+++ b/src/image_parse_api.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import base64
+from argparse import Namespace
+from pathlib import Path
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+
+from scripts.parse_board_image import parse_image_hybrid
+from src.number_position_predictor import predict_number_positions
+
+app = FastAPI(title="Board Parse API")
+
+
+def _to_tmp(file: UploadFile) -> str:
+    suffix = Path(file.filename or "upload.jpg").suffix or ".jpg"
+    out = Path("/tmp") / f"board_api_{file.filename or 'upload'}{suffix}"
+    out.write_bytes(file.file.read())
+    return str(out)
+
+
+def _attach_overlay_payload(payload: dict[str, object]) -> dict[str, object]:
+    overlay_path = payload.get("overlay_path")
+    if not overlay_path:
+        return payload
+    p = Path(str(overlay_path))
+    if p.exists():
+        payload["overlay_image_base64"] = base64.b64encode(p.read_bytes()).decode("ascii")
+    return payload
+
+
+@app.post("/board/parse")
+def board_parse(
+    image: UploadFile = File(...),
+    rows: int | None = Form(default=None),
+    cols: int | None = Form(default=None),
+    size_class: str | None = Form(default=None),
+    strict: bool = Form(default=False),
+    manual_grid: str | None = Form(default=None),
+    override: str | None = Form(default=None),
+    query_number: int | None = Form(default=None),
+    no_overlay: bool = Form(default=False),
+):
+    image_path = _to_tmp(image)
+    args = Namespace(
+        image=image_path,
+        rows=rows,
+        cols=cols,
+        size_class=size_class,
+        strict=strict,
+        manual_grid=manual_grid,
+        override=override,
+        query_number=query_number,
+        output_json="/tmp/parsed_board_api.json",
+        output_csv="/tmp/parsed_board_api.csv",
+        output_overlay="/tmp/parsed_board_api_overlay.png",
+        no_overlay=no_overlay,
+    )
+    payload = parse_image_hybrid(args)
+    if not payload.get("contract_passed"):
+        raise HTTPException(status_code=422, detail=payload)
+    return _attach_overlay_payload(payload)
+
+
+@app.post("/board/predict-number-position")
+def predict_number_position(
+    image: UploadFile = File(...),
+    query_number: int = Form(...),
+    rows: int | None = Form(default=None),
+    cols: int | None = Form(default=None),
+    size_class: str | None = Form(default=None),
+    strict: bool = Form(default=False),
+    manual_grid: str | None = Form(default=None),
+    override: str | None = Form(default=None),
+    no_overlay: bool = Form(default=False),
+):
+    image_path = _to_tmp(image)
+    args = Namespace(
+        image=image_path,
+        rows=rows,
+        cols=cols,
+        size_class=size_class,
+        strict=strict,
+        manual_grid=manual_grid,
+        override=override,
+        query_number=None,
+        output_json="/tmp/parsed_board_api.json",
+        output_csv="/tmp/parsed_board_api.csv",
+        output_overlay="/tmp/parsed_board_api_overlay.png",
+        no_overlay=no_overlay,
+    )
+    payload = parse_image_hybrid(args)
+    if not payload.get("contract_passed"):
+        raise HTTPException(status_code=422, detail=payload)
+    payload = _attach_overlay_payload(payload)
+
+    query = predict_number_positions(
+        grid=payload["grid"],
+        query_number=query_number,
+        missing_values=payload.get("missing_values", []),
+        low_confidence_cells=payload.get("low_confidence_cells", []),
+        black_cells=payload.get("black_cells", []),
+        manual_override_cells={
+            (x["row"] + 1, x["col"] + 1)
+            for x in payload.get("parse_diagnostics", {}).get("override_audit", [])
+            if "row" in x and "col" in x
+        },
+    )
+    return {"parse": payload, **query}

--- a/src/image_parse_api.py
+++ b/src/image_parse_api.py
@@ -4,7 +4,7 @@ import base64
 from argparse import Namespace
 from pathlib import Path
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, UploadFile
 
 from scripts.parse_board_image import parse_image_hybrid
 from src.number_position_predictor import predict_number_positions
@@ -57,8 +57,7 @@ def board_parse(
         no_overlay=no_overlay,
     )
     payload = parse_image_hybrid(args)
-    if not payload.get("contract_passed"):
-        raise HTTPException(status_code=422, detail=payload)
+    payload["needs_review"] = bool(payload.get("needs_manual_review"))
     return _attach_overlay_payload(payload)
 
 
@@ -90,9 +89,8 @@ def predict_number_position(
         no_overlay=no_overlay,
     )
     payload = parse_image_hybrid(args)
-    if not payload.get("contract_passed"):
-        raise HTTPException(status_code=422, detail=payload)
     payload = _attach_overlay_payload(payload)
+    payload["needs_review"] = bool(payload.get("needs_manual_review"))
 
     query = predict_number_positions(
         grid=payload["grid"],

--- a/src/manual_board_input.py
+++ b/src/manual_board_input.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+class ManualInputError(ValueError):
+    pass
+
+
+def _read_json(path: str | None) -> object | None:
+    if path is None:
+        return None
+    raw = str(path).strip()
+    if raw.startswith("{") or raw.startswith("["):
+        return json.loads(raw)
+    return json.loads(Path(raw).read_text(encoding="utf-8"))
+
+
+def _normalize_manual_cell(
+    cell: object,
+) -> Tuple[Optional[int], str]:
+    if cell is None:
+        return None, "empty"
+    if isinstance(cell, int):
+        return int(cell), "confirmed_number"
+    if isinstance(cell, str):
+        label = cell.strip().lower()
+        if label in ("black", "unknown", "empty"):
+            return None, label
+        raise ManualInputError("manual_grid_cell_label_invalid")
+    if isinstance(cell, dict):
+        label = str(cell.get("label", "")).strip().lower()
+        if label == "number":
+            if "value" not in cell:
+                raise ManualInputError("manual_grid_number_missing_value")
+            return int(cell["value"]), "confirmed_number"
+        if label in ("black", "unknown", "empty"):
+            return None, label
+    raise ManualInputError("manual_grid_cell_invalid")
+
+
+def _normalize_grid_payload(
+    payload: object,
+) -> tuple[List[List[Optional[int]]], List[List[str]]]:
+    if isinstance(payload, dict):
+        if "grid" not in payload:
+            raise ManualInputError("manual_grid_missing_grid_key")
+        payload = payload["grid"]
+    if not isinstance(payload, list) or not payload:
+        raise ManualInputError("manual_grid_invalid")
+    out: List[List[Optional[int]]] = []
+    states: List[List[str]] = []
+    for row in payload:
+        if not isinstance(row, list):
+            raise ManualInputError("manual_grid_invalid_row")
+        out_row: List[Optional[int]] = []
+        state_row: List[str] = []
+        for v in row:
+            value, state = _normalize_manual_cell(v)
+            out_row.append(value)
+            state_row.append(state)
+        out.append(out_row)
+        states.append(state_row)
+    width = len(out[0])
+    if any(len(r) != width for r in out):
+        raise ManualInputError("manual_grid_non_rectangular")
+    return out, states
+
+
+def load_manual_grid(manual_grid_path: str | None) -> List[List[Optional[int]]] | None:
+    payload = _read_json(manual_grid_path)
+    if payload is None:
+        return None
+    grid, _ = _normalize_grid_payload(payload)
+    return grid
+
+
+def load_manual_grid_with_states(
+    manual_grid_path: str | None,
+) -> tuple[List[List[Optional[int]]] | None, List[List[str]] | None]:
+    payload = _read_json(manual_grid_path)
+    if payload is None:
+        return None, None
+    return _normalize_grid_payload(payload)
+
+
+def apply_overrides(
+    base_grid: List[List[Optional[int]]], override_path: str | None
+) -> tuple[List[List[Optional[int]]], List[Dict[str, object]]]:
+    if override_path is None:
+        return [row[:] for row in base_grid], []
+    payload = _read_json(override_path)
+    if not isinstance(payload, list):
+        raise ManualInputError("override_invalid")
+
+    grid = [row[:] for row in base_grid]
+    audit: List[Dict[str, object]] = []
+    rows = len(grid)
+    cols = len(grid[0]) if rows else 0
+    for idx, patch in enumerate(payload):
+        if not isinstance(patch, dict):
+            raise ManualInputError("override_item_invalid")
+        if "row" not in patch or "col" not in patch or "label" not in patch:
+            raise ManualInputError("override_item_missing_keys")
+        r = int(patch["row"]) - 1
+        c = int(patch["col"]) - 1
+        if not (0 <= r < rows and 0 <= c < cols):
+            raise ManualInputError("override_out_of_bounds")
+        label = str(patch["label"])
+        if label == "number":
+            if "value" not in patch:
+                raise ManualInputError("override_number_missing_value")
+            grid[r][c] = int(patch["value"])
+        elif label in ("black", "empty"):
+            grid[r][c] = None
+        else:
+            raise ManualInputError("override_label_invalid")
+        audit.append(
+            {
+                "index": idx,
+                "row": r,
+                "col": c,
+                "label": label,
+                "note": patch.get("note"),
+            }
+        )
+    return grid, audit

--- a/src/multi_size_data_loader.py
+++ b/src/multi_size_data_loader.py
@@ -8,7 +8,12 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from .board_manifest import build_multisize_manifest
-from .image_board_parser import parse_manifest_entries, write_boards, write_parse_audit, write_pending
+from .image_board_parser import (
+    parse_manifest_entries,
+    write_boards,
+    write_parse_audit,
+    write_pending,
+)
 
 
 @dataclass
@@ -32,23 +37,73 @@ def _is_complete_grid(grid: List[List[Optional[int]]]) -> bool:
     return all(v is not None for row in grid for v in row)
 
 
+def _apply_manual_manifest_overrides(
+    manifest: list, manual_manifest_path: str | None
+) -> list:
+    if not manual_manifest_path:
+        return manifest
+    p = Path(manual_manifest_path)
+    if not p.exists():
+        return manifest
+    payload = json.loads(p.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        return manifest
+    index = {(m.size_class, m.sample_id): m for m in manifest}
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        key = (str(item.get("size_class")), str(item.get("sample_id")))
+        entry = index.get(key)
+        if entry is None:
+            continue
+        if "manual_grid" in item:
+            entry.manual_grid = str(item["manual_grid"])
+        if "override" in item:
+            entry.override = str(item["override"])
+    return manifest
+
+
 def load_multisize_samples(config: Dict) -> ParseArtifacts:
     repo_root = Path(config["data"]["repo_root"])
     manifest, manifest_audit = build_multisize_manifest(repo_root)
+    manifest = _apply_manual_manifest_overrides(
+        manifest, config.get("parser", {}).get("manual_manifest")
+    )
+    max_per_size = int(config.get("parser", {}).get("max_samples_per_size", 0) or 0)
+    if max_per_size > 0:
+        keep: Dict[str, int] = {"20": 0, "80": 0, "120": 0}
+        filtered = []
+        for m in manifest:
+            if keep.get(m.size_class, 0) >= max_per_size:
+                continue
+            filtered.append(m)
+            keep[m.size_class] = keep.get(m.size_class, 0) + 1
+        manifest = filtered
     boards, parse_audit, pending, _ = parse_manifest_entries(
         manifest=manifest,
         min_confidence=float(config["parser"]["min_confidence"]),
+        strict=False,
     )
 
     samples: List[MultiSizeBoardSample] = []
     for b in boards:
-        if not _is_complete_grid(b.grid):
+        complete = _is_complete_grid(b.grid)
+        usable = bool(b.metadata.get("usable_for_backtest", False)) and complete
+        if not usable:
             pending.append(
                 {
                     "sample_id": b.sample_id,
                     "size_class": b.size_class,
-                    "reason": "incomplete_grid",
-                    "parse_confidence": b.metadata.get("parse_confidence", 0.0),
+                    "reason": (
+                        "pending_review"
+                        if b.metadata.get("low_confidence_cells")
+                        else "incomplete_grid"
+                    ),
+                    "parse_success": True,
+                    "complete_grid": complete,
+                    "usable_for_backtest": usable,
+                    "pending_review": True,
+                    "hard_fail": False,
                 }
             )
             continue
@@ -69,7 +124,9 @@ def load_multisize_samples(config: Dict) -> ParseArtifacts:
         sample_counts_by_size[m.size_class] += 1
         image_counts_by_size[m.size_class] += len(m.image_paths)
 
-    parse_counts: Dict[str, Dict[str, int]] = {k: {"success": 0, "failed": 0} for k in ("20", "80", "120")}
+    parse_counts: Dict[str, Dict[str, int]] = {
+        k: {"success": 0, "failed": 0} for k in ("20", "80", "120")
+    }
     pending_counts: Dict[str, int] = {k: 0 for k in ("20", "80", "120")}
     valid_count_by_size: Dict[str, int] = {k: 0 for k in ("20", "80", "120")}
     reasons: Dict[str, int] = {}
@@ -102,12 +159,22 @@ def load_multisize_samples(config: Dict) -> ParseArtifacts:
         "parse_counts_by_size": parse_counts,
         "pending_counts_by_size": pending_counts,
         "parse_failure_reasons": reasons,
+        "status_flags": {
+            "parse_success": [x.parse_success for x in parse_audit],
+            "complete_grid": [x.complete_grid for x in parse_audit],
+            "usable_for_backtest": [x.usable_for_backtest for x in parse_audit],
+            "pending_review": [x.pending_review for x in parse_audit],
+            "hard_fail": [x.hard_fail for x in parse_audit],
+        },
         "anti_leakage_checks": "passed",
     }
 
-    Path(config["reports"]["data_audit"]).write_text(json.dumps(audit, indent=2, ensure_ascii=False), encoding="utf-8")
+    Path(config["reports"]["data_audit"]).write_text(
+        json.dumps(audit, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
     Path(config["reports"]["manifest"]).write_text(
-        json.dumps([x.__dict__ for x in manifest], indent=2, ensure_ascii=False), encoding="utf-8"
+        json.dumps([x.__dict__ for x in manifest], indent=2, ensure_ascii=False),
+        encoding="utf-8",
     )
     write_parse_audit(parse_audit, Path(config["reports"]["parse_audit"]))
     write_pending(pending, Path(config["reports"]["pending_annotations"]))

--- a/src/number_position_predictor.py
+++ b/src/number_position_predictor.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Set
+
+from .board_query import find_number_positions
+
+
+def predict_number_positions(
+    grid: List[List[Optional[int]]],
+    query_number: int,
+    missing_values: List[int],
+    low_confidence_cells: List[Dict[str, object]],
+    black_cells: List[Dict[str, int]],
+    manual_override_cells: Set[tuple[int, int]] | None = None,
+) -> Dict[str, object]:
+    exact = find_number_positions(grid, query_number)
+    if exact["found"] and not exact["contract_violation"]:
+        return {
+            "query_number": query_number,
+            "query_status": "exact_found",
+            "exact_positions": exact["positions"],
+            "top5_position_candidates": [
+                {
+                    **exact["positions"][0],
+                    "score": 1.0,
+                    "reason": "exact_match",
+                }
+            ],
+        }
+
+    rows = len(grid)
+    cols = len(grid[0]) if rows else 0
+    black = {(x["row"], x["col"]) for x in black_cells}
+    low = {
+        (int(x.get("row", -1)) + 1, int(x.get("col", -1)) + 1)
+        for x in low_confidence_cells
+    }
+    manual = manual_override_cells or set()
+
+    candidates = []
+    if query_number not in missing_values and not exact["found"]:
+        return {
+            "query_number": query_number,
+            "query_status": "not_possible",
+            "exact_positions": [],
+            "top5_position_candidates": [],
+        }
+
+    for r in range(1, rows + 1):
+        for c in range(1, cols + 1):
+            if (r, c) in black:
+                continue
+            v = grid[r - 1][c - 1]
+            if v is not None and v != query_number:
+                continue
+            score = 0.2
+            reason = ["candidate_cell"]
+            if (r, c) in low:
+                score += 0.5
+                reason.append("low_confidence_replaceable")
+            if v is None:
+                score += 0.2
+                reason.append("empty_cell")
+            if (r, c) in manual:
+                score -= 0.3
+                reason.append("manual_override_penalty")
+            candidates.append(
+                {
+                    "row_1based": r,
+                    "col_1based": c,
+                    "row_0based": r - 1,
+                    "col_0based": c - 1,
+                    "score": max(0.0, min(1.0, score)),
+                    "reason": ",".join(reason),
+                }
+            )
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    return {
+        "query_number": query_number,
+        "query_status": "predicted" if candidates else "not_possible",
+        "exact_positions": exact["positions"],
+        "top5_position_candidates": candidates[:5],
+    }

--- a/src/ticket_specs.py
+++ b/src/ticket_specs.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+SizeClass = Literal["20", "80", "120"]
+
+
+@dataclass(frozen=True)
+class TicketSpec:
+    size_class: str
+    expected_rows: int
+    expected_cols: int
+    page_count: int
+    page_merge_axis: str
+    user_index_base: int
+    allowed_mask_labels: tuple[str, ...]
+
+    @property
+    def expected_shape(self) -> tuple[int, int]:
+        return self.expected_rows, self.expected_cols
+
+    @property
+    def legal_values(self) -> set[int]:
+        return set(range(1, self.expected_rows * self.expected_cols + 1))
+
+
+TICKET_SPECS: Dict[str, TicketSpec] = {
+    "20": TicketSpec("20", 5, 4, 1, "none", 1, ("solid_black",)),
+    "80": TicketSpec("80", 10, 8, 1, "none", 1, ("solid_black",)),
+    "120": TicketSpec("120", 12, 10, 2, "vertical", 1, ("solid_black",)),
+}
+
+
+class TicketSpecError(ValueError):
+    pass
+
+
+def build_ticket_spec(
+    rows: int,
+    cols: int,
+    *,
+    page_count: int = 1,
+    page_merge_axis: str = "none",
+    size_class: str = "generic",
+) -> TicketSpec:
+    if rows <= 0 or cols <= 0:
+        raise TicketSpecError("invalid_shape")
+    return TicketSpec(
+        size_class=size_class,
+        expected_rows=int(rows),
+        expected_cols=int(cols),
+        page_count=int(page_count),
+        page_merge_axis=page_merge_axis,
+        user_index_base=1,
+        allowed_mask_labels=("solid_black",),
+    )
+
+
+def get_ticket_spec(size_class: str) -> TicketSpec:
+    if size_class not in TICKET_SPECS:
+        raise TicketSpecError(f"unknown_size_class:{size_class}")
+    return TICKET_SPECS[size_class]
+
+
+def get_ticket_spec_by_shape(rows: int, cols: int) -> TicketSpec:
+    for spec in TICKET_SPECS.values():
+        if spec.expected_shape == (rows, cols):
+            return spec
+    return build_ticket_spec(rows, cols)
+
+
+def detect_size_class_from_path(image_path: str) -> Optional[SizeClass]:
+    p = Path(image_path)
+    for part in p.parts:
+        if part in TICKET_SPECS:
+            return part  # type: ignore[return-value]
+    return None
+
+
+def resolve_ticket_spec(
+    *,
+    size_class: str | None = None,
+    rows: int | None = None,
+    cols: int | None = None,
+    image_path: str | None = None,
+) -> TicketSpec:
+    if rows is not None or cols is not None:
+        if rows is None or cols is None:
+            raise TicketSpecError("rows_cols_must_be_paired")
+        return build_ticket_spec(rows, cols)
+    if size_class is not None:
+        return get_ticket_spec(size_class)
+    if image_path is not None:
+        inferred = detect_size_class_from_path(image_path)
+        if inferred is not None:
+            return get_ticket_spec(inferred)
+    raise TicketSpecError("shape_resolution_failed")
+
+
+def validate_page_contract(spec: TicketSpec, image_paths: List[str]) -> None:
+    if len(image_paths) != spec.page_count:
+        raise TicketSpecError("page_merge_invalid")
+    if spec.page_count == 2:
+        names = [Path(x).stem for x in image_paths]
+        if not ("頁面_1" in names[0] and "頁面_2" in names[1]):
+            raise TicketSpecError("page_merge_invalid")

--- a/tests/test_board_contracts.py
+++ b/tests/test_board_contracts.py
@@ -1,0 +1,33 @@
+from src.board_contracts import evaluate_board_contract
+from src.ticket_specs import build_ticket_spec
+
+
+def test_contract_duplicate_fail_4x5() -> None:
+    spec = build_ticket_spec(4, 5)
+    grid = [
+        [1, 1, 3, 4, 5],
+        [6, 7, 8, 9, 10],
+        [11, 12, 13, 14, 15],
+        [16, 17, 18, 19, 20],
+    ]
+    result = evaluate_board_contract(grid, spec, 0.9, [], strict=True)
+    assert result.status == "contract_violation"
+
+
+def test_contract_legal_range_8x10() -> None:
+    spec = build_ticket_spec(8, 10)
+    grid = [list(range(r * 10 + 1, r * 10 + 11)) for r in range(8)]
+    result = evaluate_board_contract(grid, spec, 0.9, [], strict=True)
+    assert result.contract_passed is True
+
+
+def test_contract_missing_and_illegal() -> None:
+    spec = build_ticket_spec(4, 5)
+    grid = [
+        [1, 2, 3, 4, 5],
+        [6, 7, 8, 9, 10],
+        [11, 12, 13, 14, 999],
+        [16, 17, 18, 19, 20],
+    ]
+    result = evaluate_board_contract(grid, spec, 0.9, [], strict=True)
+    assert result.status == "contract_violation"

--- a/tests/test_board_parser.py
+++ b/tests/test_board_parser.py
@@ -105,3 +105,60 @@ def test_board_parser_override_only_fallback(monkeypatch, tmp_path: Path) -> Non
     payload = parse_board_image.parse_image_hybrid(args)
     assert payload["source_mode"] == "hybrid"
     assert payload["grid"][0][0] == 1
+
+
+def test_board_parser_auto_selects_shape(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        parse_board_image.cv2,
+        "imread",
+        lambda *_args, **_kwargs: np.zeros((64, 64), dtype=np.uint8),
+    )
+
+    def _detect(_gray, spec):
+        if spec.expected_shape == (5, 4):
+            return parse_board_image.GridDetection(
+                board_image=np.zeros((320, 256), dtype=np.uint8),
+                board_bbox=(0, 0, 10, 10),
+                row_count=5,
+                col_count=4,
+                row_lines=[0, 64, 128, 192, 256, 320],
+                col_lines=[0, 64, 128, 192, 256],
+                board_confidence=0.8,
+                warp_confidence=0.8,
+                shape_confidence=0.8,
+                cell_boxes=[],
+            )
+        raise GridDetectionError("shape_mismatch")
+
+    monkeypatch.setattr(parse_board_image, "detect_grid", _detect)
+    monkeypatch.setattr(
+        parse_board_image,
+        "structure_board",
+        lambda **_kwargs: parse_board_image._manual_result_from_grid(
+            image_path="dummy.jpg",
+            spec=parse_board_image.get_ticket_spec("20"),
+            grid=[
+                [1, 2, 3, 4],
+                [5, 6, 7, 8],
+                [9, 10, 11, 12],
+                [13, 14, 15, 16],
+                [17, 18, 19, 20],
+            ],
+        ),
+    )
+    args = parse_board_image.argparse.Namespace(
+        image="dummy.jpg",
+        rows=None,
+        cols=None,
+        size_class=None,
+        strict=False,
+        manual_grid=None,
+        override=None,
+        query_number=None,
+        output_json=str(tmp_path / "out.json"),
+        output_csv=str(tmp_path / "out.csv"),
+        output_overlay=None,
+        no_overlay=True,
+    )
+    payload = parse_board_image.parse_image_hybrid(args)
+    assert payload["shape"] == "5x4"

--- a/tests/test_board_parser.py
+++ b/tests/test_board_parser.py
@@ -1,16 +1,107 @@
+import json
+import subprocess
 from pathlib import Path
 
-import cv2
+import numpy as np
 
-from src.board_structurer import structure_board
-from src.grid_detector import detect_grid
+import scripts.parse_board_image as parse_board_image
+from src.grid_detector import GridDetectionError
 
 
-def test_board_parser_runs_on_repo_image() -> None:
-    image = Path("gogo/20/IS23120130.jpg")
-    gray = cv2.imread(str(image), cv2.IMREAD_GRAYSCALE)
-    assert gray is not None
-    det = detect_grid(gray)
-    result = structure_board(sample_id=image.stem, image_path=str(image), detection=det)
-    assert result.row_count >= 2
-    assert result.col_count >= 2
+def test_board_parser_manual_override_schema(tmp_path: Path) -> None:
+    manual_grid = tmp_path / "manual.json"
+    manual_grid.write_text(
+        json.dumps(
+            {
+                "grid": [
+                    [1, 2, 3, 4],
+                    [5, 6, 7, 8],
+                    [9, 10, 11, 12],
+                    [13, 14, 15, 16],
+                    [17, 18, 19, 20],
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    cmd = [
+        "python",
+        "scripts/parse_board_image.py",
+        "--image",
+        "gogo/20/IS23120130.jpg",
+        "--size-class",
+        "20",
+        "--strict",
+        "--manual-grid",
+        str(manual_grid),
+    ]
+    out = subprocess.check_output(cmd, text=True)
+    payload = json.loads(out.strip().splitlines()[-1])
+    for key in (
+        "status",
+        "source_mode",
+        "shape",
+        "grid",
+        "numbers_all",
+        "value_to_position",
+        "parse_diagnostics",
+        "contract_passed",
+        "needs_manual_review",
+    ):
+        assert key in payload
+    assert payload["contract_passed"] is True
+
+
+def test_board_parser_auto_fail_without_manual() -> None:
+    cmd = [
+        "python",
+        "scripts/parse_board_image.py",
+        "--image",
+        "gogo/20/IS23120130.jpg",
+        "--size-class",
+        "20",
+        "--strict",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode != 0
+    lines = [x for x in proc.stdout.splitlines() if x.strip().startswith("{")]
+    payload = json.loads(lines[-1])
+    assert payload["status"] in (
+        "needs_manual_review",
+        "shape_mismatch",
+        "incomplete_grid",
+        "low_confidence_parse",
+        "contract_violation",
+    )
+
+
+def test_board_parser_override_only_fallback(monkeypatch, tmp_path: Path) -> None:
+    override = tmp_path / "override.json"
+    override.write_text(
+        json.dumps([{"row": 1, "col": 1, "label": "number", "value": 1}]),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(parse_board_image.cv2, "imread", lambda *_args, **_kwargs: np.zeros((32, 32), dtype=np.uint8))
+
+    def _raise_detection(*_args, **_kwargs):
+        raise GridDetectionError("detect_failed")
+
+    monkeypatch.setattr(parse_board_image, "detect_grid", _raise_detection)
+    args = parse_board_image.argparse.Namespace(
+        image="dummy.jpg",
+        rows=5,
+        cols=4,
+        size_class=None,
+        strict=False,
+        manual_grid=None,
+        override=str(override),
+        query_number=None,
+        output_json=str(tmp_path / "out.json"),
+        output_csv=str(tmp_path / "out.csv"),
+        output_overlay=str(tmp_path / "out.png"),
+        no_overlay=True,
+    )
+    payload = parse_board_image.parse_image_hybrid(args)
+    assert payload["source_mode"] == "hybrid"
+    assert payload["grid"][0][0] == 1

--- a/tests/test_board_query.py
+++ b/tests/test_board_query.py
@@ -1,0 +1,22 @@
+from src.board_query import build_value_to_position, find_number_positions
+
+
+def test_value_to_position_ok() -> None:
+    grid = [[1, None], [2, 3]]
+    out = build_value_to_position(grid)
+    assert out["1"][0]["row_1based"] == 1
+    assert out["3"][0]["col_1based"] == 2
+
+
+def test_find_number_not_found() -> None:
+    grid = [[1, 2], [3, 4]]
+    out = find_number_positions(grid, 9)
+    assert out["status"] == "not_found"
+    assert out["positions"] == []
+
+
+def test_find_number_duplicate_violation() -> None:
+    grid = [[1, 2], [2, 4]]
+    out = find_number_positions(grid, 2)
+    assert out["contract_violation"] is True
+    assert len(out["positions"]) == 2

--- a/tests/test_board_solver.py
+++ b/tests/test_board_solver.py
@@ -1,0 +1,20 @@
+from src.board_solver import solve_board
+from src.ticket_specs import get_ticket_spec
+
+
+def test_solver_repairs_duplicate_using_candidates() -> None:
+    spec = get_ticket_spec("20")
+    grid = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16], [17, 18, 19, 19]]
+    candidates = {(4, 3): [20, 19]}
+    labels = {(4, 3): "printed_number"}
+    out = solve_board(grid, candidates, labels, spec)
+    assert out.grid[4][3] == 20
+
+
+def test_solver_pending_when_ambiguous() -> None:
+    spec = get_ticket_spec("20")
+    grid = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16], [17, 18, None, None]]
+    candidates = {(4, 2): [19, 20], (4, 3): [19, 20]}
+    labels = {(4, 2): "printed_number", (4, 3): "printed_number"}
+    out = solve_board(grid, candidates, labels, spec)
+    assert len(out.pending_cells) >= 1

--- a/tests/test_grid_detector.py
+++ b/tests/test_grid_detector.py
@@ -1,13 +1,22 @@
 import numpy as np
+import cv2
 
-from src.grid_detector import detect_grid
+from src.grid_detector import GridDetectionError, detect_grid
+from src.ticket_specs import get_ticket_spec
 
 
 def test_grid_detector_fail_fast_on_blank() -> None:
     img = np.full((200, 300), 255, dtype=np.uint8)
     try:
-        detect_grid(img)
-    except ValueError as exc:
-        assert "board" in str(exc) or "grid" in str(exc)
+        detect_grid(img, get_ticket_spec("20"))
+    except GridDetectionError as exc:
+        assert "perspective" in str(exc) or "shape" in str(exc)
     else:
-        raise AssertionError("expected ValueError")
+        raise AssertionError("expected GridDetectionError")
+
+
+def test_grid_detector_80_shape_matches_spec() -> None:
+    gray = cv2.imread("gogo/80/NL230505019.jpg", cv2.IMREAD_GRAYSCALE)
+    assert gray is not None
+    det = detect_grid(gray, get_ticket_spec("80"))
+    assert (det.row_count, det.col_count) == (10, 8)

--- a/tests/test_manual_board_input.py
+++ b/tests/test_manual_board_input.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.manual_board_input import ManualInputError, apply_overrides, load_manual_grid
+
+
+def test_load_full_manual_grid(tmp_path: Path) -> None:
+    p = tmp_path / "grid.json"
+    p.write_text(json.dumps({"grid": [[1, 2], [3, 4]]}), encoding="utf-8")
+    grid = load_manual_grid(str(p))
+    assert grid == [[1, 2], [3, 4]]
+
+
+def test_apply_override_success(tmp_path: Path) -> None:
+    p = tmp_path / "override.json"
+    p.write_text(
+        json.dumps([{"row": 2, "col": 2, "label": "number", "value": 9}]),
+        encoding="utf-8",
+    )
+    grid, audit = apply_overrides([[1, 2], [3, None]], str(p))
+    assert grid == [[1, 2], [3, 9]]
+    assert audit[0]["label"] == "number"
+
+
+def test_apply_override_out_of_bounds(tmp_path: Path) -> None:
+    p = tmp_path / "override.json"
+    p.write_text(
+        json.dumps([{"row": 9, "col": 1, "label": "number", "value": 5}]),
+        encoding="utf-8",
+    )
+    with pytest.raises(ManualInputError):
+        apply_overrides([[1, 2], [3, 4]], str(p))
+
+
+def test_load_manual_grid_supports_cell_labels(tmp_path: Path) -> None:
+    p = tmp_path / "grid.json"
+    p.write_text(
+        json.dumps(
+            {
+                "grid": [
+                    [1, "black"],
+                    ["unknown", {"label": "number", "value": 4}],
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    grid = load_manual_grid(str(p))
+    assert grid == [[1, None], [None, 4]]

--- a/tests/test_multisize_integration.py
+++ b/tests/test_multisize_integration.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import cv2
+
+from src.board_structurer import structure_board
+from src.grid_detector import detect_grid
+from src.ticket_specs import get_ticket_spec
+
+
+CASES = [
+    ("20", "gogo/20/IS23120130.jpg", "5x4"),
+    ("80", "gogo/80/NL230505019.jpg", "10x8"),
+    ("120", "gogo/120/NR23010101_頁面_1.jpg", "12x10"),
+]
+
+
+def test_contract_parse_for_sizes() -> None:
+    for size_class, image_path, shape in CASES:
+        if not Path(image_path).exists():
+            continue
+        gray = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+        assert gray is not None
+        spec = get_ticket_spec(size_class)
+        det = detect_grid(gray, spec)
+        result = structure_board(sample_id=Path(image_path).stem, image_path=image_path, detection=det, spec=spec)
+        assert result.shape == shape

--- a/tests/test_multisize_loader.py
+++ b/tests/test_multisize_loader.py
@@ -2,11 +2,39 @@ from pathlib import Path
 
 import yaml
 
-from src.multi_size_data_loader import load_multisize_samples
+from src.board_manifest import ManifestEntry
+from src.multi_size_data_loader import (
+    _apply_manual_manifest_overrides,
+    load_multisize_samples,
+)
 
 
 def test_multisize_loader_builds_audit() -> None:
-    cfg = yaml.safe_load(Path("configs/multisize_masking_eval.yaml").read_text(encoding="utf-8"))
+    cfg = yaml.safe_load(
+        Path("configs/multisize_masking_eval.yaml").read_text(encoding="utf-8")
+    )
+    cfg["parser"]["max_samples_per_size"] = 1
     artifacts = load_multisize_samples(cfg)
     assert artifacts.audit["manifest_audit"]["total_samples"] > 0
     assert set(artifacts.audit["parse_counts_by_size"].keys()) == {"20", "80", "120"}
+
+
+def test_apply_manual_manifest_overrides(tmp_path: Path) -> None:
+    manifest = [
+        ManifestEntry(
+            sample_id="sid",
+            size_class="20",
+            image_paths=["a.jpg"],
+            page_count=1,
+            source_folder="gogo/20",
+            valid=True,
+        )
+    ]
+    p = tmp_path / "manual_manifest.json"
+    p.write_text(
+        '[{"sample_id":"sid","size_class":"20","manual_grid":"m.json","override":"o.json"}]',
+        encoding="utf-8",
+    )
+    updated = _apply_manual_manifest_overrides(manifest, str(p))
+    assert updated[0].manual_grid == "m.json"
+    assert updated[0].override == "o.json"

--- a/tests/test_number_position_predictor.py
+++ b/tests/test_number_position_predictor.py
@@ -1,0 +1,23 @@
+from src.number_position_predictor import predict_number_positions
+
+
+def test_predictor_exact_found() -> None:
+    grid = [[1, 2], [3, 4]]
+    out = predict_number_positions(grid, 3, [], [], [])
+    assert out["query_status"] == "exact_found"
+
+
+def test_predictor_missing_returns_top5() -> None:
+    grid = [[1, None], [3, 4]]
+    out = predict_number_positions(grid, 2, [2], [{"row": 0, "col": 1}], [])
+    assert out["query_status"] == "predicted"
+    assert len(out["top5_position_candidates"]) >= 1
+
+
+def test_predictor_black_excluded() -> None:
+    grid = [[None, None], [3, 4]]
+    out = predict_number_positions(grid, 1, [1, 2], [], [{"row": 1, "col": 1}])
+    assert all(
+        not (x["row_1based"] == 1 and x["col_1based"] == 1)
+        for x in out["top5_position_candidates"]
+    )

--- a/tests/test_parse_board_api.py
+++ b/tests/test_parse_board_api.py
@@ -1,0 +1,90 @@
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import src.image_parse_api as image_parse_api
+from fastapi.testclient import TestClient
+
+from src.image_parse_api import app
+
+
+client = TestClient(app)
+
+
+def test_board_parse_api() -> None:
+    img_path = Path("gogo/20/IS23120130.jpg")
+    with img_path.open("rb") as f:
+        resp = client.post(
+            "/board/parse",
+            files={"image": (img_path.name, f, "image/jpeg")},
+            data={
+                "rows": "5",
+                "cols": "4",
+                "manual_grid": json.dumps(
+                    {
+                        "grid": [
+                            [1, 2, 3, 4],
+                            [5, 6, 7, 8],
+                            [9, 10, 11, 12],
+                            [13, 14, 15, 16],
+                            [17, 18, 19, 20],
+                        ]
+                    }
+                ),
+            },
+        )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["contract_passed"] is True
+
+
+def test_predict_number_position_api() -> None:
+    img_path = Path("gogo/20/IS23120130.jpg")
+    with img_path.open("rb") as f:
+        resp = client.post(
+            "/board/predict-number-position",
+            files={"image": (img_path.name, f, "image/jpeg")},
+            data={
+                "query_number": "11",
+                "rows": "5",
+                "cols": "4",
+                "manual_grid": json.dumps(
+                    {
+                        "grid": [
+                            [1, 2, 3, 4],
+                            [5, 6, 7, 8],
+                            [9, 10, 11, 12],
+                            [13, 14, 15, 16],
+                            [17, 18, 19, 20],
+                        ]
+                    }
+                ),
+            },
+        )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["query_status"] in ("exact_found", "predicted")
+
+
+def test_board_parse_api_overlay_toggle(monkeypatch, tmp_path: Path) -> None:
+    overlay = tmp_path / "overlay.png"
+    overlay.write_bytes(b"fakepng")
+
+    def _stub(_args: Namespace) -> dict[str, object]:
+        return {
+            "contract_passed": True,
+            "grid": [[1]],
+            "overlay_path": str(overlay),
+            "parse_diagnostics": {},
+        }
+
+    monkeypatch.setattr(image_parse_api, "parse_image_hybrid", _stub)
+    with Path("gogo/20/IS23120130.jpg").open("rb") as f:
+        resp = client.post(
+            "/board/parse",
+            files={"image": ("x.jpg", f, "image/jpeg")},
+            data={"no_overlay": "false"},
+        )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert "overlay_image_base64" in payload

--- a/tests/test_parse_board_api.py
+++ b/tests/test_parse_board_api.py
@@ -88,3 +88,30 @@ def test_board_parse_api_overlay_toggle(monkeypatch, tmp_path: Path) -> None:
     assert resp.status_code == 200
     payload = resp.json()
     assert "overlay_image_base64" in payload
+
+
+def test_predict_api_minimal_sop_payload(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _stub(args: Namespace) -> dict[str, object]:
+        seen["rows"] = args.rows
+        seen["cols"] = args.cols
+        seen["size_class"] = args.size_class
+        return {
+            "contract_passed": True,
+            "grid": [[11]],
+            "missing_values": [],
+            "low_confidence_cells": [],
+            "black_cells": [],
+            "parse_diagnostics": {},
+        }
+
+    monkeypatch.setattr(image_parse_api, "parse_image_hybrid", _stub)
+    with Path("gogo/20/IS23120130.jpg").open("rb") as f:
+        resp = client.post(
+            "/board/predict-number-position",
+            files={"image": ("x.jpg", f, "image/jpeg")},
+            data={"query_number": "11", "strict": "true"},
+        )
+    assert resp.status_code == 200
+    assert seen == {"rows": None, "cols": None, "size_class": None}

--- a/tests/test_single_image_predict.py
+++ b/tests/test_single_image_predict.py
@@ -1,13 +1,33 @@
 import json
 import subprocess
+from pathlib import Path
 
 
-def test_single_image_predict_cli_runs() -> None:
+MANUAL_GRID = {
+    "grid": [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+        [17, 18, 19, 20],
+    ]
+}
+
+
+def test_single_image_predict_mode_a_target_cell(tmp_path: Path) -> None:
+    manual_grid = tmp_path / "manual.json"
+    manual_grid.write_text(json.dumps(MANUAL_GRID), encoding="utf-8")
     cmd = [
         "python",
         "scripts/run_single_image_predict.py",
         "--image",
         "gogo/20/IS23120130.jpg",
+        "--rows",
+        "5",
+        "--cols",
+        "4",
+        "--manual-grid",
+        str(manual_grid),
         "--target-row",
         "0",
         "--target-col",
@@ -15,4 +35,49 @@ def test_single_image_predict_cli_runs() -> None:
     ]
     out = subprocess.check_output(cmd, text=True)
     payload = json.loads(out)
-    assert "top3" in payload or payload.get("status") == "parse_confidence_too_low"
+    assert payload["mode"] == "target_cell_digit"
+    assert "top5" in payload
+
+
+def test_single_image_predict_mode_b_query_number(tmp_path: Path) -> None:
+    manual_grid = tmp_path / "manual.json"
+    manual_grid.write_text(json.dumps(MANUAL_GRID), encoding="utf-8")
+    cmd = [
+        "python",
+        "scripts/run_single_image_predict.py",
+        "--image",
+        "gogo/20/IS23120130.jpg",
+        "--rows",
+        "5",
+        "--cols",
+        "4",
+        "--manual-grid",
+        str(manual_grid),
+        "--query-number",
+        "11",
+    ]
+    out = subprocess.check_output(cmd, text=True)
+    payload = json.loads(out)
+    assert payload["mode"] == "query_number_position"
+    assert "top5_position_candidates" in payload
+
+
+def test_single_image_predict_mode_conflict_fail_fast() -> None:
+    cmd = [
+        "python",
+        "scripts/run_single_image_predict.py",
+        "--image",
+        "gogo/20/IS23120130.jpg",
+        "--rows",
+        "5",
+        "--cols",
+        "4",
+        "--query-number",
+        "11",
+        "--target-row",
+        "0",
+        "--target-col",
+        "0",
+    ]
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    assert proc.returncode != 0

--- a/tests/test_ticket_specs.py
+++ b/tests/test_ticket_specs.py
@@ -1,0 +1,18 @@
+from src.ticket_specs import build_ticket_spec, resolve_ticket_spec
+
+
+def test_build_ticket_spec_4x5_legal_values() -> None:
+    spec = build_ticket_spec(4, 5)
+    assert min(spec.legal_values) == 1
+    assert max(spec.legal_values) == 20
+
+
+def test_build_ticket_spec_8x10_legal_values() -> None:
+    spec = build_ticket_spec(8, 10)
+    assert min(spec.legal_values) == 1
+    assert max(spec.legal_values) == 80
+
+
+def test_rows_cols_precedence_over_size_class() -> None:
+    spec = resolve_ticket_spec(rows=4, cols=5, size_class="80")
+    assert spec.expected_shape == (4, 5)


### PR DESCRIPTION
### Motivation
- Improve robustness of board parsing by introducing explicit ticket specifications, a hybrid manual-first parsing mode, and explicit contract checks to decide accept/reject flows.
- Support manual overrides and programmatic prediction of missing number positions to enable human-in-the-loop corrections and downstream prediction tools.
- Refactor detection/structuring/ocr pieces to produce richer diagnostics, consistent cell metadata, and overlays for visual audit.
- Expose parsing via a small HTTP API and add tooling/tests to validate multi-size workflows.

### Description
- Introduced a `TicketSpec` system (`src/ticket_specs.py`) and used it across grid detection and structuring to enforce expected shapes and page-merge rules.
- Added board contract evaluation and output schema (`src/board_contracts.py`) to decide `contract_passed` and standardize payloads returned by parsers.
- Implemented manual input and override handling (`src/manual_board_input.py`) and a solver (`src/board_solver.py`) that repairs duplicates and produces pending cells.
- Refactored board structurer (`src/board_structurer.py`) and grid detector (`src/grid_detector.py`) to use the new spec model, produce richer confidences and `cell_boxes`, and to raise clear errors (`GridDetectionError`, `BoardStructureError`).
- Reworked cell classification and digit reading (`src/cell_classifier.py`, `src/cell_digit_reader.py`) to return richer results and candidate lists used by the solver and downstream logic.
- Added utilities for querying number positions (`src/board_query.py`) and a simple predictor to propose positions for a missing number (`src/number_position_predictor.py`).
- Exposed parsing functionality as a FastAPI service (`src/image_parse_api.py`) and unified the CLI parsing logic into a hybrid parser (`scripts/parse_board_image.py`) used by `scripts/run_single_image_predict.py`.
- Updated export overlay logic (`src/board_export.py`) to draw `cell_boxes` and support manual/pending highlights.
- Added many unit and integration tests under `tests/` covering contracts, parser behaviors, detector behavior, manual input, solver, prediction, CLI flows, API, and multi-size loader logic.
- Updated `requirements.txt` to include `opencv-python-headless` and `python-multipart` for headless image processing and multipart form uploads.

### Testing
- Ran the test suite with `pytest -q` covering new and updated tests under `tests/`, including `test_board_contracts.py`, `test_board_parser.py`, `test_grid_detector.py`, `test_manual_board_input.py`, `test_board_solver.py`, `test_number_position_predictor.py`, and API/CLI integration tests, and all tests passed.
- Exercised CLI flows by invoking `scripts/parse_board_image.py` and `scripts/run_single_image_predict.py` in unit tests to verify hybrid/manual/override behaviors and they returned expected payloads.
- Exercised the FastAPI endpoints using `fastapi.testclient` in `tests/test_parse_board_api.py`, and the API returned the standardized payload including overlay data when requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4cd15f4f0832480382bf124cce53f)