### PR TITLE
Deepen target-cell inference with directional/line/global scoring and configurable formal eval

### DIFF
--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -3,9 +3,30 @@ modules:
     logic_rule: true
     pattern_model: true
     prior_model: true
+    directional_consistency: true
+    line_consistency: true
+    global_assignment_prior: true
   weights:
-    logic_rule: 0.4
-    pattern_model: 0.4
-    prior_model: 0.2
+    logic_rule: 0.22
+    pattern_model: 0.16
+    prior_model: 0.12
+    directional_consistency: 0.20
+    line_consistency: 0.20
+    global_assignment_prior: 0.10
   aggregator:
     type: weighted_average
+    global_assignment_solver: greedy
+    enable_hungarian: false
+weight_tuning:
+  enabled: true
+  search_method: random
+  trials: 120
+  seed: 2026
+  optimize_metric: top3_hit_rate
+  modules:
+    - logic_rule
+    - pattern_model
+    - prior_model
+    - directional_consistency
+    - line_consistency
+    - global_assignment_prior

--- a/scripts/run_gogo_formal_eval.py
+++ b/scripts/run_gogo_formal_eval.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.inference_config import load_module_weights
+from src.inference_service import run_inference
+
+
+Cell = Tuple[int, int]
+Board = List[List[int]]
+
+
+@dataclass
+class EvalCase:
+    board_id: str
+    full_board: Board
+
+
+def _validate_full_board(board: Board) -> None:
+    if not board or not board[0]:
+        raise ValueError("board must be non-empty")
+    cols = len(board[0])
+    if any(len(row) != cols for row in board):
+        raise ValueError("board must be rectangular")
+    flat = [int(v) for row in board for v in row]
+    n_total = len(flat)
+    if len(set(flat)) != n_total:
+        raise ValueError("board values must be unique")
+    if sorted(flat) != list(range(1, n_total + 1)):
+        raise ValueError("board values must be exactly 1..N")
+
+
+def _iter_candidate_files(input_dir: Path) -> Iterable[Path]:
+    for p in input_dir.rglob("*.json"):
+        if "reports" in p.parts:
+            continue
+        yield p
+
+
+def _extract_boards_from_json(path: Path) -> List[EvalCase]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    records: List[Dict[str, Any]]
+    if isinstance(raw, list):
+        records = raw
+    elif isinstance(raw, dict) and "boards" in raw and isinstance(raw["boards"], list):
+        records = raw["boards"]
+    elif isinstance(raw, dict) and "grid" in raw:
+        records = [raw]
+    else:
+        return []
+
+    out: List[EvalCase] = []
+    for i, rec in enumerate(records):
+        grid = rec.get("full_board") or rec.get("grid")
+        if not isinstance(grid, list):
+            continue
+        board = [[int(v) for v in row] for row in grid]
+        _validate_full_board(board)
+        out.append(EvalCase(board_id=str(rec.get("board_id", f"{path.stem}:{i}")), full_board=board))
+    return out
+
+
+def load_eval_cases(input_dir: Path) -> List[EvalCase]:
+    if not input_dir.exists():
+        raise ValueError(f"Fail-fast: input-dir does not exist: {input_dir}")
+
+    out: List[EvalCase] = []
+    errors: List[str] = []
+    for p in _iter_candidate_files(input_dir):
+        try:
+            out.extend(_extract_boards_from_json(p))
+        except Exception as exc:
+            errors.append(f"{p}: {exc}")
+
+    if not out:
+        msg = "Fail-fast: no valid board json found under input-dir"
+        if errors:
+            msg += f"; examples={errors[:3]}"
+        raise ValueError(msg)
+    return out
+
+
+def _masked_board(full_board: Board, masking_ratio: float, rnd: random.Random) -> Tuple[Board, List[Cell]]:
+    rows, cols = len(full_board), len(full_board[0])
+    n_total = rows * cols
+    mask_count = int(math.floor(n_total * masking_ratio))
+    cells = [(r, c) for r in range(rows) for c in range(cols)]
+    rnd.shuffle(cells)
+    masked = set(cells[:mask_count])
+    board = [[-1 if (r, c) in masked else full_board[r][c] for c in range(cols)] for r in range(rows)]
+    return board, list(masked)
+
+
+def _rank_of_true(candidates: Sequence[Dict[str, Any]], true_cell: Cell) -> int:
+    for idx, cand in enumerate(candidates, start=1):
+        if (cand["row"] - 1, cand["col"] - 1) == true_cell:
+            return idx
+    return len(candidates) + 1
+
+
+def _metrics(rows: Sequence[Dict[str, Any]]) -> Dict[str, float]:
+    ranks = [int(r["rank"]) for r in rows]
+    return {
+        "num_cases": len(rows),
+        "top1_hit_rate": sum(1 for x in ranks if x <= 1) / max(1, len(ranks)),
+        "top3_hit_rate": sum(1 for x in ranks if x <= 3) / max(1, len(ranks)),
+        "top5_hit_rate": sum(1 for x in ranks if x <= 5) / max(1, len(ranks)),
+        "mrr": sum(1.0 / x for x in ranks) / max(1, len(ranks)),
+        "mean_rank": sum(ranks) / max(1, len(ranks)),
+        "median_rank": float(median(ranks)) if ranks else 0.0,
+    }
+
+
+def _normalize_weights(w: Dict[str, float]) -> Dict[str, float]:
+    total = sum(w.values())
+    if total <= 0:
+        return {k: 1.0 / len(w) for k in w}
+    return {k: v / total for k, v in w.items()}
+
+
+def random_weight_search(
+    modules: List[str],
+    trials: int,
+    seed: int,
+    eval_cases: List[Tuple[EvalCase, Board, int, Cell]],
+) -> Tuple[Dict[str, float], List[Dict[str, Any]]]:
+    rnd = random.Random(seed)
+    best: Dict[str, float] | None = None
+    best_metric = -1.0
+    records: List[Dict[str, Any]] = []
+    for t in range(trials):
+        raw = {m: rnd.random() + 1e-9 for m in modules}
+        w = _normalize_weights(raw)
+        case_rows = []
+        for case, masked_board, target_number, true_cell in eval_cases:
+            res = run_inference(masked_board, target_number, source="weight_search", module_weights=w)
+            rank = _rank_of_true(res["candidate_cells"], true_cell)
+            case_rows.append({"rank": rank})
+        metric = _metrics(case_rows)
+        rec = {"trial": t, **{f"w_{k}": v for k, v in w.items()}, **metric}
+        records.append(rec)
+        if metric["top3_hit_rate"] > best_metric:
+            best_metric = metric["top3_hit_rate"]
+            best = w
+    assert best is not None
+    return best, records
+
+
+def _ablation(
+    modules: List[str],
+    best_weights: Dict[str, float],
+    eval_cases: List[Tuple[EvalCase, Board, int, Cell]],
+) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    full_metrics_rows = []
+    for case, masked_board, target_number, true_cell in eval_cases:
+        res = run_inference(masked_board, target_number, source="ablation_full", module_weights=best_weights)
+        full_metrics_rows.append({"rank": _rank_of_true(res["candidate_cells"], true_cell)})
+    rows.append({"variant": "full", **_metrics(full_metrics_rows)})
+
+    for drop in modules:
+        kept = [m for m in modules if m != drop]
+        weights = _normalize_weights({m: best_weights[m] for m in kept})
+        metric_rows = []
+        for case, masked_board, target_number, true_cell in eval_cases:
+            res = run_inference(masked_board, target_number, source=f"ablation_drop_{drop}", module_weights=weights)
+            metric_rows.append({"rank": _rank_of_true(res["candidate_cells"], true_cell)})
+        rows.append({"variant": f"drop_{drop}", **_metrics(metric_rows)})
+    return rows
+
+
+def _write_csv(path: Path, rows: Sequence[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    keys = list(rows[0].keys())
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=keys)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-dir", default="gogo")
+    parser.add_argument("--output-dir", default="reports/gogo_eval")
+    parser.add_argument("--masking-ratio", type=float, default=0.5)
+    parser.add_argument("--seeds", type=int, nargs="+", default=[2026, 2027])
+    parser.add_argument("--weight-trials", type=int, default=80)
+    args = parser.parse_args()
+
+    cases = load_eval_cases(Path(args.input_dir))
+    baseline_weights = load_module_weights()
+    modules = list(baseline_weights.keys())
+
+    instantiated: List[Tuple[EvalCase, Board, int, Cell]] = []
+    for seed in args.seeds:
+        rnd = random.Random(seed)
+        for case in cases:
+            masked_board, masked_cells = _masked_board(case.full_board, args.masking_ratio, rnd)
+            for cell in masked_cells:
+                instantiated.append((case, masked_board, case.full_board[cell[0]][cell[1]], cell))
+
+    per_case_rows: List[Dict[str, Any]] = []
+    for case, masked_board, target_number, true_cell in instantiated:
+        res = run_inference(masked_board, target_number, source="gogo_formal_eval")
+        rank = _rank_of_true(res["candidate_cells"], true_cell)
+        best = res["best_cell"]
+        per_case_rows.append(
+            {
+                "board_id": case.board_id,
+                "target_number": target_number,
+                "true_row": true_cell[0] + 1,
+                "true_col": true_cell[1] + 1,
+                "pred_row": best["row"],
+                "pred_col": best["col"],
+                "rank": rank,
+                "top1_hit": int(rank <= 1),
+                "top3_hit": int(rank <= 3),
+                "top5_hit": int(rank <= 5),
+                "score": best["score"],
+                "confidence_1_to_100": best["confidence_1_to_100"],
+            }
+        )
+
+    summary = _metrics(per_case_rows)
+
+    best_weights, search_rows = random_weight_search(modules, args.weight_trials, args.seeds[0], instantiated)
+    tuned_rows = []
+    for case, masked_board, target_number, true_cell in instantiated:
+        res = run_inference(masked_board, target_number, source="gogo_formal_eval_tuned", module_weights=best_weights)
+        tuned_rows.append({"rank": _rank_of_true(res["candidate_cells"], true_cell)})
+    tuned_summary = _metrics(tuned_rows)
+    ablation_rows = _ablation(modules, best_weights, instantiated)
+
+    out_dir = Path(args.output_dir)
+    _write_csv(out_dir / "per_case_results.csv", per_case_rows)
+    _write_csv(out_dir / "weight_search_results.csv", search_rows)
+    _write_csv(out_dir / "ablation_results.csv", ablation_rows)
+    (out_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "input_dir": args.input_dir,
+                "masking_ratio": args.masking_ratio,
+                "seeds": args.seeds,
+                "baseline_weights": baseline_weights,
+                "best_weights": best_weights,
+                "baseline_metrics": summary,
+                "best_metrics": tuned_summary,
+                "delta": {
+                    "top1_hit_rate": tuned_summary["top1_hit_rate"] - summary["top1_hit_rate"],
+                    "top3_hit_rate": tuned_summary["top3_hit_rate"] - summary["top3_hit_rate"],
+                    "top5_hit_rate": tuned_summary["top5_hit_rate"] - summary["top5_hit_rate"],
+                    "mrr": tuned_summary["mrr"] - summary["mrr"],
+                },
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/inference_facade.py
+++ b/src/inference_facade.py
@@ -21,19 +21,26 @@ def validate_single_case_data(
     masked_board: List[List[int]],
     target_number: int,
     true_cell_0_based: Tuple[int, int],
+    masking_ratio: float = 0.5,
 ) -> Dict[str, object]:
-    if len(full_board) != 8 or any(len(row) != 10 for row in full_board):
-        raise ValueError("full_board must be 8x10")
+    if not full_board or not full_board[0]:
+        raise ValueError("full_board must be non-empty")
+    rows = len(full_board)
+    cols = len(full_board[0])
+    if any(len(row) != cols for row in full_board):
+        raise ValueError("full_board must be rectangular")
     flat_full = [v for row in full_board for v in row]
-    if sorted(flat_full) != list(range(1, 81)):
-        raise ValueError("full_board must contain 1..80 exactly once")
+    n_total = rows * cols
+    if sorted(flat_full) != list(range(1, n_total + 1)):
+        raise ValueError("full_board must contain 1..N exactly once")
 
-    if len(masked_board) != 8 or any(len(row) != 10 for row in masked_board):
-        raise ValueError("masked_board must be 8x10")
+    if len(masked_board) != rows or any(len(row) != cols for row in masked_board):
+        raise ValueError("masked_board shape must equal full_board shape")
 
     masked_count = sum(1 for row in masked_board for v in row if v == -1)
-    if masked_count != 40:
-        raise ValueError("masked_board must mask exactly 40 cells for 50% masking")
+    expected_masked = int(n_total * masking_ratio)
+    if masked_count != expected_masked:
+        raise ValueError(f"masked_board must mask exactly {expected_masked} cells for ratio={masking_ratio}")
 
     target_pos = None
     for r, row in enumerate(full_board):
@@ -49,9 +56,12 @@ def validate_single_case_data(
 
     if target_pos != true_cell_0_based:
         raise ValueError("true_cell_0_based does not match full_board location")
+    tr, tc = true_cell_0_based
+    if masked_board[tr][tc] != -1:
+        raise ValueError("true_cell_0_based must be masked in masked_board")
 
     return {
-        "shape": [8, 10],
+        "shape": [rows, cols],
         "masked_count": masked_count,
         "target_cell_0_based": list(target_pos),
         "target_cell_1_based": [target_pos[0] + 1, target_pos[1] + 1],

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -104,6 +104,11 @@ def score_candidates(
     module_weights: Optional[Dict[str, float]] = None,
 ) -> Tuple[List[Dict[str, object]], Dict[str, float], List[str]]:
     weights = module_weights or load_module_weights()
+    if module_weights is not None:
+        total = sum(float(v) for v in weights.values())
+        if total <= 0:
+            raise InferenceError("module_weights must sum to positive value")
+        weights = {k: float(v) / total for k, v in weights.items()}
     explanations: List[str] = []
 
     for module_name, weight in weights.items():
@@ -120,6 +125,8 @@ def score_candidates(
             cell = c["cell"]
             module_score = float(normalized.get(cell, 0.0))
             c["module_scores"][module_name] = module_score
+            c.setdefault("module_details", {})
+            c["module_details"][module_name] = (result.details or {}).get(cell, {})
             c["score"] += module_score * weight
 
     return candidates, weights, explanations
@@ -229,6 +236,10 @@ def run_inference(
                 "module_scores": {
                     k: round(float(v), 6) for k, v in sorted(cell["module_scores"].items())
                 },
+                "module_details": {
+                    k: {dk: round(float(dv), 6) for dk, dv in sorted(v.items())}
+                    for k, v in sorted(cell.get("module_details", {}).items())
+                },
             }
         )
 
@@ -255,6 +266,8 @@ def run_inference(
             board_shape=(parsed.rows, parsed.cols),
             candidates=baseline_candidate_cells,
             true_cell_1_based=None,
+            board=board,
+            target_number=target_number,
         )
         candidate_cells, rerank_meta = apply_reranker(baseline_candidate_cells, feature_rows)
 

--- a/src/ranking_features.py
+++ b/src/ranking_features.py
@@ -13,11 +13,27 @@ def _dense_ranks(values: List[float]) -> List[int]:
     return [rank_map[v] for v in values]
 
 
+def _known_density(board: List[List[int]], coords: List[Tuple[int, int]]) -> float:
+    if not coords:
+        return 0.0
+    known = sum(1 for r, c in coords if board[r][c] != -1)
+    return known / len(coords)
+
+
+def _relative_rank(value: int, known_values: List[int]) -> float:
+    if not known_values:
+        return 0.5
+    lower = sum(1 for v in known_values if v <= value)
+    return lower / len(known_values)
+
+
 def build_candidate_feature_rows(
     case_id: str,
     board_shape: Tuple[int, int],
     candidates: List[Dict[str, Any]],
     true_cell_1_based: Optional[Tuple[int, int]] = None,
+    board: Optional[List[List[int]]] = None,
+    target_number: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     rows, cols = board_shape
     if not candidates:
@@ -45,6 +61,11 @@ def build_candidate_feature_rows(
         row = int(candidate["row"])
         col = int(candidate["col"])
         module_scores = candidate.get("module_scores", {})
+        module_details = candidate.get("module_details", {})
+        directional = module_details.get("directional_consistency", {})
+        line = module_details.get("line_consistency", {})
+        global_detail = module_details.get("global_assignment_prior", {})
+
         consensus = {
             f"module_consensus_top{k}": sum(1 for mod_set in module_topk[k] if idx in mod_set) for k in TOP_KS
         }
@@ -64,9 +85,66 @@ def build_candidate_feature_rows(
             "dist_to_center": (abs(row - center_r) + abs(col - center_c)) / max_center_dist,
             "is_border": int(row in (1, rows) or col in (1, cols)),
             "is_corner": int((row in (1, rows)) and (col in (1, cols))),
+            "directional_score": float(
+                module_scores.get("directional_consistency", directional.get("directional_score", 0.0))
+            ),
+            "left_order_score": float(directional.get("left_order_score", 0.5)),
+            "right_order_score": float(directional.get("right_order_score", 0.5)),
+            "up_order_score": float(directional.get("up_order_score", 0.5)),
+            "down_order_score": float(directional.get("down_order_score", 0.5)),
+            "left_distance_score": float(directional.get("left_distance_score", 0.5)),
+            "right_distance_score": float(directional.get("right_distance_score", 0.5)),
+            "up_distance_score": float(directional.get("up_distance_score", 0.5)),
+            "down_distance_score": float(directional.get("down_distance_score", 0.5)),
+            "row_balance_score": float(directional.get("row_balance_score", 0.5)),
+            "col_balance_score": float(directional.get("col_balance_score", 0.5)),
+            "line_score": float(module_scores.get("line_consistency", line.get("line_score", 0.0))),
+            "row_residual_score": float(line.get("row_residual_score", 0.5)),
+            "col_residual_score": float(line.get("col_residual_score", 0.5)),
+            "main_diag_score": float(line.get("main_diag_score", 0.5)),
+            "anti_diag_score": float(line.get("anti_diag_score", 0.5)),
+            "row_monotonicity_score": float(line.get("row_monotonicity_score", 0.5)),
+            "col_monotonicity_score": float(line.get("col_monotonicity_score", 0.5)),
+            "diag_monotonicity_score": float(line.get("diag_monotonicity_score", 0.5)),
+            "row_percentile_fit": float(line.get("row_percentile_fit", 0.5)),
+            "col_percentile_fit": float(line.get("col_percentile_fit", 0.5)),
+            "diag_percentile_fit": float(line.get("diag_percentile_fit", 0.5)),
+            "global_assignment_score": float(
+                module_scores.get("global_assignment_prior", global_detail.get("global_assignment_score", 0.5))
+            ),
             **consensus,
             "label": int(true_cell_1_based == (row, col)) if true_cell_1_based else None,
         }
+
+        if board is not None:
+            r0, c0 = row - 1, col - 1
+            row_coords = [(r0, x) for x in range(cols)]
+            col_coords = [(x, c0) for x in range(rows)]
+            main_coords = [(i, i) for i in range(min(rows, cols))] if r0 == c0 else []
+            anti_coords = [(i, cols - 1 - i) for i in range(min(rows, cols))] if r0 + c0 == cols - 1 else []
+            feature["same_row_known_density"] = _known_density(board, row_coords)
+            feature["same_col_known_density"] = _known_density(board, col_coords)
+            feature["same_main_diag_known_density"] = _known_density(board, main_coords) if main_coords else 0.0
+            feature["same_anti_diag_known_density"] = _known_density(board, anti_coords) if anti_coords else 0.0
+            if target_number is not None:
+                row_known = [board[r0][x] for x in range(cols) if board[r0][x] != -1]
+                col_known = [board[x][c0] for x in range(rows) if board[x][c0] != -1]
+                diag_known = [board[a][b] for a, b in (main_coords or anti_coords) if board[a][b] != -1]
+                feature["relative_rank_within_row"] = _relative_rank(target_number, row_known)
+                feature["relative_rank_within_col"] = _relative_rank(target_number, col_known)
+                feature["relative_rank_within_diag"] = _relative_rank(target_number, diag_known)
+            else:
+                feature["relative_rank_within_row"] = 0.5
+                feature["relative_rank_within_col"] = 0.5
+                feature["relative_rank_within_diag"] = 0.5
+        else:
+            feature["same_row_known_density"] = 0.0
+            feature["same_col_known_density"] = 0.0
+            feature["same_main_diag_known_density"] = 0.0
+            feature["same_anti_diag_known_density"] = 0.0
+            feature["relative_rank_within_row"] = 0.5
+            feature["relative_rank_within_col"] = 0.5
+            feature["relative_rank_within_diag"] = 0.5
 
         for m in module_names:
             feature[f"module_score_{m}"] = float(module_scores.get(m, 0.0))

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Dict, List, Protocol, Tuple
 
@@ -11,6 +12,7 @@ Cell = Tuple[int, int]
 class ModuleScoreResult:
     scores: Dict[Cell, float]
     explanation: str
+    details: Dict[Cell, Dict[str, float]] | None = None
 
 
 class ScoringModule(Protocol):
@@ -18,6 +20,99 @@ class ScoringModule(Protocol):
 
     def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
         ...
+
+
+def _clamp_01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _neutral() -> float:
+    return 0.5
+
+
+def _mean(values: List[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _safe_std(values: List[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mu = _mean(values)
+    return math.sqrt(sum((x - mu) ** 2 for x in values) / len(values))
+
+
+def _distance_score(values: List[int], target_number: int, n_total: int) -> float:
+    if not values:
+        return _neutral()
+    min_d = min(abs(v - target_number) for v in values)
+    mean_d = _mean([abs(v - target_number) for v in values])
+    scale = max(1.0, n_total / 2.0)
+    score = 1.0 - ((0.6 * min_d + 0.4 * mean_d) / scale)
+    return _clamp_01(score)
+
+
+def _order_score(values: List[int], target_number: int, expect_target_greater: bool) -> float:
+    if not values:
+        return _neutral()
+    if expect_target_greater:
+        ok = sum(1 for v in values if target_number >= v)
+    else:
+        ok = sum(1 for v in values if target_number <= v)
+    return _clamp_01(ok / len(values))
+
+
+def _balance_score(known_values: List[int], inserted_value: int, n_total: int) -> float:
+    if not known_values:
+        return _neutral()
+    before = sorted(known_values)
+    after = sorted(known_values + [inserted_value])
+    before_span = max(before) - min(before) if len(before) > 1 else n_total
+    after_span = max(after) - min(after) if len(after) > 1 else n_total
+    before_std = _safe_std(before)
+    after_std = _safe_std(after)
+    span_gain = 1.0 - abs(after_span - before_span) / max(1.0, n_total)
+    std_gain = 1.0 - abs(after_std - before_std) / max(1.0, n_total / 3.0)
+    return _clamp_01(0.5 * span_gain + 0.5 * std_gain)
+
+
+def _monotonicity_score(series: List[int]) -> float:
+    if len(series) < 3:
+        return _neutral()
+    inc_viol = dec_viol = 0
+    for a, b in zip(series, series[1:]):
+        if b < a:
+            inc_viol += 1
+        if b > a:
+            dec_viol += 1
+    total = len(series) - 1
+    best = min(inc_viol, dec_viol)
+    return _clamp_01(1.0 - (best / max(1, total)))
+
+
+def _residual_score(values: List[int], positions: List[int]) -> float:
+    if len(values) < 3:
+        return _neutral()
+    x_mean = _mean([float(p) for p in positions])
+    y_mean = _mean([float(v) for v in values])
+    denom = sum((p - x_mean) ** 2 for p in positions)
+    if abs(denom) < 1e-12:
+        return _neutral()
+    slope = sum((p - x_mean) * (v - y_mean) for p, v in zip(positions, values)) / denom
+    intercept = y_mean - slope * x_mean
+    residual = _mean([abs((slope * p + intercept) - v) for p, v in zip(positions, values)])
+    value_span = max(values) - min(values)
+    scale = max(1.0, value_span)
+    return _clamp_01(1.0 - residual / scale)
+
+
+def _percentile_fit(series: List[int], target: int, pos: int, length: int, n_total: int) -> float:
+    if length <= 1:
+        return _neutral()
+    expected_quantile = pos / (length - 1)
+    expected_value = 1.0 + expected_quantile * (n_total - 1)
+    err = abs(target - expected_value)
+    scale = max(1.0, n_total / 2.0)
+    return _clamp_01(1.0 - err / scale)
 
 
 class LogicRuleModule:
@@ -82,8 +177,186 @@ class PriorModelModule:
         return ModuleScoreResult(result, "prior_model: 使用位置先驗（中心偏好）評分")
 
 
+class DirectionalConsistencyModule:
+    name = "directional_consistency"
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        rows, cols = len(board), len(board[0])
+        n_total = rows * cols
+        result: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for r, c in unopened_cells:
+            left_vals = [board[r][x] for x in range(0, c) if board[r][x] != -1]
+            right_vals = [board[r][x] for x in range(c + 1, cols) if board[r][x] != -1]
+            up_vals = [board[x][c] for x in range(0, r) if board[x][c] != -1]
+            down_vals = [board[x][c] for x in range(r + 1, rows) if board[x][c] != -1]
+            row_vals = [board[r][x] for x in range(cols) if board[r][x] != -1]
+            col_vals = [board[x][c] for x in range(rows) if board[x][c] != -1]
+
+            cell_detail = {
+                "left_order_score": _order_score(left_vals, target_number, expect_target_greater=True),
+                "right_order_score": _order_score(right_vals, target_number, expect_target_greater=False),
+                "up_order_score": _order_score(up_vals, target_number, expect_target_greater=True),
+                "down_order_score": _order_score(down_vals, target_number, expect_target_greater=False),
+                "left_distance_score": _distance_score(left_vals, target_number, n_total),
+                "right_distance_score": _distance_score(right_vals, target_number, n_total),
+                "up_distance_score": _distance_score(up_vals, target_number, n_total),
+                "down_distance_score": _distance_score(down_vals, target_number, n_total),
+                "row_balance_score": _balance_score(row_vals, target_number, n_total),
+                "col_balance_score": _balance_score(col_vals, target_number, n_total),
+            }
+            directional = _mean(list(cell_detail.values()))
+            cell_detail["directional_score"] = directional
+            result[(r, c)] = directional
+            details[(r, c)] = cell_detail
+
+        return ModuleScoreResult(result, "directional_consistency: 左右上下＋行列平衡一致性", details=details)
+
+
+class LineConsistencyModule:
+    name = "line_consistency"
+
+    def _collect_line(
+        self,
+        board: Board,
+        coords: List[Cell],
+        target_number: int,
+        candidate: Cell,
+    ) -> Tuple[List[int], List[int]]:
+        vals: List[int] = []
+        pos: List[int] = []
+        for idx, (r, c) in enumerate(coords):
+            v = board[r][c]
+            if (r, c) == candidate:
+                v = target_number
+            if v == -1:
+                continue
+            vals.append(int(v))
+            pos.append(idx)
+        return vals, pos
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        rows, cols = len(board), len(board[0])
+        n_total = rows * cols
+        result: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for r, c in unopened_cells:
+            row_coords = [(r, x) for x in range(cols)]
+            col_coords = [(x, c) for x in range(rows)]
+            main_coords = [(i, i) for i in range(min(rows, cols))] if r == c else []
+            anti_coords = [(i, cols - 1 - i) for i in range(min(rows, cols))] if r + c == cols - 1 else []
+
+            row_vals, row_pos = self._collect_line(board, row_coords, target_number, (r, c))
+            col_vals, col_pos = self._collect_line(board, col_coords, target_number, (r, c))
+            main_vals, main_pos = (
+                self._collect_line(board, main_coords, target_number, (r, c)) if main_coords else ([], [])
+            )
+            anti_vals, anti_pos = (
+                self._collect_line(board, anti_coords, target_number, (r, c)) if anti_coords else ([], [])
+            )
+            diag_vals = main_vals if main_coords else anti_vals
+            diag_index = 0
+            diag_len = 1
+            if main_coords:
+                diag_index = main_coords.index((r, c))
+                diag_len = len(main_coords)
+            elif anti_coords:
+                diag_index = anti_coords.index((r, c))
+                diag_len = len(anti_coords)
+
+            detail = {
+                "row_residual_score": _residual_score(row_vals, row_pos),
+                "col_residual_score": _residual_score(col_vals, col_pos),
+                "main_diag_score": _residual_score(main_vals, main_pos) if main_coords else _neutral(),
+                "anti_diag_score": _residual_score(anti_vals, anti_pos) if anti_coords else _neutral(),
+                "row_monotonicity_score": _monotonicity_score(row_vals),
+                "col_monotonicity_score": _monotonicity_score(col_vals),
+                "diag_monotonicity_score": _monotonicity_score(diag_vals),
+                "row_percentile_fit": _percentile_fit(row_vals, target_number, c, cols, n_total),
+                "col_percentile_fit": _percentile_fit(col_vals, target_number, r, rows, n_total),
+                "diag_percentile_fit": _percentile_fit(
+                    diag_vals,
+                    target_number,
+                    diag_index,
+                    diag_len,
+                    n_total,
+                ),
+            }
+            line_score = _mean(list(detail.values()))
+            detail["line_score"] = line_score
+            result[(r, c)] = line_score
+            details[(r, c)] = detail
+        return ModuleScoreResult(result, "line_consistency: 整行整列與對角一致性", details=details)
+
+
+class GlobalAssignmentPriorModule:
+    name = "global_assignment_prior"
+
+    def _cell_number_compat(self, board: Board, cell: Cell, number: int) -> float:
+        rows, cols = len(board), len(board[0])
+        r, c = cell
+        neighbors: List[int] = []
+        for rr, cc in ((r - 1, c), (r + 1, c), (r, c - 1), (r, c + 1)):
+            if 0 <= rr < rows and 0 <= cc < cols:
+                v = board[rr][cc]
+                if v != -1:
+                    neighbors.append(v)
+        if not neighbors:
+            return _neutral()
+        span = rows * cols
+        mean_abs = _mean([abs(number - x) for x in neighbors])
+        return _clamp_01(1.0 - mean_abs / max(1.0, span / 2.0))
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        rows, cols = len(board), len(board[0])
+        n_total = rows * cols
+        known = {v for row in board for v in row if v != -1}
+        remaining_numbers = [x for x in range(1, n_total + 1) if x not in known]
+        if target_number not in remaining_numbers:
+            return ModuleScoreResult(
+                {cell: _neutral() for cell in unopened_cells},
+                "global_assignment_prior: target不在剩餘集合，回傳中性",
+            )
+
+        result: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for cell in unopened_cells:
+            others = [c for c in unopened_cells if c != cell]
+            other_nums = [x for x in remaining_numbers if x != target_number]
+            compat_pairs: List[Tuple[float, Cell, int]] = []
+            for oc in others:
+                for num in other_nums:
+                    compat_pairs.append((self._cell_number_compat(board, oc, num), oc, num))
+            compat_pairs.sort(reverse=True, key=lambda x: x[0])
+            used_cells: set[Cell] = set()
+            used_nums: set[int] = set()
+            agg_scores: List[float] = []
+            for sc, oc, num in compat_pairs:
+                if oc in used_cells or num in used_nums:
+                    continue
+                used_cells.add(oc)
+                used_nums.add(num)
+                agg_scores.append(sc)
+                if len(used_cells) >= len(others):
+                    break
+            target_fit = self._cell_number_compat(board, cell, target_number)
+            assignment_quality = _mean(agg_scores) if agg_scores else _neutral()
+            global_score = _clamp_01(0.65 * target_fit + 0.35 * assignment_quality)
+            result[cell] = global_score
+            details[cell] = {
+                "target_compatibility": target_fit,
+                "greedy_assignment_quality": assignment_quality,
+                "global_assignment_score": global_score,
+            }
+
+        return ModuleScoreResult(result, "global_assignment_prior: 固定target後估計剩餘唯一分配品質", details=details)
+
+
 MODULES: Dict[str, ScoringModule] = {
     "logic_rule": LogicRuleModule(),
     "pattern_model": PatternModelModule(),
     "prior_model": PriorModelModule(),
+    "directional_consistency": DirectionalConsistencyModule(),
+    "line_consistency": LineConsistencyModule(),
+    "global_assignment_prior": GlobalAssignmentPriorModule(),
 }

--- a/tests/test_deep_modules_and_eval.py
+++ b/tests/test_deep_modules_and_eval.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from scripts.run_gogo_formal_eval import _masked_board, load_eval_cases, random_weight_search
+from src.inference_service import run_inference
+from src.scoring_modules import MODULES
+
+
+def _board_3x4() -> list[list[int]]:
+    return [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+    ]
+
+
+def test_arbitrary_board_size_infer_and_module_scores_finite() -> None:
+    full = _board_3x4()
+    masked = [row[:] for row in full]
+    masked[1][1] = -1
+    masked[2][3] = -1
+    res = run_inference(masked, target_number=6, source="unit")
+    assert res["status"] == "ok"
+    for cand in res["candidate_cells"]:
+        assert isinstance(cand["row"], int)
+        for m in ("directional_consistency", "line_consistency", "global_assignment_prior"):
+            v = cand["module_scores"][m]
+            assert 0.0 <= float(v) <= 1.0
+            assert math.isfinite(float(v))
+
+
+def test_masking_ratio_floor_half() -> None:
+    full = _board_3x4()
+    masked, cells = _masked_board(full, 0.5, __import__("random").Random(1))
+    assert len(cells) == 6
+    assert sum(1 for row in masked for v in row if v == -1) == 6
+
+
+def test_weight_tuning_produces_normalized_weights() -> None:
+    full = _board_3x4()
+    masked = [row[:] for row in full]
+    masked[0][1] = -1
+    masked[2][2] = -1
+    eval_cases = [
+        (
+            type("Case", (), {"board_id": "x"})(),
+            masked,
+            2,
+            (0, 1),
+        )
+    ]
+    mods = [
+        "logic_rule",
+        "pattern_model",
+        "prior_model",
+        "directional_consistency",
+        "line_consistency",
+        "global_assignment_prior",
+    ]
+    best, records = random_weight_search(mods, trials=3, seed=7, eval_cases=eval_cases)
+    assert records
+    assert abs(sum(best.values()) - 1.0) < 1e-6
+
+
+def test_gogo_missing_fail_fast(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    try:
+        load_eval_cases(missing)
+        assert False, "expected failure"
+    except ValueError as exc:
+        assert "does not exist" in str(exc)
+
+
+def test_global_assignment_safe_fallback_information_insufficient() -> None:
+    board = [[-1]]
+    res = MODULES["global_assignment_prior"].score(board, [(0, 0)], 1)
+    assert (0, 0) in res.scores
+    assert 0.0 <= res.scores[(0, 0)] <= 1.0
+
+
+def test_baseline_only_path_not_broken() -> None:
+    board = [[1, -1, 3], [-1, 5, -1]]
+    out = run_inference(board, 4, source="unit", apply_reranker_stage=False)
+    assert out["metadata"]["ranking_stage"] == "baseline_only"

--- a/tests/test_ranking_features.py
+++ b/tests/test_ranking_features.py
@@ -9,18 +9,50 @@ def test_feature_schema_stable() -> None:
             "row": 1,
             "col": 1,
             "score": 0.9,
-            "module_scores": {"logic_rule": 0.9, "pattern_model": 0.1, "prior_model": 0.5},
+            "module_scores": {
+                "logic_rule": 0.9,
+                "pattern_model": 0.1,
+                "prior_model": 0.5,
+                "directional_consistency": 0.8,
+                "line_consistency": 0.7,
+                "global_assignment_prior": 0.6,
+            },
+            "module_details": {
+                "directional_consistency": {"left_order_score": 0.7, "directional_score": 0.8},
+                "line_consistency": {"row_residual_score": 0.9, "line_score": 0.7},
+                "global_assignment_prior": {"global_assignment_score": 0.6},
+            },
         },
         {
             "row": 1,
             "col": 2,
             "score": 0.7,
-            "module_scores": {"logic_rule": 0.8, "pattern_model": 0.4, "prior_model": 0.2},
+            "module_scores": {
+                "logic_rule": 0.8,
+                "pattern_model": 0.4,
+                "prior_model": 0.2,
+                "directional_consistency": 0.5,
+                "line_consistency": 0.4,
+                "global_assignment_prior": 0.3,
+            },
         },
     ]
-    rows = build_candidate_feature_rows("c1", (2, 2), candidates, true_cell_1_based=(1, 2))
+    board = [[1, -1], [-1, 4]]
+    rows = build_candidate_feature_rows(
+        "c1",
+        (2, 2),
+        candidates,
+        true_cell_1_based=(1, 2),
+        board=board,
+        target_number=2,
+    )
     assert rows[0]["case_id"] == "c1"
     assert rows[0]["module_consensus_top3"] >= 0
     assert rows[0]["baseline_rank"] == 1
     assert rows[1]["label"] == 1
+    assert "directional_score" in rows[0]
+    assert "line_score" in rows[0]
+    assert "global_assignment_score" in rows[0]
+    assert "same_row_known_density" in rows[0]
+    assert "relative_rank_within_diag" in rows[0]
     assert FEATURE_SCHEMA_VERSION.startswith("ranking_features_")

--- a/tests/test_single_board_top5_eval.py
+++ b/tests/test_single_board_top5_eval.py
@@ -36,6 +36,7 @@ def test_single_board_top5_eval_case() -> None:
         true_cell_0_based=true_cell_0_based,
     )
     assert validation["masked_count"] == 40
+    assert validation["shape"] == [8, 10]
     assert validation["target_cell_0_based"] == [1, 4]
 
     result = infer_target_position(masked_board, target_number, source="single_board_test")


### PR DESCRIPTION
### Motivation
- Upgrade the existing local-neighbor heuristics into a deeper, testable inference pipeline that evaluates left/right/up/down, full rows/cols/diagonals, and a global unique-assignment prior. 
- Keep the existing mainline architecture (`scoring_modules` → `ranking_features` → `reranker` → `inference_service`) and make the new logic plug into the same flow and config-driven weights. 
- Provide a configurable, reproducible formal evaluation over `gogo/`-style board data with automated weight tuning and ablation to find improved module weights.

### Description
- Added three new scoring modules in `src/scoring_modules.py`: `directional_consistency`, `line_consistency`, and `global_assignment_prior`, and registered them in `MODULES`; each module returns per-cell scores and optional per-cell `details` used by features. 
- Propagated module `details` through `src/inference_service.py` into candidate payloads and normalized runtime-supplied `module_weights` (sum-to-1), and passed `board`/`target_number` into feature builder so new features are consumed by reranker. 
- Extended `src/ranking_features.py` with the requested directional/line/global feature columns plus density and relative-rank features while keeping the feature schema check and reranker fallback logic intact. 
- Generalized single-case validation in `src/inference_facade.py` from fixed 8x10/1..80/mask40 to arbitrary rectangular boards with configurable `masking_ratio`. 
- Added a configurable formal evaluation and weight-search script `scripts/run_gogo_formal_eval.py` (default `--input-dir gogo`) that does recursive JSON discovery, 50% masking (configurable), per-target inference, random weight search, and ablation; updated `configs/inference.yaml` to enable new modules and include a `weight_tuning` section. 
- Added tests and small test updates: `tests/test_deep_modules_and_eval.py` (new), updated `tests/test_ranking_features.py` and `tests/test_single_board_top5_eval.py` to assert new fields and generalized validation.

### Testing
- Installed dev dependencies and ran static checks with `pip install -r requirements-dev.txt` and `flake8 src tests`, and ensured Python files compile with `python -m py_compile $(git ls-files '*.py')`. 
- Ran the full test-suite with `pytest -q`, which passed: `41 passed`. 
- Executed the formal-eval smoke run `python scripts/run_gogo_formal_eval.py --input-dir tmp_eval_input --output-dir reports/gogo_eval_smoke --seeds 2026 --weight-trials 5` which produced `summary.json` and `weight_search_results.csv` and returned normalized `best_weights` (sum = 1). 
- Verified fail-fast behavior with `python scripts/run_gogo_formal_eval.py --input-dir does_not_exist --output-dir reports/gogo_eval_missing` which raised the expected `Fail-fast: input-dir does not exist` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ccd929188324b47516987f9afe82)