### PR TITLE
Add directional/line/global scoring modules, feature v2, and mainline evaluation tooling

### DIFF
--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -3,9 +3,18 @@ modules:
     logic_rule: true
     pattern_model: true
     prior_model: true
+    directional_consistency: true
+    line_consistency: true
+    global_assignment_prior: true
   weights:
-    logic_rule: 0.4
-    pattern_model: 0.4
-    prior_model: 0.2
+    logic_rule: 0.24
+    pattern_model: 0.16
+    prior_model: 0.12
+    directional_consistency: 0.2
+    line_consistency: 0.18
+    global_assignment_prior: 0.1
+  settings:
+    global_assignment_prior:
+      assignment_mode: exact
   aggregator:
     type: weighted_average

--- a/scripts/run_gogo_mainline_eval.py
+++ b/scripts/run_gogo_mainline_eval.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.inference_config import load_module_weights
+from src.mainline_eval import (
+    CORE_MODULES,
+    discover_full_boards_with_audit,
+    random_weight_candidates,
+    run_weighted_eval,
+    write_csv,
+)
+from src.inference_config import load_module_settings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-dir", default="gogo")
+    parser.add_argument("--output-dir", default="reports/mainline_eval")
+    parser.add_argument("--masking-ratio", type=float, default=0.5)
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument("--weight-trials", type=int, default=20)
+    parser.add_argument("--apply-reranker-stage", action="store_true")
+    args = parser.parse_args()
+
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+    discovery = discover_full_boards_with_audit(input_dir)
+    boards = discovery.boards
+    baseline_weights = load_module_weights()
+    module_settings_snapshot = load_module_settings()
+
+    search_rows = []
+    best = None
+    candidates = [baseline_weights] + random_weight_candidates(CORE_MODULES, args.weight_trials, args.seed)
+    for idx, weights in enumerate(candidates):
+        per_case, metrics = run_weighted_eval(
+            boards=boards,
+            weights=weights,
+            masking_ratio=args.masking_ratio,
+            repeats=args.repeats,
+            seed=args.seed + idx * 1000,
+            apply_reranker_stage=args.apply_reranker_stage,
+        )
+        search_rows.append({"trial": idx, "weights": json.dumps(weights, ensure_ascii=False), **metrics})
+        score_key = (metrics["top1_hit_rate"], metrics["top3_hit_rate"], metrics["mrr"], -metrics["mean_rank"])
+        if best is None or score_key > best[0]:
+            best = (score_key, weights, metrics, per_case)
+
+    assert best is not None
+    best_weights = best[1]
+    best_metrics = best[2]
+    best_per_case = best[3]
+    _, baseline_metrics = run_weighted_eval(
+        boards=boards,
+        weights=baseline_weights,
+        masking_ratio=args.masking_ratio,
+        repeats=args.repeats,
+        seed=args.seed,
+        apply_reranker_stage=args.apply_reranker_stage,
+    )
+
+    ablation_rows = []
+    for module in CORE_MODULES:
+        ablated = {k: v for k, v in best_weights.items() if k != module}
+        total = sum(ablated.values())
+        if total > 0:
+            ablated = {k: v / total for k, v in ablated.items()}
+        _, metrics = run_weighted_eval(
+            boards=boards,
+            weights=ablated,
+            masking_ratio=args.masking_ratio,
+            repeats=args.repeats,
+            seed=args.seed + 5000,
+            apply_reranker_stage=args.apply_reranker_stage,
+        )
+        ablation_rows.append({"drop_module": module, "weights": json.dumps(ablated, ensure_ascii=False), **metrics})
+
+    write_csv(output_dir / "per_case_results.csv", best_per_case)
+    write_csv(output_dir / "weight_search_results.csv", search_rows)
+    write_csv(output_dir / "ablation_results.csv", ablation_rows)
+    summary = {
+        "best_weights": best_weights,
+        "best_metric_summary": best_metrics,
+        "baseline_metric_summary": baseline_metrics,
+        "delta_vs_baseline": {k: best_metrics[k] - baseline_metrics.get(k, 0.0) for k in best_metrics},
+        "num_boards": len(boards),
+        "invalid_board_count": int(sum(discovery.invalid_reasons.values())),
+        "invalid_reasons": discovery.invalid_reasons,
+        "apply_reranker_stage": bool(args.apply_reranker_stage),
+        "module_settings_snapshot": module_settings_snapshot,
+    }
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/board_geometry.py
+++ b/src/board_geometry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+Cell = Tuple[int, int]
+
+
+def main_diagonal_cells(rows: int, cols: int) -> List[Cell]:
+    limit = min(rows, cols)
+    return [(i, i) for i in range(limit)]
+
+
+def anti_diagonal_cells(rows: int, cols: int) -> List[Cell]:
+    limit = min(rows, cols)
+    return [(i, cols - 1 - i) for i in range(limit)]
+
+
+def cell_on_main_diagonal(cell: Cell, rows: int, cols: int) -> bool:
+    r, c = cell
+    return 0 <= r < rows and 0 <= c < cols and r == c and r < min(rows, cols)
+
+
+def cell_on_anti_diagonal(cell: Cell, rows: int, cols: int) -> bool:
+    r, c = cell
+    return 0 <= r < rows and 0 <= c < cols and (r + c == cols - 1) and r < min(rows, cols)
+
+
+def relative_rank_in_line(cells: List[Cell], cell: Cell) -> Optional[int]:
+    try:
+        return cells.index(cell)
+    except ValueError:
+        return None

--- a/src/inference_config.py
+++ b/src/inference_config.py
@@ -36,3 +36,13 @@ def load_module_weights(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, fl
         raise ValueError("Enabled module weights must sum to a positive value")
 
     return {k: v / total for k, v in active_weights.items()}
+
+
+def load_module_settings(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, Dict[str, object]]:
+    with config_path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    modules = data.get("modules", {})
+    settings = modules.get("settings", {})
+    if not isinstance(settings, dict):
+        raise ValueError("modules.settings must be a mapping")
+    return settings

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-from src.inference_config import load_module_weights
+from src.inference_config import load_module_settings, load_module_weights
 from src.ranking_features import build_candidate_feature_rows
 from src.reranker import apply_reranker
-from src.scoring_modules import MODULES, Cell, ModuleScoreResult
+from src.scoring_modules import Cell, ModuleScoreResult, build_modules
 
 
 @dataclass
@@ -81,6 +81,7 @@ def build_cell_candidates(
             "cell": cell,
             "score": 0.0,
             "module_scores": {},
+            "module_details": {},
         }
         for cell in unopened_cells
     ]
@@ -93,7 +94,7 @@ def _normalize_scores(raw_scores: Dict[Cell, float]) -> Dict[Cell, float]:
     min_v = min(values)
     max_v = max(values)
     if abs(max_v - min_v) < 1e-12:
-        return {k: 1.0 for k in raw_scores}
+        return {k: 0.5 for k in raw_scores}
     return {k: (v - min_v) / (max_v - min_v) for k, v in raw_scores.items()}
 
 
@@ -102,14 +103,17 @@ def score_candidates(
     candidates: List[Dict[str, object]],
     target_number: int,
     module_weights: Optional[Dict[str, float]] = None,
+    module_settings: Optional[Dict[str, Dict[str, object]]] = None,
 ) -> Tuple[List[Dict[str, object]], Dict[str, float], List[str]]:
     weights = module_weights or load_module_weights()
+    settings = module_settings if module_settings is not None else load_module_settings()
+    modules = build_modules(settings)
     explanations: List[str] = []
 
     for module_name, weight in weights.items():
-        if module_name not in MODULES:
+        if module_name not in modules:
             raise InferenceError(f"Unknown module in weights: {module_name}")
-        result: ModuleScoreResult = MODULES[module_name].score(
+        result: ModuleScoreResult = modules[module_name].score(
             board,
             [c["cell"] for c in candidates],
             target_number,
@@ -120,6 +124,8 @@ def score_candidates(
             cell = c["cell"]
             module_score = float(normalized.get(cell, 0.0))
             c["module_scores"][module_name] = module_score
+            if result.details:
+                c["module_details"][module_name] = result.details.get(cell, {})
             c["score"] += module_score * weight
 
     return candidates, weights, explanations
@@ -162,6 +168,7 @@ def run_inference(
     target_number: int,
     source: str,
     module_weights: Optional[Dict[str, float]] = None,
+    module_settings: Optional[Dict[str, Dict[str, object]]] = None,
     version: str = "v1",
     apply_reranker_stage: bool = True,
 ) -> Dict[str, Any]:
@@ -209,7 +216,13 @@ def run_inference(
         raise InferenceError("board has no unopened cells")
 
     candidates = build_cell_candidates(parsed.unopened_cells)
-    scored, weights, module_explanations = score_candidates(board, candidates, target_number, module_weights)
+    scored, weights, module_explanations = score_candidates(
+        board,
+        candidates,
+        target_number,
+        module_weights=module_weights,
+        module_settings=module_settings,
+    )
     ranked = rank_candidates(scored)
     best = ranked[0]
 
@@ -229,6 +242,7 @@ def run_inference(
                 "module_scores": {
                     k: round(float(v), 6) for k, v in sorted(cell["module_scores"].items())
                 },
+                "module_details": cell.get("module_details", {}),
             }
         )
 
@@ -255,6 +269,8 @@ def run_inference(
             board_shape=(parsed.rows, parsed.cols),
             candidates=baseline_candidate_cells,
             true_cell_1_based=None,
+            board=board,
+            target_number=target_number,
         )
         candidate_cells, rerank_meta = apply_reranker(baseline_candidate_cells, feature_rows)
 

--- a/src/mainline_eval.py
+++ b/src/mainline_eval.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import csv
+import json
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean, median
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+from src.inference_service import run_inference
+
+Board = List[List[int]]
+Cell = Tuple[int, int]
+
+CORE_MODULES = [
+    "logic_rule",
+    "pattern_model",
+    "prior_model",
+    "directional_consistency",
+    "line_consistency",
+    "global_assignment_prior",
+]
+
+
+@dataclass
+class FullBoardRecord:
+    board_id: str
+    board: Board
+    source: str
+
+
+@dataclass
+class DiscoveryArtifacts:
+    boards: List[FullBoardRecord]
+    invalid_reasons: Dict[str, int]
+
+
+def validate_full_board(full_board: Board) -> None:
+    if not full_board or not full_board[0]:
+        raise ValueError("board must be non-empty")
+    rows = len(full_board)
+    cols = len(full_board[0])
+    if any(len(row) != cols for row in full_board):
+        raise ValueError("board must be rectangular")
+    flat = [int(v) for row in full_board for v in row]
+    n = rows * cols
+    if len(set(flat)) != n:
+        raise ValueError("board values must be unique")
+    if sorted(flat) != list(range(1, n + 1)):
+        raise ValueError("board values must equal 1..N")
+
+
+def mask_full_board(full_board: Board, masking_ratio: float, seed: int) -> Tuple[Board, List[Cell]]:
+    validate_full_board(full_board)
+    rows = len(full_board)
+    cols = len(full_board[0])
+    n = rows * cols
+    mask_count = int(math.floor(n * masking_ratio))
+    rng = random.Random(seed)
+    cells = [(r, c) for r in range(rows) for c in range(cols)]
+    rng.shuffle(cells)
+    masked_cells = cells[:mask_count]
+    masked_set = set(masked_cells)
+    masked = [[-1 if (r, c) in masked_set else full_board[r][c] for c in range(cols)] for r in range(rows)]
+    return masked, masked_cells
+
+
+def _iter_boards_from_json(path: Path) -> Iterable[FullBoardRecord]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload if isinstance(payload, list) else payload.get("boards", [])
+    if isinstance(rows, dict):
+        rows = [rows]
+    for idx, item in enumerate(rows):
+        board = item
+        board_id = f"{path.stem}:{idx}"
+        if isinstance(item, dict):
+            board = item.get("board") or item.get("grid")
+            board_id = str(item.get("board_id", board_id))
+        if not isinstance(board, list):
+            continue
+        yield FullBoardRecord(board_id=board_id, board=board, source=str(path))
+
+
+def _parse_grid_lines(lines: List[str]) -> Board:
+    grid: Board = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        if "," in line:
+            parts = [x.strip() for x in line.split(",")]
+        else:
+            parts = line.split()
+        if not parts:
+            continue
+        grid.append([int(x) for x in parts])
+    return grid
+
+
+def _iter_boards_from_csv(path: Path) -> Iterable[FullBoardRecord]:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames and ("board" in reader.fieldnames or "grid" in reader.fieldnames):
+            for idx, row in enumerate(reader):
+                board_id = str(row.get("board_id", f"{path.stem}:{idx}"))
+                raw = row.get("board") or row.get("grid") or ""
+                try:
+                    board = json.loads(raw)
+                except Exception:
+                    continue
+                yield FullBoardRecord(board_id=board_id, board=board, source=str(path))
+            return
+    lines = path.read_text(encoding="utf-8").splitlines()
+    grid = _parse_grid_lines(lines)
+    if grid:
+        yield FullBoardRecord(board_id=f"{path.stem}:0", board=grid, source=str(path))
+
+
+def _iter_boards_from_txt(path: Path) -> Iterable[FullBoardRecord]:
+    text = path.read_text(encoding="utf-8")
+    blocks = [b.strip() for b in text.split("\n\n") if b.strip()]
+    for idx, block in enumerate(blocks):
+        lines = [x for x in block.splitlines() if x.strip()]
+        board_id = f"{path.stem}:{idx}"
+        if lines and lines[0].startswith("board_id:"):
+            board_id = lines[0].split(":", 1)[1].strip() or board_id
+            lines = lines[1:]
+        try:
+            grid = _parse_grid_lines(lines)
+        except Exception:
+            continue
+        if grid:
+            yield FullBoardRecord(board_id=board_id, board=grid, source=str(path))
+
+
+def discover_full_boards(input_dir: Path) -> List[FullBoardRecord]:
+    return discover_full_boards_with_audit(input_dir).boards
+
+
+def discover_full_boards_with_audit(input_dir: Path) -> DiscoveryArtifacts:
+    if not input_dir.exists():
+        raise FileNotFoundError(f"input-dir not found: {input_dir}")
+    out: List[FullBoardRecord] = []
+    invalid_reasons: Dict[str, int] = {}
+    iterators = {
+        ".json": _iter_boards_from_json,
+        ".csv": _iter_boards_from_csv,
+        ".txt": _iter_boards_from_txt,
+    }
+    for path in sorted(input_dir.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in iterators:
+            continue
+        try:
+            parsed_records = list(iterators[path.suffix.lower()](path))
+        except Exception as exc:
+            key = f"{path.suffix.lower()}_parse_error:{exc}"
+            invalid_reasons[key] = invalid_reasons.get(key, 0) + 1
+            continue
+        for rec in parsed_records:
+            try:
+                validate_full_board(rec.board)
+            except Exception as exc:
+                key = str(exc)
+                invalid_reasons[key] = invalid_reasons.get(key, 0) + 1
+                continue
+            out.append(rec)
+    if not out:
+        raise ValueError(f"no valid full-board data found under {input_dir}; reasons={invalid_reasons}")
+    return DiscoveryArtifacts(boards=out, invalid_reasons=invalid_reasons)
+
+
+def _rank_of_cell(candidates: Sequence[Dict[str, Any]], true_cell: Cell) -> Tuple[int, float, float]:
+    for idx, cand in enumerate(candidates, start=1):
+        if (cand["row"] - 1, cand["col"] - 1) == true_cell:
+            return idx, float(cand["score"]), float(cand["confidence_1_to_100"])
+    raise ValueError("true cell not found in candidates")
+
+
+def aggregate_metrics(ranks: Sequence[int]) -> Dict[str, float]:
+    if not ranks:
+        return {
+            "top1_hit_rate": 0.0,
+            "top3_hit_rate": 0.0,
+            "top5_hit_rate": 0.0,
+            "mrr": 0.0,
+            "mean_rank": 0.0,
+            "median_rank": 0.0,
+            "num_samples": 0,
+        }
+    return {
+        "top1_hit_rate": sum(1 for x in ranks if x <= 1) / len(ranks),
+        "top3_hit_rate": sum(1 for x in ranks if x <= 3) / len(ranks),
+        "top5_hit_rate": sum(1 for x in ranks if x <= 5) / len(ranks),
+        "mrr": mean(1.0 / x for x in ranks),
+        "mean_rank": mean(ranks),
+        "median_rank": float(median(ranks)),
+        "num_samples": len(ranks),
+    }
+
+
+def normalize_weights(weights: Dict[str, float]) -> Dict[str, float]:
+    clipped = {k: max(0.0, float(v)) for k, v in weights.items()}
+    total = sum(clipped.values())
+    if total <= 0:
+        return {k: 1.0 / len(clipped) for k in clipped}
+    return {k: v / total for k, v in clipped.items()}
+
+
+def random_weight_candidates(modules: List[str], trials: int, seed: int) -> List[Dict[str, float]]:
+    rng = random.Random(seed)
+    out = []
+    for _ in range(trials):
+        proposal = {m: rng.random() for m in modules}
+        out.append(normalize_weights(proposal))
+    return out
+
+
+def run_weighted_eval(
+    boards: Sequence[FullBoardRecord],
+    weights: Dict[str, float],
+    masking_ratio: float,
+    repeats: int,
+    seed: int,
+    apply_reranker_stage: bool = False,
+) -> Tuple[List[Dict[str, Any]], Dict[str, float]]:
+    per_case: List[Dict[str, Any]] = []
+    ranks: List[int] = []
+    for board_idx, rec in enumerate(boards):
+        for rep in range(repeats):
+            masked, masked_cells = mask_full_board(rec.board, masking_ratio, seed + board_idx * 997 + rep)
+            for target_cell in masked_cells:
+                target_number = int(rec.board[target_cell[0]][target_cell[1]])
+                result = run_inference(
+                    masked,
+                    target_number=target_number,
+                    source="mainline_eval",
+                    module_weights=weights,
+                    apply_reranker_stage=apply_reranker_stage,
+                )
+                rank, score, confidence = _rank_of_cell(result["candidate_cells"], target_cell)
+                ranks.append(rank)
+                per_case.append(
+                    {
+                        "board_id": rec.board_id,
+                        "source": rec.source,
+                        "repeat": rep,
+                        "rows": len(rec.board),
+                        "cols": len(rec.board[0]),
+                        "target_number": target_number,
+                        "true_row": target_cell[0] + 1,
+                        "true_col": target_cell[1] + 1,
+                        "rank": rank,
+                        "score": score,
+                        "confidence_1_to_100": confidence,
+                        "top1_hit": int(rank <= 1),
+                        "top3_hit": int(rank <= 3),
+                        "top5_hit": int(rank <= 5),
+                    }
+                )
+    return per_case, aggregate_metrics(ranks)
+
+
+def write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)

--- a/src/ranking_features.py
+++ b/src/ranking_features.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from src.board_geometry import anti_diagonal_cells, cell_on_anti_diagonal, cell_on_main_diagonal, main_diagonal_cells
 
-FEATURE_SCHEMA_VERSION = "ranking_features_v1"
+FEATURE_SCHEMA_VERSION = "ranking_features_v2"
 TOP_KS = (1, 3, 5)
 
 
@@ -13,12 +14,23 @@ def _dense_ranks(values: List[float]) -> List[int]:
     return [rank_map[v] for v in values]
 
 
+def _dense_rank_by_indices(all_scores: List[float], indices: List[int]) -> Dict[int, int]:
+    if not indices:
+        return {}
+    sub_scores = [all_scores[i] for i in indices]
+    sub_ranks = _dense_ranks(sub_scores)
+    return {idx: rank for idx, rank in zip(indices, sub_ranks)}
+
+
 def build_candidate_feature_rows(
     case_id: str,
     board_shape: Tuple[int, int],
     candidates: List[Dict[str, Any]],
     true_cell_1_based: Optional[Tuple[int, int]] = None,
+    board: Optional[List[List[int]]] = None,
+    target_number: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
+    _ = target_number
     rows, cols = board_shape
     if not candidates:
         return []
@@ -41,13 +53,72 @@ def build_candidate_feature_rows(
     max_center_dist = max(center_r + center_c, 1.0)
 
     out: List[Dict[str, Any]] = []
+    row_to_indices: Dict[int, List[int]] = {}
+    col_to_indices: Dict[int, List[int]] = {}
+    main_diag_indices: List[int] = []
+    anti_diag_indices: List[int] = []
+    for idx, candidate in enumerate(candidates):
+        row = int(candidate["row"])
+        col = int(candidate["col"])
+        row_to_indices.setdefault(row, []).append(idx)
+        col_to_indices.setdefault(col, []).append(idx)
+        zero_based = (row - 1, col - 1)
+        if cell_on_main_diagonal(zero_based, rows, cols):
+            main_diag_indices.append(idx)
+        if cell_on_anti_diagonal(zero_based, rows, cols):
+            anti_diag_indices.append(idx)
+
+    row_relative_ranks = {
+        row: _dense_rank_by_indices(baseline_scores, indices) for row, indices in row_to_indices.items()
+    }
+    col_relative_ranks = {
+        col: _dense_rank_by_indices(baseline_scores, indices) for col, indices in col_to_indices.items()
+    }
+    main_diag_relative_ranks = _dense_rank_by_indices(baseline_scores, main_diag_indices)
+    anti_diag_relative_ranks = _dense_rank_by_indices(baseline_scores, anti_diag_indices)
+
     for idx, candidate in enumerate(candidates):
         row = int(candidate["row"])
         col = int(candidate["col"])
         module_scores = candidate.get("module_scores", {})
+        module_details = candidate.get("module_details", {})
         consensus = {
             f"module_consensus_top{k}": sum(1 for mod_set in module_topk[k] if idx in mod_set) for k in TOP_KS
         }
+        directional = module_details.get("directional_consistency", {})
+        line = module_details.get("line_consistency", {})
+        global_details = module_details.get("global_assignment_prior", {})
+
+        row_known_density = 0.0
+        col_known_density = 0.0
+        main_diag_known_density = 0.0
+        anti_diag_known_density = 0.0
+        if board is not None and board and board[0]:
+            row_known_density = sum(1 for v in board[row - 1] if v != -1) / cols
+            col_known_density = sum(1 for rr in range(rows) if board[rr][col - 1] != -1) / rows
+            zero_based = (row - 1, col - 1)
+            if cell_on_main_diagonal(zero_based, rows, cols):
+                diag_cells = main_diagonal_cells(rows, cols)
+                limit = max(len(diag_cells), 1)
+                main_diag_known_density = sum(1 for rr, cc in diag_cells if board[rr][cc] != -1) / limit
+            else:
+                main_diag_known_density = 0.0
+            if cell_on_anti_diagonal(zero_based, rows, cols):
+                diag_cells = anti_diagonal_cells(rows, cols)
+                limit = max(len(diag_cells), 1)
+                anti_diag_known_density = sum(1 for rr, cc in diag_cells if board[rr][cc] != -1) / limit
+            else:
+                anti_diag_known_density = 0.0
+
+        row_rel = row_relative_ranks.get(row, {}).get(idx, 1)
+        col_rel = col_relative_ranks.get(col, {}).get(idx, 1)
+        zero_based = (row - 1, col - 1)
+        if cell_on_main_diagonal(zero_based, rows, cols):
+            diag_rel = main_diag_relative_ranks.get(idx, 1)
+        elif cell_on_anti_diagonal(zero_based, rows, cols):
+            diag_rel = anti_diag_relative_ranks.get(idx, 1)
+        else:
+            diag_rel = 1
 
         feature = {
             "case_id": case_id,
@@ -65,6 +136,38 @@ def build_candidate_feature_rows(
             "is_border": int(row in (1, rows) or col in (1, cols)),
             "is_corner": int((row in (1, rows)) and (col in (1, cols))),
             **consensus,
+            "directional_score": float(module_scores.get("directional_consistency", 0.0)),
+            "left_order_score": float(directional.get("left_order_score", 0.5)),
+            "right_order_score": float(directional.get("right_order_score", 0.5)),
+            "up_order_score": float(directional.get("up_order_score", 0.5)),
+            "down_order_score": float(directional.get("down_order_score", 0.5)),
+            "left_distance_score": float(directional.get("left_distance_score", 0.5)),
+            "right_distance_score": float(directional.get("right_distance_score", 0.5)),
+            "up_distance_score": float(directional.get("up_distance_score", 0.5)),
+            "down_distance_score": float(directional.get("down_distance_score", 0.5)),
+            "row_balance_score": float(directional.get("row_balance_score", 0.5)),
+            "col_balance_score": float(directional.get("col_balance_score", 0.5)),
+            "line_score": float(module_scores.get("line_consistency", 0.0)),
+            "row_residual_score": float(line.get("row_residual_score", 0.5)),
+            "col_residual_score": float(line.get("col_residual_score", 0.5)),
+            "main_diag_score": float(line.get("main_diag_score", 0.5)),
+            "anti_diag_score": float(line.get("anti_diag_score", 0.5)),
+            "row_monotonicity_score": float(line.get("row_monotonicity_score", 0.5)),
+            "col_monotonicity_score": float(line.get("col_monotonicity_score", 0.5)),
+            "diag_monotonicity_score": float(line.get("diag_monotonicity_score", 0.5)),
+            "row_percentile_fit": float(line.get("row_percentile_fit", 0.5)),
+            "col_percentile_fit": float(line.get("col_percentile_fit", 0.5)),
+            "diag_percentile_fit": float(line.get("diag_percentile_fit", 0.5)),
+            "global_assignment_score": float(
+                module_scores.get("global_assignment_prior", global_details.get("global_assignment_score", 0.5))
+            ),
+            "same_row_known_density": row_known_density,
+            "same_col_known_density": col_known_density,
+            "same_main_diag_known_density": main_diag_known_density,
+            "same_anti_diag_known_density": anti_diag_known_density,
+            "relative_rank_within_row": row_rel,
+            "relative_rank_within_col": col_rel,
+            "relative_rank_within_diag": diag_rel,
             "label": int(true_cell_1_based == (row, col)) if true_cell_1_based else None,
         }
 

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -1,16 +1,33 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, List, Protocol, Tuple
+import math
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+from src.board_geometry import (
+    anti_diagonal_cells,
+    cell_on_anti_diagonal,
+    cell_on_main_diagonal,
+    main_diagonal_cells,
+    relative_rank_in_line,
+)
+
+try:
+    from scipy.optimize import linear_sum_assignment
+except Exception:  # pragma: no cover - fallback exercised in tests via monkeypatch
+    linear_sum_assignment = None
 
 Board = List[List[int]]
 Cell = Tuple[int, int]
+NEUTRAL_SCORE = 0.5
 
 
 @dataclass
 class ModuleScoreResult:
     scores: Dict[Cell, float]
     explanation: str
+    details: Dict[Cell, Dict[str, float]] = field(default_factory=dict)
 
 
 class ScoringModule(Protocol):
@@ -82,8 +99,350 @@ class PriorModelModule:
         return ModuleScoreResult(result, "prior_model: 使用位置先驗（中心偏好）評分")
 
 
-MODULES: Dict[str, ScoringModule] = {
-    "logic_rule": LogicRuleModule(),
-    "pattern_model": PatternModelModule(),
-    "prior_model": PriorModelModule(),
+def _clip(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, v))
+
+
+def _known_values(cells: List[Tuple[int, int, int]]) -> List[int]:
+    return [v for _, _, v in cells if v != -1]
+
+
+def _order_score(values: List[int], target_number: int, expect_less: bool) -> float:
+    if not values:
+        return NEUTRAL_SCORE
+    if expect_less:
+        satisfied = sum(1 for v in values if v < target_number)
+    else:
+        satisfied = sum(1 for v in values if v > target_number)
+    return _clip(satisfied / len(values))
+
+
+def _distance_score(values: List[int], target_number: int, board_size: int) -> float:
+    if not values:
+        return NEUTRAL_SCORE
+    diffs = sorted(abs(v - target_number) for v in values)
+    nearest = diffs[0]
+    avg = sum(diffs) / len(diffs)
+    scale = max(board_size / 3.0, 1.0)
+    return _clip(1.0 - ((0.6 * nearest + 0.4 * avg) / scale))
+
+
+def _smoothness_score(values: List[int]) -> float:
+    if len(values) <= 2:
+        return NEUTRAL_SCORE
+    ordered = sorted(values)
+    gaps = [ordered[i + 1] - ordered[i] for i in range(len(ordered) - 1)]
+    if not gaps:
+        return NEUTRAL_SCORE
+    mu = sum(gaps) / len(gaps)
+    if mu <= 0:
+        return NEUTRAL_SCORE
+    variance = sum((g - mu) ** 2 for g in gaps) / len(gaps)
+    cv = math.sqrt(variance) / mu
+    return _clip(1.0 / (1.0 + cv))
+
+
+def _monotonicity_score(positioned_values: List[Tuple[int, int]]) -> float:
+    if len(positioned_values) <= 2:
+        return NEUTRAL_SCORE
+    positioned_values = sorted(positioned_values)
+    diffs = [positioned_values[i + 1][1] - positioned_values[i][1] for i in range(len(positioned_values) - 1)]
+    non_decreasing = sum(1 for d in diffs if d >= 0) / len(diffs)
+    non_increasing = sum(1 for d in diffs if d <= 0) / len(diffs)
+    return max(non_decreasing, non_increasing)
+
+
+def _residual_score(values: List[int], board_size: int) -> float:
+    if len(values) <= 2:
+        return NEUTRAL_SCORE
+    ordered = sorted(values)
+    gaps = [ordered[i + 1] - ordered[i] for i in range(len(ordered) - 1)]
+    med = median(gaps)
+    if med <= 0:
+        med = max(board_size / max(len(values), 1), 1.0)
+    residual = sum(abs(g - med) for g in gaps) / len(gaps)
+    return _clip(1.0 - residual / max(board_size / 2.0, 1.0))
+
+
+def _percentile_fit(known_values: List[int], target_number: int, line_length: int, idx: int, board_size: int) -> float:
+    if len(known_values) < 2:
+        return NEUTRAL_SCORE
+    sorted_vals = sorted(known_values)
+    low = sorted_vals[0]
+    high = sorted_vals[-1]
+    if high == low:
+        return NEUTRAL_SCORE
+    expected = idx / max(line_length - 1, 1)
+    actual = (target_number - low) / (high - low)
+    return _clip(1.0 - abs(actual - expected))
+
+
+def _line_values_with_positions(
+    board: Board,
+    cells: List[Cell],
+    candidate: Cell,
+    target_number: int,
+) -> List[Tuple[int, int]]:
+    out: List[Tuple[int, int]] = []
+    for i, (r, c) in enumerate(cells):
+        v = target_number if (r, c) == candidate else board[r][c]
+        if v != -1:
+            out.append((i, v))
+    return out
+
+
+def _directional_components(board: Board, candidate: Cell, target_number: int) -> Dict[str, float]:
+    rows, cols = len(board), len(board[0])
+    r, c = candidate
+    left = [board[r][cc] for cc in range(0, c) if board[r][cc] != -1]
+    right = [board[r][cc] for cc in range(c + 1, cols) if board[r][cc] != -1]
+    up = [board[rr][c] for rr in range(0, r) if board[rr][c] != -1]
+    down = [board[rr][c] for rr in range(r + 1, rows) if board[rr][c] != -1]
+    row_vals = [board[r][cc] for cc in range(cols) if board[r][cc] != -1] + [target_number]
+    col_vals = [board[rr][c] for rr in range(rows) if board[rr][c] != -1] + [target_number]
+    board_size = rows * cols
+    components = {
+        "left_order_score": _order_score(left, target_number, expect_less=True),
+        "right_order_score": _order_score(right, target_number, expect_less=False),
+        "up_order_score": _order_score(up, target_number, expect_less=True),
+        "down_order_score": _order_score(down, target_number, expect_less=False),
+        "left_distance_score": _distance_score(left, target_number, board_size),
+        "right_distance_score": _distance_score(right, target_number, board_size),
+        "up_distance_score": _distance_score(up, target_number, board_size),
+        "down_distance_score": _distance_score(down, target_number, board_size),
+        "row_balance_score": _smoothness_score(row_vals),
+        "col_balance_score": _smoothness_score(col_vals),
+    }
+    components["directional_consistency"] = sum(components.values()) / len(components)
+    return components
+
+
+def _line_components(board: Board, candidate: Cell, target_number: int) -> Dict[str, float]:
+    rows, cols = len(board), len(board[0])
+    r, c = candidate
+    board_size = rows * cols
+    row_cells = [(r, cc) for cc in range(cols)]
+    col_cells = [(rr, c) for rr in range(rows)]
+    row_pos = _line_values_with_positions(board, row_cells, candidate, target_number)
+    col_pos = _line_values_with_positions(board, col_cells, candidate, target_number)
+
+    row_vals = [v for _, v in row_pos]
+    col_vals = [v for _, v in col_pos]
+    row_residual = _residual_score(row_vals, board_size)
+    col_residual = _residual_score(col_vals, board_size)
+    row_mono = _monotonicity_score(row_pos)
+    col_mono = _monotonicity_score(col_pos)
+    row_pct = _percentile_fit(row_vals, target_number, cols, c, board_size)
+    col_pct = _percentile_fit(col_vals, target_number, rows, r, board_size)
+
+    main_diag = main_diagonal_cells(rows, cols) if cell_on_main_diagonal(candidate, rows, cols) else []
+    anti_diag = anti_diagonal_cells(rows, cols) if cell_on_anti_diagonal(candidate, rows, cols) else []
+
+    diag_scores = []
+    diag_monotonicity = []
+    diag_percentiles = []
+    for diag_cells in (main_diag, anti_diag):
+        if not diag_cells:
+            diag_scores.append(NEUTRAL_SCORE)
+            diag_monotonicity.append(NEUTRAL_SCORE)
+            diag_percentiles.append(NEUTRAL_SCORE)
+            continue
+        pos_vals = _line_values_with_positions(board, diag_cells, candidate, target_number)
+        vals = [v for _, v in pos_vals]
+        diag_scores.append(_residual_score(vals, board_size))
+        diag_monotonicity.append(_monotonicity_score(pos_vals))
+        diag_idx = relative_rank_in_line(diag_cells, candidate)
+        if diag_idx is None:
+            diag_percentiles.append(NEUTRAL_SCORE)
+            continue
+        diag_percentiles.append(_percentile_fit(vals, target_number, len(diag_cells), diag_idx, board_size))
+
+    components = {
+        "row_residual_score": row_residual,
+        "col_residual_score": col_residual,
+        "main_diag_score": diag_scores[0],
+        "anti_diag_score": diag_scores[1],
+        "row_monotonicity_score": row_mono,
+        "col_monotonicity_score": col_mono,
+        "diag_monotonicity_score": sum(diag_monotonicity) / len(diag_monotonicity),
+        "row_percentile_fit": row_pct,
+        "col_percentile_fit": col_pct,
+        "diag_percentile_fit": sum(diag_percentiles) / len(diag_percentiles),
+    }
+    components["line_consistency"] = sum(components.values()) / len(components)
+    return components
+
+
+def _cell_number_compatibility(board: Board, cell: Cell, number: int) -> float:
+    directional = _directional_components(board, cell, number)["directional_consistency"]
+    line = _line_components(board, cell, number)["line_consistency"]
+    rows, cols = len(board), len(board[0])
+    center_r = (rows - 1) / 2.0
+    center_c = (cols - 1) / 2.0
+    max_dist = max(center_r + center_c, 1.0)
+    prior = 1.0 - ((abs(cell[0] - center_r) + abs(cell[1] - center_c)) / max_dist)
+    return _clip(0.4 * directional + 0.4 * line + 0.2 * prior)
+
+
+class DirectionalConsistencyModule:
+    name = "directional_consistency"
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        scores: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for cell in unopened_cells:
+            components = _directional_components(board, cell, target_number)
+            scores[cell] = components["directional_consistency"]
+            details[cell] = components
+        return ModuleScoreResult(
+            scores,
+            "directional_consistency: 以左右上下順序、距離與列欄平滑性評估",
+            details=details,
+        )
+
+
+class LineConsistencyModule:
+    name = "line_consistency"
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        scores: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for cell in unopened_cells:
+            components = _line_components(board, cell, target_number)
+            scores[cell] = components["line_consistency"]
+            details[cell] = components
+        return ModuleScoreResult(
+            scores,
+            "line_consistency: 以整行整列與對角殘差/單調性/分位吻合度評估",
+            details=details,
+        )
+
+
+class GlobalAssignmentPriorModule:
+    name = "global_assignment_prior"
+
+    def __init__(self, assignment_mode: str = "exact") -> None:
+        self.assignment_mode = assignment_mode
+
+    @staticmethod
+    def _greedy_assignment_score(
+        board: Board,
+        cells: List[Cell],
+        numbers: List[int],
+    ) -> float:
+        if not cells or not numbers:
+            return NEUTRAL_SCORE
+        ranked_pairs = []
+        for number in numbers:
+            for cell in cells:
+                compat = _cell_number_compatibility(board, cell, number)
+                ranked_pairs.append((compat, number, cell))
+        ranked_pairs.sort(reverse=True, key=lambda x: x[0])
+        used_cells: set[Cell] = set()
+        used_numbers: set[int] = set()
+        total = 0.0
+        count = 0
+        for compat, number, cell in ranked_pairs:
+            if number in used_numbers or cell in used_cells:
+                continue
+            used_numbers.add(number)
+            used_cells.add(cell)
+            total += compat
+            count += 1
+            if len(used_cells) == len(cells):
+                break
+        if count == 0:
+            return NEUTRAL_SCORE
+        return total / count
+
+    @staticmethod
+    def _exact_assignment_score(
+        board: Board,
+        cells: List[Cell],
+        numbers: List[int],
+    ) -> Optional[float]:
+        if linear_sum_assignment is None or not cells or not numbers or len(cells) != len(numbers):
+            return None
+        matrix = []
+        for cell in cells:
+            row_costs = []
+            for number in numbers:
+                compatibility = _cell_number_compatibility(board, cell, number)
+                row_costs.append(1.0 - compatibility)
+            matrix.append(row_costs)
+        row_idx, col_idx = linear_sum_assignment(matrix)
+        if len(row_idx) == 0:
+            return None
+        compat_total = 0.0
+        for r_idx, c_idx in zip(row_idx.tolist(), col_idx.tolist()):
+            compat_total += 1.0 - matrix[r_idx][c_idx]
+        return compat_total / len(row_idx)
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        if len(unopened_cells) <= 1:
+            return ModuleScoreResult(
+                {cell: NEUTRAL_SCORE for cell in unopened_cells},
+                "global_assignment_prior: 資訊不足，返回中性分數",
+            )
+        rows, cols = len(board), len(board[0])
+        n_total = rows * cols
+        scores: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for anchor in unopened_cells:
+            board_with_anchor = [list(row) for row in board]
+            board_with_anchor[anchor[0]][anchor[1]] = target_number
+            others = [cell for cell in unopened_cells if cell != anchor]
+            opened_with_anchor = {
+                board_with_anchor[r][c]
+                for r in range(rows)
+                for c in range(cols)
+                if board_with_anchor[r][c] != -1
+            }
+            pool = [x for x in range(1, n_total + 1) if x not in opened_with_anchor]
+            used_exact = 0
+            used_greedy = 0
+            assignment_score = None
+            if self.assignment_mode == "exact":
+                assignment_score = self._exact_assignment_score(board_with_anchor, others, pool)
+                used_exact = int(assignment_score is not None)
+            if assignment_score is None:
+                assignment_score = self._greedy_assignment_score(board_with_anchor, others, pool)
+                used_greedy = 1
+            anchor_compat = _cell_number_compatibility(board, anchor, target_number)
+            final_score = _clip(0.5 * assignment_score + 0.5 * anchor_compat)
+            scores[anchor] = final_score
+            details[anchor] = {
+                "global_assignment_mode": 1.0 if self.assignment_mode == "exact" else 0.0,
+                "used_exact_assignment": float(used_exact),
+                "used_greedy_fallback": float(used_greedy),
+                "global_assignment_score": final_score,
+                "global_anchor_compatibility": anchor_compat,
+                "global_remaining_assignment_score": assignment_score,
+            }
+
+        return ModuleScoreResult(
+            scores,
+            "global_assignment_prior: 固定 target 後估計剩餘數字全局唯一分配一致性",
+            details=details,
+        )
+
+
+MODULE_FACTORIES = {
+    "logic_rule": lambda _cfg: LogicRuleModule(),
+    "pattern_model": lambda _cfg: PatternModelModule(),
+    "prior_model": lambda _cfg: PriorModelModule(),
+    "directional_consistency": lambda _cfg: DirectionalConsistencyModule(),
+    "line_consistency": lambda _cfg: LineConsistencyModule(),
+    "global_assignment_prior": lambda cfg: GlobalAssignmentPriorModule(
+        assignment_mode=str(cfg.get("assignment_mode", "exact"))
+    ),
 }
+
+
+def build_modules(module_settings: Optional[Dict[str, Dict[str, Any]]] = None) -> Dict[str, ScoringModule]:
+    settings = module_settings or {}
+    return {name: factory(settings.get(name, {})) for name, factory in MODULE_FACTORIES.items()}
+
+
+# backward-compatible default module map (do not mutate at runtime)
+MODULES: Dict[str, ScoringModule] = build_modules()

--- a/tests/test_inference_reranker_runtime.py
+++ b/tests/test_inference_reranker_runtime.py
@@ -31,7 +31,7 @@ def test_reranker_keeps_candidate_set() -> None:
             {
                 "enabled": True,
                 "version": "test",
-                "feature_schema_version": "ranking_features_v1",
+                "feature_schema_version": "ranking_features_v2",
                 "feature_columns": ["baseline_score"],
                 "weights": {"baseline_score": 1.0},
             }

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from src.inference_service import build_cell_candidates, rank_candidates, score_candidates
+from src.inference_service import _normalize_scores, build_cell_candidates, rank_candidates, score_candidates
 
 
 def test_module_weights_take_effect() -> None:
@@ -29,3 +29,45 @@ def test_module_weights_take_effect() -> None:
     top_logic = rank_candidates(scored_logic)[0]["cell"]
     top_prior = rank_candidates(scored_prior)[0]["cell"]
     assert top_logic != top_prior
+
+
+def test_module_settings_applied_even_when_module_weights_passed() -> None:
+    board = [[1, -1, 3], [-1, 5, -1]]
+    candidates = build_cell_candidates([(0, 1), (1, 0), (1, 2)])
+    scored, _, _ = score_candidates(
+        board,
+        candidates,
+        target_number=4,
+        module_weights={"global_assignment_prior": 1.0},
+        module_settings={"global_assignment_prior": {"assignment_mode": "greedy"}},
+    )
+    assert "global_assignment_prior" in scored[0]["module_details"]
+    assert scored[0]["module_details"]["global_assignment_prior"]["global_assignment_mode"] == 0.0
+
+
+def test_no_global_module_state_leakage_between_calls() -> None:
+    board = [[1, -1, 3], [-1, 5, -1]]
+    c1 = build_cell_candidates([(0, 1), (1, 0), (1, 2)])
+    out1, _, _ = score_candidates(
+        board,
+        c1,
+        target_number=4,
+        module_weights={"global_assignment_prior": 1.0},
+        module_settings={"global_assignment_prior": {"assignment_mode": "greedy"}},
+    )
+    c2 = build_cell_candidates([(0, 1), (1, 0), (1, 2)])
+    out2, _, _ = score_candidates(
+        board,
+        c2,
+        target_number=4,
+        module_weights={"global_assignment_prior": 1.0},
+        module_settings={"global_assignment_prior": {"assignment_mode": "exact"}},
+    )
+    assert out1[0]["module_details"]["global_assignment_prior"]["global_assignment_mode"] == 0.0
+    assert out2[0]["module_details"]["global_assignment_prior"]["global_assignment_mode"] == 1.0
+
+
+def test_constant_module_scores_are_neutral_not_all_ones() -> None:
+    out = _normalize_scores({(0, 0): 2.0, (0, 1): 2.0})
+    assert out[(0, 0)] == 0.5
+    assert out[(0, 1)] == 0.5

--- a/tests/test_mainline_upgrade.py
+++ b/tests/test_mainline_upgrade.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+from unittest.mock import patch
+from pathlib import Path
+
+from src.board_geometry import anti_diagonal_cells, main_diagonal_cells
+from src.inference_service import run_inference
+from src.mainline_eval import (
+    CORE_MODULES,
+    FullBoardRecord,
+    discover_full_boards,
+    discover_full_boards_with_audit,
+    mask_full_board,
+    random_weight_candidates,
+    run_weighted_eval,
+)
+from src.scoring_modules import MODULES, _line_components
+
+
+def test_any_size_board_parse_infer_evaluate() -> None:
+    board = [[1, 2, 3], [4, -1, 6], [7, 8, -1], [10, 11, 12]]
+    result = run_inference(board, target_number=5, source="test")
+    assert result["status"] == "ok"
+    assert result["board_shape"] == {"rows": 4, "cols": 3}
+    assert len(result["candidate_cells"]) == 2
+
+
+def test_masking_ratio_50pct_floor() -> None:
+    full = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    masked, masked_cells = mask_full_board(full, masking_ratio=0.5, seed=123)
+    assert len(masked_cells) == math.floor(9 * 0.5)
+    assert sum(1 for row in masked for v in row if v == -1) == 4
+
+
+def test_new_modules_scores_are_finite() -> None:
+    board = [[1, -1, 3], [-1, 5, -1], [7, 8, 9]]
+    unopened = [(0, 1), (1, 0), (1, 2)]
+    target = 4
+    for module in ("directional_consistency", "line_consistency", "global_assignment_prior"):
+        result = MODULES[module].score(board, unopened, target)
+        for value in result.scores.values():
+            assert 0.0 <= value <= 1.0
+            assert math.isfinite(value)
+
+
+def test_weight_search_generates_normalized_weights() -> None:
+    candidates = random_weight_candidates(CORE_MODULES, trials=5, seed=7)
+    assert candidates
+    for w in candidates:
+        assert abs(sum(w.values()) - 1.0) < 1e-9
+
+
+def test_missing_input_dir_fail_fast(tmp_path: Path) -> None:
+    missing = tmp_path / "no_gogo_here"
+    try:
+        discover_full_boards(missing)
+    except FileNotFoundError as exc:
+        assert "input-dir not found" in str(exc)
+    else:
+        raise AssertionError("expected fail-fast FileNotFoundError")
+
+
+def test_global_assignment_prior_safe_fallback() -> None:
+    board = [[-1]]
+    result = MODULES["global_assignment_prior"].score(board, [(0, 0)], 1)
+    assert result.scores[(0, 0)] == 0.5
+
+
+def test_baseline_only_path_not_broken() -> None:
+    result = run_inference([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    assert result["metadata"]["ranking_stage"] == "baseline_only"
+
+
+def test_gogo_eval_script_outputs_files(tmp_path: Path) -> None:
+    input_dir = tmp_path / "gogo"
+    input_dir.mkdir()
+    (input_dir / "boards.json").write_text(
+        json.dumps([{"board_id": "b1", "board": [[1, 2], [3, 4]]}]),
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "out"
+    subprocess.check_call(
+        [
+            sys.executable,
+            "scripts/run_gogo_mainline_eval.py",
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(out_dir),
+            "--repeats",
+            "1",
+            "--weight-trials",
+            "2",
+        ]
+    )
+    assert (out_dir / "per_case_results.csv").exists()
+    assert (out_dir / "summary.json").exists()
+
+
+def test_discover_full_boards_supports_json_csv_txt(tmp_path: Path) -> None:
+    root = tmp_path / "gogo"
+    root.mkdir()
+    (root / "a.json").write_text(json.dumps([{"board_id": "j1", "board": [[1, 2], [3, 4]]}]), encoding="utf-8")
+    (root / "b.csv").write_text('board_id,board\nc1,"[[1,2],[3,4]]"\n', encoding="utf-8")
+    (root / "c.txt").write_text("board_id:t1\n1 2\n3 4\n", encoding="utf-8")
+    boards = discover_full_boards(root)
+    ids = {x.board_id for x in boards}
+    assert {"j1", "c1", "t1"}.issubset(ids)
+
+
+def test_weight_search_eval_defaults_to_reranker_disabled() -> None:
+    calls = []
+
+    def _fake_run_inference(*args, **kwargs):
+        calls.append(kwargs.get("apply_reranker_stage"))
+        return {
+            "candidate_cells": [
+                {"row": 1, "col": 1, "score": 1.0, "confidence_1_to_100": 99.0},
+            ]
+        }
+
+    with patch("src.mainline_eval.run_inference", side_effect=_fake_run_inference):
+        run_weighted_eval(
+            boards=[FullBoardRecord(board_id="b", board=[[1]], source="s")],
+            weights={m: 1.0 / len(CORE_MODULES) for m in CORE_MODULES},
+            masking_ratio=1.0,
+            repeats=1,
+            seed=1,
+        )
+    assert calls and all(flag is False for flag in calls)
+
+
+def test_global_assignment_exact_path() -> None:
+    board = [[1, -1], [-1, 4]]
+    result = MODULES["global_assignment_prior"].score(board, [(0, 1), (1, 0)], 2)
+    cell_details = result.details[(0, 1)]
+    assert cell_details["used_exact_assignment"] in (0.0, 1.0)
+    assert cell_details["global_assignment_mode"] == 1.0
+
+
+def test_global_assignment_greedy_fallback_path() -> None:
+    module = MODULES["global_assignment_prior"].__class__(assignment_mode="exact")
+    with patch("src.scoring_modules.linear_sum_assignment", None):
+        result = module.score([[1, -1], [-1, 4]], [(0, 1), (1, 0)], 2)
+    details = result.details[(0, 1)]
+    assert details["used_greedy_fallback"] == 1.0
+
+
+def test_discover_full_boards_skips_bad_json_csv_txt_without_crashing(tmp_path: Path) -> None:
+    root = tmp_path / "gogo"
+    root.mkdir()
+    (root / "ok.json").write_text(json.dumps([{"board_id": "ok", "board": [[1, 2], [3, 4]]}]), encoding="utf-8")
+    (root / "bad.json").write_text("{oops", encoding="utf-8")
+    (root / "bad.csv").write_text("board_id,board\nx,not_json\n", encoding="utf-8")
+    (root / "bad.txt").write_text("board_id:t\n1 a\n", encoding="utf-8")
+    artifacts = discover_full_boards_with_audit(root)
+    assert any(b.board_id == "ok" for b in artifacts.boards)
+    assert artifacts.invalid_reasons
+
+
+def test_shared_diagonal_helper_consistent_between_features_and_scoring() -> None:
+    board = [[1, -1, 3], [4, -1, 6], [7, 8, 9]]
+    component = _line_components(board, (1, 1), 5)
+    main_diag = main_diagonal_cells(3, 3)
+    anti_diag = anti_diagonal_cells(3, 3)
+    assert (1, 1) in main_diag
+    assert (1, 1) in anti_diag
+    assert component["main_diag_score"] >= 0.0
+
+
+def test_summary_contains_apply_reranker_stage_and_settings_snapshot(tmp_path: Path) -> None:
+    input_dir = tmp_path / "gogo2"
+    input_dir.mkdir()
+    (input_dir / "boards.json").write_text(
+        json.dumps([{"board_id": "b1", "board": [[1, 2], [3, 4]]}]),
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "out2"
+    subprocess.check_call(
+        [
+            sys.executable,
+            "scripts/run_gogo_mainline_eval.py",
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(out_dir),
+            "--weight-trials",
+            "1",
+        ]
+    )
+    summary = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+    assert "apply_reranker_stage" in summary
+    assert "module_settings_snapshot" in summary

--- a/tests/test_ranking_features.py
+++ b/tests/test_ranking_features.py
@@ -9,18 +9,62 @@ def test_feature_schema_stable() -> None:
             "row": 1,
             "col": 1,
             "score": 0.9,
-            "module_scores": {"logic_rule": 0.9, "pattern_model": 0.1, "prior_model": 0.5},
+            "module_scores": {
+                "logic_rule": 0.9,
+                "pattern_model": 0.1,
+                "prior_model": 0.5,
+                "directional_consistency": 0.4,
+                "line_consistency": 0.6,
+                "global_assignment_prior": 0.3,
+            },
+            "module_details": {
+                "directional_consistency": {"left_order_score": 0.5},
+                "line_consistency": {"row_residual_score": 0.5},
+            },
         },
         {
             "row": 1,
             "col": 2,
             "score": 0.7,
-            "module_scores": {"logic_rule": 0.8, "pattern_model": 0.4, "prior_model": 0.2},
+            "module_scores": {
+                "logic_rule": 0.8,
+                "pattern_model": 0.4,
+                "prior_model": 0.2,
+                "directional_consistency": 0.5,
+                "line_consistency": 0.7,
+                "global_assignment_prior": 0.4,
+            },
+            "module_details": {
+                "directional_consistency": {"left_order_score": 0.7},
+                "line_consistency": {"row_residual_score": 0.7},
+            },
         },
     ]
-    rows = build_candidate_feature_rows("c1", (2, 2), candidates, true_cell_1_based=(1, 2))
+    rows = build_candidate_feature_rows(
+        "c1",
+        (2, 2),
+        candidates,
+        true_cell_1_based=(1, 2),
+        board=[[1, -1], [-1, 4]],
+        target_number=2,
+    )
     assert rows[0]["case_id"] == "c1"
     assert rows[0]["module_consensus_top3"] >= 0
     assert rows[0]["baseline_rank"] == 1
+    assert "directional_score" in rows[0]
+    assert "line_score" in rows[0]
+    assert "global_assignment_score" in rows[0]
     assert rows[1]["label"] == 1
     assert FEATURE_SCHEMA_VERSION.startswith("ranking_features_")
+
+
+def test_relative_rank_dense_with_duplicate_scores() -> None:
+    candidates = [
+        {"row": 1, "col": 1, "score": 0.9, "module_scores": {}},
+        {"row": 1, "col": 2, "score": 0.9, "module_scores": {}},
+        {"row": 1, "col": 3, "score": 0.7, "module_scores": {}},
+    ]
+    rows = build_candidate_feature_rows("dup", (1, 3), candidates)
+    assert rows[0]["relative_rank_within_row"] == 1
+    assert rows[1]["relative_rank_within_row"] == 1
+    assert rows[2]["relative_rank_within_row"] == 2


### PR DESCRIPTION
### Motivation
- Introduce richer scoring signals (directional consistency, line consistency, and a global assignment prior) to improve inference ranking and enable weight search and ablation studies at scale.
- Surface per-module details and module settings so the reranker can consume richer features and configuration snapshots can be recorded for reproducibility.
- Provide a reproducible mainline evaluation script to search weights, run ablations, and produce CSV/JSON summaries for production-style comparisons.

### Description
- Added three new scoring modules and supporting logic in `src/scoring_modules.py`: `directional_consistency`, `line_consistency`, and `global_assignment_prior`, together with component functions, per-cell `details`, module factories, and `build_modules()`; retained a backward-compatible `MODULES` map.
- Added geometry helpers in `src/board_geometry.py` used by both scoring and feature code.
- Extended config handling in `src/inference_config.py` with `load_module_settings()` and updated `configs/inference.yaml` to enable the new modules, set default weights, and add `global_assignment_prior.assignment_mode` setting.
- Updated `src/inference_service.py` to accept `module_settings`, attach `module_details` to candidate outputs, normalize constant module scores to a neutral `0.5`, and build modules via `build_modules()` so settings are applied per-call.
- Upgraded the feature schema to `ranking_features_v2` and expanded `src/ranking_features.py` to emit many new features (directional, line, global assignment scores, known-density features, and relative ranks within rows/cols/diags) and to keep feature computation consistent with scoring internals.
- Added evaluation tooling in `src/mainline_eval.py` for discovering full boards, masking, randomized weight candidates, running weighted evaluations, aggregating metrics, and writing CSV/JSON outputs; and added a convenience CLI `scripts/run_gogo_mainline_eval.py` to run searches and produce a summary.
- Added/updated tests in `tests/` to cover the new modules, settings propagation, feature schema changes, mainline eval script behavior, and edge cases around global assignment fallback.

### Testing
- Ran the full automated test suite with `pytest -q`, which executed existing and newly added unit/integration tests (including `tests/test_mainline_upgrade.py` that invokes `scripts/run_gogo_mainline_eval.py`); all tests passed.
- The mainline evaluation script was exercised by tests and verified to produce `per_case_results.csv` and `summary.json` and to include `apply_reranker_stage` and `module_settings_snapshot` in the summary JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ccd929188324b47516987f9afe82)