### PR TITLE
Add multi-target inference, gated aggregation, and joint assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ## API
 - `GET /health`
 - `POST /infer_target_position`
+- `POST /infer_multi_target_positions`
 
 ### Request example
 ```json

--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -18,12 +18,14 @@ modules:
       assignment_mode: exact
   aggregator:
     type: gate_then_weighted_sum
-    normalization_mode: disabled
+    normalization_mode: light
     gating_enabled: true
     contradiction_penalty_weight: 1.0
     hard_violation_threshold: 2.0
     hard_gate_multiplier: 0.05
     soft_gate_floor: 0.25
+    score_spread_enabled: true
+    score_spread_temperature: 0.2
     elimination_version: v2
 
 joint_assignment:

--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -17,4 +17,20 @@ modules:
     global_assignment_prior:
       assignment_mode: exact
   aggregator:
-    type: weighted_average
+    type: gate_then_weighted_sum
+    normalization_mode: disabled
+    gating_enabled: true
+    contradiction_penalty_weight: 1.0
+    hard_violation_threshold: 2.0
+    hard_gate_multiplier: 0.05
+    soft_gate_floor: 0.25
+    elimination_version: v2
+
+joint_assignment:
+  enabled: true
+  assignment_mode: exact
+  contradiction_alpha: 0.35
+  gate_beta: 0.2
+  dedup_enabled: true
+  top_k_per_target: 10
+  version: v1

--- a/src/api.py
+++ b/src/api.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from fastapi import FastAPI, HTTPException
 
-from src.inference_facade import infer_target_position
-from src.inference_models import InferTargetPositionRequest, InferTargetPositionResponse
+from src.inference_facade import infer_multi_target_positions, infer_target_position
+from src.inference_models import (
+    InferMultiTargetPositionRequest,
+    InferMultiTargetPositionResponse,
+    InferTargetPositionRequest,
+    InferTargetPositionResponse,
+)
 from src.inference_service import InferenceError
 
 app = FastAPI(title="Scratchcard Board Inference Service", version="v1")
@@ -23,5 +28,18 @@ def infer_target_position_api(payload: InferTargetPositionRequest) -> InferTarge
             source=payload.source,
         )
         return InferTargetPositionResponse(**result)
+    except InferenceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@app.post("/infer_multi_target_positions", response_model=InferMultiTargetPositionResponse)
+def infer_multi_target_positions_api(payload: InferMultiTargetPositionRequest) -> InferMultiTargetPositionResponse:
+    try:
+        result = infer_multi_target_positions(
+            board=payload.board,
+            target_numbers=payload.target_numbers,
+            source=payload.source,
+        )
+        return InferMultiTargetPositionResponse(**result)
     except InferenceError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/src/inference_config.py
+++ b/src/inference_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 import yaml
 
@@ -9,9 +9,13 @@ import yaml
 DEFAULT_CONFIG_PATH = Path("configs/inference.yaml")
 
 
-def load_module_weights(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, float]:
+def _load_raw_config(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
     with config_path.open("r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+        return yaml.safe_load(fh) or {}
+
+
+def load_module_weights(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, float]:
+    data = _load_raw_config(config_path)
 
     modules = data.get("modules", {})
     enabled = modules.get("enabled", {})
@@ -39,10 +43,26 @@ def load_module_weights(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, fl
 
 
 def load_module_settings(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, Dict[str, object]]:
-    with config_path.open("r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+    data = _load_raw_config(config_path)
     modules = data.get("modules", {})
     settings = modules.get("settings", {})
     if not isinstance(settings, dict):
         raise ValueError("modules.settings must be a mapping")
     return settings
+
+
+def load_aggregator_config(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    data = _load_raw_config(config_path)
+    modules = data.get("modules", {})
+    aggregator = modules.get("aggregator", {})
+    if not isinstance(aggregator, dict):
+        raise ValueError("modules.aggregator must be a mapping")
+    return aggregator
+
+
+def load_joint_assignment_config(config_path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    data = _load_raw_config(config_path)
+    cfg = data.get("joint_assignment", {})
+    if not isinstance(cfg, dict):
+        raise ValueError("joint_assignment must be a mapping")
+    return cfg

--- a/src/inference_facade.py
+++ b/src/inference_facade.py
@@ -2,11 +2,23 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
-from src.inference_service import run_inference
+from src.inference_service import run_inference, run_multi_target_inference
 
 
 def infer_target_position(board: List[List[int]], target_number: int, source: str = "manual") -> Dict[str, Any]:
     return run_inference(board=board, target_number=target_number, source=source)
+
+
+def infer_multi_target_positions(
+    board: List[List[int]],
+    target_numbers: List[int],
+    source: str = "manual",
+) -> Dict[str, Any]:
+    return run_multi_target_inference(
+        board=board,
+        target_numbers=target_numbers,
+        source=source,
+    )
 
 
 def map_score_to_confidence_1_100(score: float, min_score: float, max_score: float) -> float:

--- a/src/inference_models.py
+++ b/src/inference_models.py
@@ -78,6 +78,7 @@ class CandidateCell(BestCell):
     support_score: float = 0.0
     contradiction_penalty: float = 0.0
     gated_score: float = 0.0
+    ranking_score: float = 0.0
     final_score: float = 0.0
     gate_multiplier: float = 1.0
 
@@ -92,10 +93,21 @@ class InferenceMetadata(BaseModel):
     confidence_type: str
     confidence_1_to_100_type: str
     confidence_1_to_100_is_probability: bool
+    best_cell_confidence_1_to_100: Optional[float] = None
     margin_to_top2: Optional[float] = None
     effective_candidate_count: Optional[int] = None
     gated_candidate_count: Optional[int] = None
     confidence_reason: Optional[str] = None
+    raw_score_min: Optional[float] = None
+    raw_score_max: Optional[float] = None
+    raw_score_std: Optional[float] = None
+    final_score_min: Optional[float] = None
+    final_score_max: Optional[float] = None
+    final_score_std: Optional[float] = None
+    top1_top2_margin: Optional[float] = None
+    top1_top5_mean_gap: Optional[float] = None
+    score_entropy_like: Optional[float] = None
+    collapsed_score_flag: Optional[bool] = None
     source: str
     version: str
     aggregation_type: Optional[str] = None

--- a/src/inference_models.py
+++ b/src/inference_models.py
@@ -39,6 +39,29 @@ class InferTargetPositionRequest(BaseModel):
         return self
 
 
+class InferMultiTargetPositionRequest(BaseModel):
+    board: List[List[int]]
+    target_numbers: List[int]
+    source: str = "gpt_image_parse"
+    parse_snapshot: ParseSnapshot = Field(default_factory=ParseSnapshot)
+
+    @field_validator("board")
+    @classmethod
+    def validate_board_non_empty(cls, value: List[List[int]]) -> List[List[int]]:
+        return InferTargetPositionRequest.validate_board_non_empty(value)
+
+    @field_validator("target_numbers")
+    @classmethod
+    def validate_target_numbers(cls, value: List[int]) -> List[int]:
+        if not value:
+            raise ValueError("target_numbers must be non-empty")
+        if len(set(value)) != len(value):
+            raise ValueError("target_numbers must be unique")
+        if any((not isinstance(v, int)) for v in value):
+            raise ValueError("target_numbers must be integers")
+        return value
+
+
 class Cell(BaseModel):
     row: int
     col: int
@@ -51,6 +74,12 @@ class BestCell(Cell):
 
 class CandidateCell(BestCell):
     module_scores: Dict[str, float]
+    module_details: Dict[str, Dict[str, float]] = Field(default_factory=dict)
+    support_score: float = 0.0
+    contradiction_penalty: float = 0.0
+    gated_score: float = 0.0
+    final_score: float = 0.0
+    gate_multiplier: float = 1.0
 
 
 class BoardShape(BaseModel):
@@ -63,8 +92,16 @@ class InferenceMetadata(BaseModel):
     confidence_type: str
     confidence_1_to_100_type: str
     confidence_1_to_100_is_probability: bool
+    margin_to_top2: Optional[float] = None
+    effective_candidate_count: Optional[int] = None
+    gated_candidate_count: Optional[int] = None
+    confidence_reason: Optional[str] = None
     source: str
     version: str
+    aggregation_type: Optional[str] = None
+    normalization_mode: Optional[str] = None
+    gating_enabled: Optional[bool] = None
+    elimination_version: Optional[str] = None
     ranking_stage: Literal["baseline_only", "reranker_applied"]
     reranker_version: Optional[str]
     reranker_feature_schema_version: Optional[str]
@@ -85,3 +122,25 @@ class InferTargetPositionResponse(BaseModel):
     metadata: InferenceMetadata
 
     model_config = ConfigDict(extra="forbid")
+
+
+class MultiTargetAssignment(BaseModel):
+    target_number: int
+    row: int
+    col: int
+    joint_score: float
+    base_score: float
+    was_reassigned_from_individual_top1: bool
+    individual_top1_row: int
+    individual_top1_col: int
+    reassignment_cost_delta: float
+
+
+class InferMultiTargetPositionResponse(BaseModel):
+    status: Literal["ok"]
+    board_shape: BoardShape
+    target_numbers: List[int]
+    assignments: List[MultiTargetAssignment]
+    assignment_score_table: Dict[str, Dict[str, float]]
+    per_target_ranked_candidates: Dict[str, List[CandidateCell]]
+    metadata: Dict[str, Any]

--- a/src/inference_models.py
+++ b/src/inference_models.py
@@ -90,6 +90,8 @@ class BoardShape(BaseModel):
 
 class InferenceMetadata(BaseModel):
     score_type: str
+    score_can_be_negative: Optional[bool] = None
+    confidence_score_is_not_ranking_score: Optional[bool] = None
     confidence_type: str
     confidence_1_to_100_type: str
     confidence_1_to_100_is_probability: bool
@@ -129,6 +131,8 @@ class InferTargetPositionResponse(BaseModel):
     best_cell: Optional[BestCell]
     candidate_cells: List[CandidateCell]
     confidence_score: float
+    best_ranking_score: Optional[float] = None
+    best_confidence_score: Optional[float] = None
     reasoning: List[str]
     module_contributions: Dict[str, float]
     metadata: InferenceMetadata

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -385,16 +385,20 @@ def run_inference(
             },
             "candidate_cells": [],
             "confidence_score": 1.0,
+            "best_ranking_score": 1.0,
+            "best_confidence_score": 1.0,
             "reasoning": [
                 f"盤面總格數為 {parsed.rows * parsed.cols}，合法數字集合為 1..{parsed.rows * parsed.cols}",
                 f"target_number={target_number} 已經在已開格",
             ],
             "module_contributions": {},
             "metadata": {
-                "score_type": "position_confidence_score",
+                "score_type": "ranking_score",
                 "confidence_type": "deterministic_when_already_opened",
                 "confidence_1_to_100_type": "fixed_100_for_already_opened",
                 "confidence_1_to_100_is_probability": False,
+                "score_can_be_negative": False,
+                "confidence_score_is_not_ranking_score": True,
                 "source": source,
                 "version": version,
                 "ranking_stage": "baseline_only",
@@ -500,6 +504,7 @@ def run_inference(
 
     best_cell_payload = candidate_cells[0]
     best_score = round(float(best_cell_payload["score"]), 6)
+    best_confidence_score = round(best_confidence_1_to_100 / 100.0, 6)
     return {
         "status": "ok",
         "board_shape": {"rows": parsed.rows, "cols": parsed.cols},
@@ -513,15 +518,19 @@ def run_inference(
             "confidence_1_to_100": best_confidence_1_to_100,
         },
         "candidate_cells": candidate_cells,
-        "confidence_score": best_score,
+        "confidence_score": best_confidence_score,
+        "best_ranking_score": best_score,
+        "best_confidence_score": best_confidence_score,
         "reasoning": reasoning,
         "module_contributions": weights,
         "metadata": {
-            "score_type": "position_confidence_score",
+            "score_type": "ranking_score",
             "confidence_type": "margin_and_elimination_aware",
             "confidence_1_to_100_type": "gap_density_mapping_non_calibrated",
             "confidence_1_to_100_is_probability": False,
             "best_cell_confidence_1_to_100": best_confidence_1_to_100,
+            "score_can_be_negative": True,
+            "confidence_score_is_not_ranking_score": True,
             "margin_to_top2": round(float(margin_to_top2), 6),
             "effective_candidate_count": effective_candidate_count,
             "gated_candidate_count": gated_candidate_count,

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
+import math
 
 from src.inference_config import (
     load_aggregator_config,
@@ -186,13 +187,16 @@ def aggregate_candidate_scores(
     candidates: List[Dict[str, object]],
     weights: Dict[str, float],
     aggregator_cfg: Dict[str, object],
-) -> None:
+) -> Dict[str, float]:
     agg_type = str(aggregator_cfg.get("type", "weighted_average"))
     gating_enabled = bool(aggregator_cfg.get("gating_enabled", True))
     contradiction_weight = float(aggregator_cfg.get("contradiction_penalty_weight", 1.0))
     hard_violation_threshold = float(aggregator_cfg.get("hard_violation_threshold", 2.0))
     hard_gate_multiplier = float(aggregator_cfg.get("hard_gate_multiplier", 0.05))
     soft_gate_floor = float(aggregator_cfg.get("soft_gate_floor", 0.25))
+    spread_enabled = bool(aggregator_cfg.get("score_spread_enabled", True))
+    spread_temperature = float(aggregator_cfg.get("score_spread_temperature", 0.2))
+    ranking_scores: List[float] = []
 
     for c in candidates:
         module_scores = c["module_scores"]
@@ -225,17 +229,109 @@ def aggregate_candidate_scores(
                 gate_multiplier = max(soft_gate_floor, 1.0 - 0.25 * contradiction_penalty)
 
         if agg_type == "weighted_average":
-            final_score = support_fusion
             gated_score = support_fusion
+            ranking_score = support_fusion
         else:
             gated_score = gate_multiplier * support_fusion
-            final_score = _clip(gated_score - contradiction_weight * contradiction_penalty)
+            ranking_score = gated_score - contradiction_weight * contradiction_penalty
 
         c["support_score"] = support_fusion
         c["contradiction_penalty"] = contradiction_penalty
         c["gated_score"] = gated_score
         c["gate_multiplier"] = gate_multiplier
+        c["ranking_score"] = ranking_score
+        ranking_scores.append(ranking_score)
+
+    if not candidates:
+        return {}
+
+    raw_mean = sum(ranking_scores) / len(ranking_scores)
+    raw_var = sum((s - raw_mean) ** 2 for s in ranking_scores) / len(ranking_scores)
+    raw_std = math.sqrt(raw_var)
+    raw_min = min(ranking_scores)
+    raw_max = max(ranking_scores)
+
+    spread_factor = 1.0
+    if spread_enabled:
+        spread_factor = 1.0 + min(2.0, spread_temperature / max(raw_std, 0.03))
+
+    final_scores: List[float] = []
+    for c in candidates:
+        ranking_score = float(c.get("ranking_score", 0.0))
+        if spread_enabled:
+            final_score = raw_mean + (ranking_score - raw_mean) * spread_factor
+        else:
+            final_score = ranking_score
         c["score"] = final_score
+        final_scores.append(final_score)
+
+    final_mean = sum(final_scores) / len(final_scores)
+    final_var = sum((s - final_mean) ** 2 for s in final_scores) / len(final_scores)
+    final_std = math.sqrt(final_var)
+    top_sorted = sorted(final_scores, reverse=True)
+    top1_top2_margin = 0.0 if len(top_sorted) < 2 else top_sorted[0] - top_sorted[1]
+    topk = top_sorted[: min(5, len(top_sorted))]
+    top1_top5_mean_gap = 0.0 if not topk else top_sorted[0] - (sum(topk) / len(topk))
+
+    tau = max(0.05, final_std)
+    exp_values = [math.exp((s - top_sorted[0]) / tau) for s in top_sorted]
+    z = sum(exp_values) or 1.0
+    probs = [x / z for x in exp_values]
+    entropy = -sum(p * math.log(max(p, 1e-12)) for p in probs)
+    max_entropy = math.log(max(len(probs), 1))
+    entropy_like = entropy / max(max_entropy, 1e-12)
+    collapsed = final_std < 0.02 or top1_top2_margin < 0.01
+    return {
+        "raw_score_min": raw_min,
+        "raw_score_max": raw_max,
+        "raw_score_std": raw_std,
+        "final_score_min": min(final_scores),
+        "final_score_max": max(final_scores),
+        "final_score_std": final_std,
+        "top1_top2_margin": top1_top2_margin,
+        "top1_top5_mean_gap": top1_top5_mean_gap,
+        "score_entropy_like": entropy_like,
+        "collapsed_score_flag": collapsed,
+    }
+
+
+def _candidate_confidence_1_to_100(
+    candidate_score: float,
+    top_score: float,
+    best_confidence: float,
+    score_std: float,
+    gate_multiplier: float,
+    contradiction_penalty: float,
+) -> float:
+    if score_std <= 1e-9:
+        gap_factor = 1.0 if abs(candidate_score - top_score) < 1e-9 else 0.0
+    else:
+        rel_gap = max(0.0, top_score - candidate_score) / max(score_std, 0.01)
+        gap_factor = math.exp(-rel_gap)
+    confidence = best_confidence * gap_factor
+    confidence *= max(0.2, min(1.0, gate_multiplier))
+    confidence *= max(0.2, 1.0 - 0.4 * contradiction_penalty)
+    return round(_clip(confidence, 1.0, 99.0), 2)
+
+
+def map_best_confidence_1_100(
+    margin_to_top2: float,
+    top1_top5_mean_gap: float,
+    effective_candidate_count: int,
+    gated_candidate_count: int,
+    score_entropy_like: float,
+    collapsed_score_flag: bool,
+) -> float:
+    if effective_candidate_count <= 1:
+        return 99.0
+    margin_factor = _clip(margin_to_top2 / 0.2)
+    topk_gap_factor = _clip(top1_top5_mean_gap / 0.2)
+    density_factor = 1.0 - _clip((gated_candidate_count - 1) / max(effective_candidate_count - 1, 1))
+    concentration = 1.0 - _clip(score_entropy_like)
+    collapse_penalty = 0.2 if collapsed_score_flag else 0.0
+    raw = 20.0 + 35.0 * margin_factor + 20.0 * topk_gap_factor + 15.0 * concentration + 10.0 * density_factor
+    raw *= 1.0 - collapse_penalty
+    return round(_clip(raw, 1.0, 99.0), 2)
 
 
 def build_explanation(
@@ -321,7 +417,7 @@ def run_inference(
         module_settings=module_settings,
         normalization_mode=str(aggregator_cfg.get("normalization_mode", "disabled")),
     )
-    aggregate_candidate_scores(scored, weights, aggregator_cfg)
+    diagnostics = aggregate_candidate_scores(scored, weights, aggregator_cfg)
     ranked = rank_candidates(scored)
     best = ranked[0]
 
@@ -331,10 +427,13 @@ def run_inference(
     )
     effective_candidate_count = len(ranked)
     gated_candidate_count = sum(1 for c in ranked if float(c.get("gate_multiplier", 1.0)) > 0.2)
-    confidence_1_to_100 = map_score_to_confidence_1_100(
+    best_confidence_1_to_100 = map_best_confidence_1_100(
         margin_to_top2,
+        float(diagnostics.get("top1_top5_mean_gap", 0.0)),
         effective_candidate_count,
         gated_candidate_count,
+        float(diagnostics.get("score_entropy_like", 1.0)),
+        bool(diagnostics.get("collapsed_score_flag", 0.0)),
     )
     confidence_reason = (
         "strong_elimination_after_gating"
@@ -350,13 +449,21 @@ def run_inference(
                 "row": cell["cell"][0] + 1,
                 "col": cell["cell"][1] + 1,
                 "score": score,
-                "confidence_1_to_100": confidence_1_to_100,
+                "confidence_1_to_100": _candidate_confidence_1_to_100(
+                    candidate_score=score,
+                    top_score=float(ranked[0]["score"]),
+                    best_confidence=best_confidence_1_to_100,
+                    score_std=float(diagnostics.get("final_score_std", 0.0)),
+                    gate_multiplier=float(cell.get("gate_multiplier", 1.0)),
+                    contradiction_penalty=float(cell.get("contradiction_penalty", 0.0)),
+                ),
                 "module_scores": {
                     k: round(float(v), 6) for k, v in sorted(cell["module_scores"].items())
                 },
                 "support_score": round(float(cell.get("support_score", score)), 6),
                 "contradiction_penalty": round(float(cell.get("contradiction_penalty", 0.0)), 6),
                 "gated_score": round(float(cell.get("gated_score", score)), 6),
+                "ranking_score": round(float(cell.get("ranking_score", score)), 6),
                 "final_score": score,
                 "gate_multiplier": round(float(cell.get("gate_multiplier", 1.0)), 6),
                 "module_details": cell.get("module_details", {}),
@@ -403,7 +510,7 @@ def run_inference(
             "row": best_cell_payload["row"],
             "col": best_cell_payload["col"],
             "score": best_score,
-            "confidence_1_to_100": best_cell_payload["confidence_1_to_100"],
+            "confidence_1_to_100": best_confidence_1_to_100,
         },
         "candidate_cells": candidate_cells,
         "confidence_score": best_score,
@@ -414,10 +521,12 @@ def run_inference(
             "confidence_type": "margin_and_elimination_aware",
             "confidence_1_to_100_type": "gap_density_mapping_non_calibrated",
             "confidence_1_to_100_is_probability": False,
+            "best_cell_confidence_1_to_100": best_confidence_1_to_100,
             "margin_to_top2": round(float(margin_to_top2), 6),
             "effective_candidate_count": effective_candidate_count,
             "gated_candidate_count": gated_candidate_count,
             "confidence_reason": confidence_reason,
+            **{k: (round(v, 6) if isinstance(v, float) else bool(v)) for k, v in diagnostics.items()},
             "source": source,
             "version": version,
             "aggregation_type": str(aggregator_cfg.get("type", "weighted_average")),

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-from src.inference_config import load_module_settings, load_module_weights
+from src.inference_config import (
+    load_aggregator_config,
+    load_joint_assignment_config,
+    load_module_settings,
+    load_module_weights,
+)
 from src.ranking_features import build_candidate_feature_rows
 from src.reranker import apply_reranker
 from src.scoring_modules import Cell, ModuleScoreResult, build_modules
+from src.scoring_modules import linear_sum_assignment
 
 
 @dataclass
@@ -87,9 +93,16 @@ def build_cell_candidates(
     ]
 
 
-def _normalize_scores(raw_scores: Dict[Cell, float]) -> Dict[Cell, float]:
+def _normalize_scores(raw_scores: Dict[Cell, float], mode: str = "disabled") -> Dict[Cell, float]:
     if not raw_scores:
         return {}
+    if mode == "disabled":
+        return {k: float(v) for k, v in raw_scores.items()}
+    if mode == "light":
+        mean_v = sum(raw_scores.values()) / len(raw_scores)
+        return {k: _clip(0.5 + (float(v) - mean_v)) for k, v in raw_scores.items()}
+    if mode != "minmax":
+        raise InferenceError(f"Unknown normalization mode: {mode}")
     values = list(raw_scores.values())
     min_v = min(values)
     max_v = max(values)
@@ -98,12 +111,17 @@ def _normalize_scores(raw_scores: Dict[Cell, float]) -> Dict[Cell, float]:
     return {k: (v - min_v) / (max_v - min_v) for k, v in raw_scores.items()}
 
 
+def _clip(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, v))
+
+
 def score_candidates(
     board: List[List[int]],
     candidates: List[Dict[str, object]],
     target_number: int,
     module_weights: Optional[Dict[str, float]] = None,
     module_settings: Optional[Dict[str, Dict[str, object]]] = None,
+    normalization_mode: str = "disabled",
 ) -> Tuple[List[Dict[str, object]], Dict[str, float], List[str]]:
     weights = module_weights or load_module_weights()
     settings = module_settings if module_settings is not None else load_module_settings()
@@ -119,8 +137,10 @@ def score_candidates(
             target_number,
         )
         explanations.append(result.explanation)
-        normalized = _normalize_scores(result.scores)
+        normalized = _normalize_scores(result.scores, mode=normalization_mode)
         for c in candidates:
+            c.setdefault("module_scores", {})
+            c.setdefault("module_details", {})
             cell = c["cell"]
             module_score = float(normalized.get(cell, 0.0))
             c["module_scores"][module_name] = module_score
@@ -135,11 +155,87 @@ def rank_candidates(candidates: List[Dict[str, object]]) -> List[Dict[str, objec
     return sorted(candidates, key=lambda item: item["score"], reverse=True)
 
 
-def map_score_to_confidence_1_100(score: float, min_score: float, max_score: float) -> float:
-    if max_score - min_score < 1e-12:
-        return 50.0
-    scaled = (score - min_score) / (max_score - min_score)
-    return round(1.0 + 99.0 * scaled, 2)
+def map_score_to_confidence_1_100(
+    margin_to_top2: float,
+    effective_candidate_count: int,
+    gated_candidate_count: int,
+) -> float:
+    if effective_candidate_count <= 1:
+        return 99.0
+    margin_factor = _clip(margin_to_top2 / 0.25)
+    density_factor = 1.0 - _clip((gated_candidate_count - 1) / max(effective_candidate_count - 1, 1))
+    raw = 35.0 + 45.0 * margin_factor + 20.0 * density_factor
+    return round(_clip(raw, lo=1.0, hi=99.0), 2)
+
+
+def _extract_contradiction_penalty(module_name: str, module_score: float, details: Dict[str, object]) -> float:
+    if module_name == "logic_rule":
+        return float(details.get("local_contradiction_penalty", 0.0))
+    if module_name == "directional_consistency":
+        return float(details.get("directional_contradiction_penalty", 0.0))
+    if module_name == "line_consistency":
+        return float(details.get("line_contradiction_penalty", 0.0))
+    if module_name == "global_assignment_prior":
+        return float(details.get("anchor_cost_delta_vs_best", 0.0)) + 0.5 * float(
+            details.get("infeasible_or_high_cost_flag", 0.0)
+        )
+    return _clip(1.0 - module_score)
+
+
+def aggregate_candidate_scores(
+    candidates: List[Dict[str, object]],
+    weights: Dict[str, float],
+    aggregator_cfg: Dict[str, object],
+) -> None:
+    agg_type = str(aggregator_cfg.get("type", "weighted_average"))
+    gating_enabled = bool(aggregator_cfg.get("gating_enabled", True))
+    contradiction_weight = float(aggregator_cfg.get("contradiction_penalty_weight", 1.0))
+    hard_violation_threshold = float(aggregator_cfg.get("hard_violation_threshold", 2.0))
+    hard_gate_multiplier = float(aggregator_cfg.get("hard_gate_multiplier", 0.05))
+    soft_gate_floor = float(aggregator_cfg.get("soft_gate_floor", 0.25))
+
+    for c in candidates:
+        module_scores = c["module_scores"]
+        module_details = c.get("module_details", {})
+        support_fusion = sum(float(module_scores.get(name, 0.0)) * weight for name, weight in weights.items())
+
+        contradiction = 0.0
+        weighted = 0.0
+        for name, weight in weights.items():
+            details = module_details.get(name, {}) if isinstance(module_details.get(name, {}), dict) else {}
+            p = _extract_contradiction_penalty(name, float(module_scores.get(name, 0.0)), details)
+            contradiction += p * weight
+            weighted += weight
+        contradiction_penalty = contradiction / max(weighted, 1e-12)
+
+        gate_multiplier = 1.0
+        row_v = float(module_details.get("directional_consistency", {}).get("row_violation_count", 0.0))
+        col_v = float(module_details.get("directional_consistency", {}).get("col_violation_count", 0.0))
+        diag_v = float(module_details.get("line_consistency", {}).get("diag_violation_count", 0.0))
+        line_flags = (
+            float(module_details.get("line_consistency", {}).get("monotonic_break_flag", 0.0))
+            + float(module_details.get("line_consistency", {}).get("percentile_outlier_flag", 0.0))
+            + float(module_details.get("line_consistency", {}).get("gap_outlier_flag", 0.0))
+        )
+        violation_score = row_v + col_v + diag_v + line_flags
+        if gating_enabled:
+            if violation_score >= hard_violation_threshold:
+                gate_multiplier = hard_gate_multiplier
+            else:
+                gate_multiplier = max(soft_gate_floor, 1.0 - 0.25 * contradiction_penalty)
+
+        if agg_type == "weighted_average":
+            final_score = support_fusion
+            gated_score = support_fusion
+        else:
+            gated_score = gate_multiplier * support_fusion
+            final_score = _clip(gated_score - contradiction_weight * contradiction_penalty)
+
+        c["support_score"] = support_fusion
+        c["contradiction_penalty"] = contradiction_penalty
+        c["gated_score"] = gated_score
+        c["gate_multiplier"] = gate_multiplier
+        c["score"] = final_score
 
 
 def build_explanation(
@@ -216,19 +312,35 @@ def run_inference(
         raise InferenceError("board has no unopened cells")
 
     candidates = build_cell_candidates(parsed.unopened_cells)
+    aggregator_cfg = load_aggregator_config()
     scored, weights, module_explanations = score_candidates(
         board,
         candidates,
         target_number,
         module_weights=module_weights,
         module_settings=module_settings,
+        normalization_mode=str(aggregator_cfg.get("normalization_mode", "disabled")),
     )
+    aggregate_candidate_scores(scored, weights, aggregator_cfg)
     ranked = rank_candidates(scored)
     best = ranked[0]
 
-    all_scores = [float(c["score"]) for c in ranked]
-    min_score = min(all_scores)
-    max_score = max(all_scores)
+    margin_to_top2 = 0.0 if len(ranked) <= 1 else max(
+        0.0,
+        float(ranked[0]["score"]) - float(ranked[1]["score"]),
+    )
+    effective_candidate_count = len(ranked)
+    gated_candidate_count = sum(1 for c in ranked if float(c.get("gate_multiplier", 1.0)) > 0.2)
+    confidence_1_to_100 = map_score_to_confidence_1_100(
+        margin_to_top2,
+        effective_candidate_count,
+        gated_candidate_count,
+    )
+    confidence_reason = (
+        "strong_elimination_after_gating"
+        if margin_to_top2 >= 0.15 and gated_candidate_count <= max(1, effective_candidate_count // 2)
+        else "limited_elimination_power"
+    )
 
     candidate_cells = []
     for cell in ranked:
@@ -238,10 +350,15 @@ def run_inference(
                 "row": cell["cell"][0] + 1,
                 "col": cell["cell"][1] + 1,
                 "score": score,
-                "confidence_1_to_100": map_score_to_confidence_1_100(score, min_score, max_score),
+                "confidence_1_to_100": confidence_1_to_100,
                 "module_scores": {
                     k: round(float(v), 6) for k, v in sorted(cell["module_scores"].items())
                 },
+                "support_score": round(float(cell.get("support_score", score)), 6),
+                "contradiction_penalty": round(float(cell.get("contradiction_penalty", 0.0)), 6),
+                "gated_score": round(float(cell.get("gated_score", score)), 6),
+                "final_score": score,
+                "gate_multiplier": round(float(cell.get("gate_multiplier", 1.0)), 6),
                 "module_details": cell.get("module_details", {}),
             }
         )
@@ -294,14 +411,198 @@ def run_inference(
         "module_contributions": weights,
         "metadata": {
             "score_type": "position_confidence_score",
-            "confidence_type": "monotonic_rank_score_mapping",
-            "confidence_1_to_100_type": "monotonic_mapped_score_non_calibrated",
+            "confidence_type": "margin_and_elimination_aware",
+            "confidence_1_to_100_type": "gap_density_mapping_non_calibrated",
             "confidence_1_to_100_is_probability": False,
+            "margin_to_top2": round(float(margin_to_top2), 6),
+            "effective_candidate_count": effective_candidate_count,
+            "gated_candidate_count": gated_candidate_count,
+            "confidence_reason": confidence_reason,
             "source": source,
             "version": version,
+            "aggregation_type": str(aggregator_cfg.get("type", "weighted_average")),
+            "normalization_mode": str(aggregator_cfg.get("normalization_mode", "disabled")),
+            "gating_enabled": bool(aggregator_cfg.get("gating_enabled", False)),
+            "elimination_version": str(aggregator_cfg.get("elimination_version", "v1")),
             "ranking_stage": rerank_meta["ranking_stage"],
             "reranker_version": rerank_meta["reranker_version"],
             "reranker_feature_schema_version": rerank_meta["reranker_feature_schema_version"],
             "reranker_fallback_reason": rerank_meta["reranker_fallback_reason"],
+        },
+    }
+
+
+def build_target_cell_score_matrix(
+    per_target_results: Dict[int, Dict[str, Any]],
+    unopened_cells: List[Cell],
+    contradiction_alpha: float,
+    gate_beta: float,
+) -> Tuple[List[int], List[List[float]], Dict[int, Dict[Cell, Dict[str, Any]]]]:
+    target_numbers = sorted(per_target_results.keys())
+    per_target_cell_scores: Dict[int, Dict[Cell, Dict[str, Any]]] = {}
+    matrix: List[List[float]] = []
+    for target in target_numbers:
+        row: List[float] = []
+        by_cell: Dict[Cell, Dict[str, Any]] = {}
+        for cand in per_target_results[target]["candidate_cells"]:
+            cell = (int(cand["row"]) - 1, int(cand["col"]) - 1)
+            by_cell[cell] = cand
+        per_target_cell_scores[target] = by_cell
+        for cell in unopened_cells:
+            cand = by_cell.get(cell)
+            if cand is None:
+                row.append(1.0)
+                continue
+            base_score = float(cand.get("score", 0.0))
+            contradiction_penalty = float(cand.get("contradiction_penalty", 0.0))
+            gate_multiplier = float(cand.get("gate_multiplier", 1.0))
+            gate_bonus = max(0.0, gate_multiplier - 0.5)
+            joint_score = _clip(base_score - contradiction_alpha * contradiction_penalty + gate_beta * gate_bonus)
+            row.append(1.0 - joint_score)
+        matrix.append(row)
+    return target_numbers, matrix, per_target_cell_scores
+
+
+def solve_joint_assignment(
+    target_numbers: List[int],
+    unopened_cells: List[Cell],
+    cost_matrix: List[List[float]],
+    assignment_mode: str = "exact",
+) -> Tuple[Dict[int, Cell], str]:
+    if not target_numbers:
+        return {}, assignment_mode
+    if len(target_numbers) > len(unopened_cells):
+        raise InferenceError("target_numbers exceed unopened cell count")
+
+    if assignment_mode == "exact" and linear_sum_assignment is not None:
+        row_idx, col_idx = linear_sum_assignment(cost_matrix)
+        if len(row_idx) == len(target_numbers):
+            assigned: Dict[int, Cell] = {}
+            for r_idx, c_idx in zip(row_idx.tolist(), col_idx.tolist()):
+                assigned[target_numbers[r_idx]] = unopened_cells[c_idx]
+            if len(assigned) == len(target_numbers):
+                return assigned, "exact"
+
+    used_cells: set[Cell] = set()
+    assigned = {}
+    ranked_pairs: List[Tuple[float, int, Cell]] = []
+    for r_idx, target in enumerate(target_numbers):
+        for c_idx, cell in enumerate(unopened_cells):
+            ranked_pairs.append((cost_matrix[r_idx][c_idx], target, cell))
+    ranked_pairs.sort(key=lambda x: x[0])
+    for _, target, cell in ranked_pairs:
+        if target in assigned or cell in used_cells:
+            continue
+        assigned[target] = cell
+        used_cells.add(cell)
+        if len(assigned) == len(target_numbers):
+            break
+    if len(assigned) != len(target_numbers):
+        raise InferenceError("joint assignment failed to assign all targets uniquely")
+    return assigned, "greedy"
+
+
+def dedup_ranked_candidates(
+    per_target_results: Dict[int, Dict[str, Any]],
+    assignments: Dict[int, Cell],
+    per_target_cell_scores: Dict[int, Dict[Cell, Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    output = []
+    for target, result in sorted(per_target_results.items()):
+        selected = assignments[target]
+        selected_cand = per_target_cell_scores[target][selected]
+        top1 = result["candidate_cells"][0]
+        top1_cell = (int(top1["row"]) - 1, int(top1["col"]) - 1)
+        base_score = float(selected_cand.get("score", 0.0))
+        top1_score = float(top1.get("score", 0.0))
+        output.append(
+            {
+                "target_number": target,
+                "row": selected[0] + 1,
+                "col": selected[1] + 1,
+                "joint_score": base_score,
+                "base_score": base_score,
+                "was_reassigned_from_individual_top1": selected != top1_cell,
+                "individual_top1_row": int(top1["row"]),
+                "individual_top1_col": int(top1["col"]),
+                "reassignment_cost_delta": round(max(0.0, top1_score - base_score), 6),
+            }
+        )
+    return output
+
+
+def run_multi_target_inference(
+    board: List[List[int]],
+    target_numbers: List[int],
+    source: str,
+    apply_reranker_stage: bool = False,
+) -> Dict[str, Any]:
+    if not target_numbers:
+        raise InferenceError("target_numbers must be non-empty")
+    if len(set(target_numbers)) != len(target_numbers):
+        raise InferenceError("target_numbers must be unique")
+
+    parsed = parse_board_input(board)
+    remaining = compute_remaining_numbers(parsed)
+    for target in target_numbers:
+        validate_target_number(target, parsed, remaining)
+
+    joint_cfg = load_joint_assignment_config()
+    per_target_results: Dict[int, Dict[str, Any]] = {}
+    for target in target_numbers:
+        per_target_results[target] = run_inference(
+            board=board,
+            target_number=target,
+            source=source,
+            apply_reranker_stage=apply_reranker_stage,
+        )
+
+    target_order, cost_matrix, per_target_cell_scores = build_target_cell_score_matrix(
+        per_target_results=per_target_results,
+        unopened_cells=parsed.unopened_cells,
+        contradiction_alpha=float(joint_cfg.get("contradiction_alpha", 0.35)),
+        gate_beta=float(joint_cfg.get("gate_beta", 0.2)),
+    )
+    assignments, used_mode = solve_joint_assignment(
+        target_numbers=target_order,
+        unopened_cells=parsed.unopened_cells,
+        cost_matrix=cost_matrix,
+        assignment_mode=str(joint_cfg.get("assignment_mode", "exact")),
+    )
+    deduped = dedup_ranked_candidates(per_target_results, assignments, per_target_cell_scores)
+
+    top1_cells = [
+        (res["candidate_cells"][0]["row"], res["candidate_cells"][0]["col"])
+        for res in per_target_results.values()
+    ]
+    duplicate_before = len(top1_cells) - len(set(top1_cells))
+    assigned_cells = [(item["row"], item["col"]) for item in deduped]
+    duplicate_after = len(assigned_cells) - len(set(assigned_cells))
+    per_target_ranked_candidates = {
+        str(target): per_target_results[target]["candidate_cells"][
+            : int(joint_cfg.get("top_k_per_target", 10))
+        ]
+        for target in target_order
+    }
+
+    return {
+        "status": "ok",
+        "board_shape": {"rows": parsed.rows, "cols": parsed.cols},
+        "target_numbers": target_order,
+        "assignments": deduped,
+        "assignment_score_table": {
+            str(target): {
+                f"{cell[0] + 1},{cell[1] + 1}": round(1.0 - cost_matrix[r_idx][c_idx], 6)
+                for c_idx, cell in enumerate(parsed.unopened_cells)
+            }
+            for r_idx, target in enumerate(target_order)
+        },
+        "per_target_ranked_candidates": per_target_ranked_candidates,
+        "metadata": {
+            "assignment_mode": used_mode,
+            "dedup_enabled": bool(joint_cfg.get("dedup_enabled", True)),
+            "duplicate_top1_count_before_assignment": duplicate_before,
+            "duplicate_top1_count_after_assignment": duplicate_after,
+            "joint_assignment_version": str(joint_cfg.get("version", "v1")),
         },
     }

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -43,17 +43,43 @@ class LogicRuleModule:
     def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
         rows, cols = len(board), len(board[0])
         result: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
         for r, c in unopened_cells:
             neighbors = []
+            contradiction_votes = 0
             for rr, cc in ((r - 1, c), (r + 1, c), (r, c - 1), (r, c + 1)):
                 if 0 <= rr < rows and 0 <= cc < cols and board[rr][cc] != -1:
-                    neighbors.append(board[rr][cc])
+                    v = board[rr][cc]
+                    neighbors.append(v)
+                    if rr == r and cc < c and v > target_number:
+                        contradiction_votes += 1
+                    if rr == r and cc > c and v < target_number:
+                        contradiction_votes += 1
+                    if cc == c and rr < r and v > target_number:
+                        contradiction_votes += 1
+                    if cc == c and rr > r and v < target_number:
+                        contradiction_votes += 1
             if not neighbors:
                 result[(r, c)] = 0.5
+                details[(r, c)] = {
+                    "local_support_score": 0.5,
+                    "local_contradiction_penalty": 0.0,
+                    "neighbor_count": 0.0,
+                    "contradiction_votes": 0.0,
+                }
                 continue
             mean_abs_delta = sum(abs(v - target_number) for v in neighbors) / len(neighbors)
-            result[(r, c)] = 1.0 / (1.0 + mean_abs_delta)
-        return ModuleScoreResult(result, "logic_rule: 根據鄰近已開數字與 target 距離評分")
+            local_support = 1.0 / (1.0 + mean_abs_delta)
+            contradiction_penalty = _clip(contradiction_votes / max(len(neighbors), 1))
+            score = _clip(local_support - 0.7 * contradiction_penalty)
+            result[(r, c)] = score
+            details[(r, c)] = {
+                "local_support_score": local_support,
+                "local_contradiction_penalty": contradiction_penalty,
+                "neighbor_count": float(len(neighbors)),
+                "contradiction_votes": float(contradiction_votes),
+            }
+        return ModuleScoreResult(result, "logic_rule: 以局部 support 與局部矛盾懲罰共同評分", details=details)
 
 
 class PatternModelModule:
@@ -201,6 +227,8 @@ def _directional_components(board: Board, candidate: Cell, target_number: int) -
     row_vals = [board[r][cc] for cc in range(cols) if board[r][cc] != -1] + [target_number]
     col_vals = [board[rr][c] for rr in range(rows) if board[rr][c] != -1] + [target_number]
     board_size = rows * cols
+    row_violation_count = sum(1 for v in left if v > target_number) + sum(1 for v in right if v < target_number)
+    col_violation_count = sum(1 for v in up if v > target_number) + sum(1 for v in down if v < target_number)
     components = {
         "left_order_score": _order_score(left, target_number, expect_less=True),
         "right_order_score": _order_score(right, target_number, expect_less=False),
@@ -212,8 +240,15 @@ def _directional_components(board: Board, candidate: Cell, target_number: int) -
         "down_distance_score": _distance_score(down, target_number, board_size),
         "row_balance_score": _smoothness_score(row_vals),
         "col_balance_score": _smoothness_score(col_vals),
+        "row_violation_count": float(row_violation_count),
+        "col_violation_count": float(col_violation_count),
     }
-    components["directional_consistency"] = sum(components.values()) / len(components)
+    support_keys = [k for k in components.keys() if k.endswith("_score")]
+    support = sum(components[k] for k in support_keys) / max(len(support_keys), 1)
+    violation_penalty = _clip((row_violation_count + col_violation_count) / 4.0)
+    components["directional_support_score"] = support
+    components["directional_contradiction_penalty"] = violation_penalty
+    components["directional_consistency"] = _clip(support - 0.8 * violation_penalty)
     return components
 
 
@@ -257,6 +292,32 @@ def _line_components(board: Board, candidate: Cell, target_number: int) -> Dict[
             continue
         diag_percentiles.append(_percentile_fit(vals, target_number, len(diag_cells), diag_idx, board_size))
 
+    diag_violation_count = 0
+    if main_diag:
+        for rr, cc in main_diag:
+            v = board[rr][cc]
+            if v == -1 or (rr, cc) == candidate:
+                continue
+            if (rr < r and cc < c and v > target_number) or (rr > r and cc > c and v < target_number):
+                diag_violation_count += 1
+    if anti_diag:
+        for rr, cc in anti_diag:
+            v = board[rr][cc]
+            if v == -1 or (rr, cc) == candidate:
+                continue
+            if (rr < r and cc > c and v > target_number) or (rr > r and cc < c and v < target_number):
+                diag_violation_count += 1
+
+    monotonic_break_flag = float(
+        (row_mono < 0.5) or (col_mono < 0.5) or (sum(diag_monotonicity) / len(diag_monotonicity) < 0.5)
+    )
+    percentile_outlier_flag = float(
+        (row_pct < 0.25) or (col_pct < 0.25) or (sum(diag_percentiles) / len(diag_percentiles) < 0.25)
+    )
+    gap_outlier_flag = float(
+        (row_residual < 0.25) or (col_residual < 0.25) or (sum(diag_scores) / len(diag_scores) < 0.25)
+    )
+
     components = {
         "row_residual_score": row_residual,
         "col_residual_score": col_residual,
@@ -268,8 +329,22 @@ def _line_components(board: Board, candidate: Cell, target_number: int) -> Dict[
         "row_percentile_fit": row_pct,
         "col_percentile_fit": col_pct,
         "diag_percentile_fit": sum(diag_percentiles) / len(diag_percentiles),
+        "diag_violation_count": float(diag_violation_count),
+        "monotonic_break_flag": monotonic_break_flag,
+        "percentile_outlier_flag": percentile_outlier_flag,
+        "gap_outlier_flag": gap_outlier_flag,
     }
-    components["line_consistency"] = sum(components.values()) / len(components)
+    support_keys = [k for k in components.keys() if k.endswith("_score") or k.endswith("_fit")]
+    support = sum(components[k] for k in support_keys) / max(len(support_keys), 1)
+    penalty = _clip(
+        (diag_violation_count / 3.0)
+        + 0.35 * monotonic_break_flag
+        + 0.25 * percentile_outlier_flag
+        + 0.25 * gap_outlier_flag
+    )
+    components["line_support_score"] = support
+    components["line_contradiction_penalty"] = _clip(penalty)
+    components["line_consistency"] = _clip(support - 0.75 * components["line_contradiction_penalty"])
     return components
 
 
@@ -325,38 +400,40 @@ class GlobalAssignmentPriorModule:
         self.assignment_mode = assignment_mode
 
     @staticmethod
-    def _greedy_assignment_score(
+    def _greedy_assignment_cost(
         board: Board,
         cells: List[Cell],
         numbers: List[int],
-    ) -> float:
+    ) -> Optional[float]:
         if not cells or not numbers:
-            return NEUTRAL_SCORE
+            return 0.0
+        if len(cells) != len(numbers):
+            return None
         ranked_pairs = []
         for number in numbers:
             for cell in cells:
                 compat = _cell_number_compatibility(board, cell, number)
-                ranked_pairs.append((compat, number, cell))
-        ranked_pairs.sort(reverse=True, key=lambda x: x[0])
+                ranked_pairs.append((1.0 - compat, number, cell))
+        ranked_pairs.sort(key=lambda x: x[0])
         used_cells: set[Cell] = set()
         used_numbers: set[int] = set()
         total = 0.0
         count = 0
-        for compat, number, cell in ranked_pairs:
+        for cost, number, cell in ranked_pairs:
             if number in used_numbers or cell in used_cells:
                 continue
             used_numbers.add(number)
             used_cells.add(cell)
-            total += compat
+            total += cost
             count += 1
             if len(used_cells) == len(cells):
                 break
-        if count == 0:
-            return NEUTRAL_SCORE
+        if count == 0 or count != len(cells):
+            return None
         return total / count
 
     @staticmethod
-    def _exact_assignment_score(
+    def _exact_assignment_cost(
         board: Board,
         cells: List[Cell],
         numbers: List[int],
@@ -373,10 +450,10 @@ class GlobalAssignmentPriorModule:
         row_idx, col_idx = linear_sum_assignment(matrix)
         if len(row_idx) == 0:
             return None
-        compat_total = 0.0
+        cost_total = 0.0
         for r_idx, c_idx in zip(row_idx.tolist(), col_idx.tolist()):
-            compat_total += 1.0 - matrix[r_idx][c_idx]
-        return compat_total / len(row_idx)
+            cost_total += matrix[r_idx][c_idx]
+        return cost_total / len(row_idx)
 
     def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
         if len(unopened_cells) <= 1:
@@ -386,8 +463,8 @@ class GlobalAssignmentPriorModule:
             )
         rows, cols = len(board), len(board[0])
         n_total = rows * cols
-        scores: Dict[Cell, float] = {}
-        details: Dict[Cell, Dict[str, float]] = {}
+        anchor_costs: Dict[Cell, float] = {}
+        anchor_details: Dict[Cell, Dict[str, float]] = {}
         for anchor in unopened_cells:
             board_with_anchor = [list(row) for row in board]
             board_with_anchor[anchor[0]][anchor[1]] = target_number
@@ -401,23 +478,42 @@ class GlobalAssignmentPriorModule:
             pool = [x for x in range(1, n_total + 1) if x not in opened_with_anchor]
             used_exact = 0
             used_greedy = 0
-            assignment_score = None
+            assignment_cost = None
             if self.assignment_mode == "exact":
-                assignment_score = self._exact_assignment_score(board_with_anchor, others, pool)
-                used_exact = int(assignment_score is not None)
-            if assignment_score is None:
-                assignment_score = self._greedy_assignment_score(board_with_anchor, others, pool)
+                assignment_cost = self._exact_assignment_cost(board_with_anchor, others, pool)
+                used_exact = int(assignment_cost is not None)
+            if assignment_cost is None:
+                assignment_cost = self._greedy_assignment_cost(board_with_anchor, others, pool)
                 used_greedy = 1
-            anchor_compat = _cell_number_compatibility(board, anchor, target_number)
-            final_score = _clip(0.5 * assignment_score + 0.5 * anchor_compat)
-            scores[anchor] = final_score
-            details[anchor] = {
+            infeasible = assignment_cost is None
+            if infeasible:
+                assignment_cost = 1.0
+            anchor_costs[anchor] = float(assignment_cost)
+            anchor_details[anchor] = {
                 "global_assignment_mode": 1.0 if self.assignment_mode == "exact" else 0.0,
                 "used_exact_assignment": float(used_exact),
                 "used_greedy_fallback": float(used_greedy),
-                "global_assignment_score": final_score,
-                "global_anchor_compatibility": anchor_compat,
-                "global_remaining_assignment_score": assignment_score,
+                "forced_anchor_total_assignment_cost": float(assignment_cost * max(len(others), 1)),
+                "forced_anchor_avg_assignment_cost": float(assignment_cost),
+                "infeasible_or_high_cost_flag": float(infeasible),
+            }
+
+        best_cost = min(anchor_costs.values()) if anchor_costs else 1.0
+        scores: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for anchor, avg_cost in anchor_costs.items():
+            delta = max(0.0, avg_cost - best_cost)
+            high_cost_flag = float(avg_cost >= 0.75 or delta >= 0.2)
+            score = _clip(1.0 - (avg_cost + 1.2 * delta + 0.6 * high_cost_flag))
+            scores[anchor] = score
+            details[anchor] = {
+                **anchor_details[anchor],
+                "anchor_cost_delta_vs_best": float(delta),
+                "infeasible_or_high_cost_flag": max(
+                    anchor_details[anchor]["infeasible_or_high_cost_flag"],
+                    high_cost_flag,
+                ),
+                "global_assignment_score": score,
             }
 
         return ModuleScoreResult(

--- a/tests/test_infer_target_position_api.py
+++ b/tests/test_infer_target_position_api.py
@@ -27,7 +27,8 @@ def test_valid_small_board_4x5() -> None:
     assert payload["status"] == "ok"
     assert payload["board_shape"] == {"rows": 4, "cols": 5}
     assert payload["best_cell"] is not None
-    assert payload["confidence_score"] == payload["best_cell"]["score"]
+    assert payload["confidence_score"] == payload["best_confidence_score"]
+    assert payload["best_ranking_score"] == payload["best_cell"]["score"]
     assert payload["metadata"]["confidence_1_to_100_is_probability"] is False
 
 

--- a/tests/test_infer_target_position_api.py
+++ b/tests/test_infer_target_position_api.py
@@ -97,3 +97,13 @@ def test_candidate_cells_sorted_descending() -> None:
     cells = response.json()["candidate_cells"]
     scores = [cell["score"] for cell in cells]
     assert scores == sorted(scores, reverse=True)
+
+
+def test_multi_target_api_returns_unique_assignments() -> None:
+    board = [[1, -1], [-1, 4]]
+    response = client.post("/infer_multi_target_positions", json={"board": board, "target_numbers": [2, 3]})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    cells = {(a["row"], a["col"]) for a in payload["assignments"]}
+    assert len(cells) == 2

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -4,7 +4,9 @@ from src.inference_service import (
     _normalize_scores,
     aggregate_candidate_scores,
     build_cell_candidates,
+    map_best_confidence_1_100,
     rank_candidates,
+    run_inference,
     score_candidates,
 )
 
@@ -85,6 +87,12 @@ def test_normalization_disabled_keeps_weak_signals_close() -> None:
     assert out == raw
 
 
+def test_normalization_light_mode_runs_and_preserves_ordering() -> None:
+    raw = {(0, 0): 0.51, (0, 1): 0.5, (1, 1): 0.49}
+    out = _normalize_scores(raw, mode="light")
+    assert out[(0, 0)] > out[(0, 1)] > out[(1, 1)]
+
+
 def test_hard_gate_can_eliminate_high_support_candidate() -> None:
     candidates = [
         {
@@ -143,6 +151,61 @@ def test_contradiction_penalty_changes_ranking() -> None:
     aggregate_candidate_scores(
         candidates,
         {"logic_rule": 0.5, "line_consistency": 0.5},
-        {"type": "gate_then_weighted_sum", "gating_enabled": True},
+        {"type": "gate_then_weighted_sum", "gating_enabled": True, "score_spread_enabled": True},
     )
     assert rank_candidates(candidates)[0]["cell"] == (0, 1)
+
+
+def test_score_spread_expands_but_preserves_ranking_order() -> None:
+    candidates = [
+        {"cell": (0, 0), "score": 0.0, "module_scores": {"logic_rule": 0.501}, "module_details": {}},
+        {"cell": (0, 1), "score": 0.0, "module_scores": {"logic_rule": 0.5}, "module_details": {}},
+        {"cell": (1, 1), "score": 0.0, "module_scores": {"logic_rule": 0.499}, "module_details": {}},
+    ]
+    diagnostics = aggregate_candidate_scores(
+        candidates,
+        {"logic_rule": 1.0},
+        {"type": "gate_then_weighted_sum", "gating_enabled": False, "score_spread_enabled": True},
+    )
+    ranked = rank_candidates(candidates)
+    assert [c["cell"] for c in ranked] == [(0, 0), (0, 1), (1, 1)]
+    assert diagnostics["final_score_std"] > diagnostics["raw_score_std"]
+
+
+def test_candidate_confidence_not_all_identical() -> None:
+    result = run_inference([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    confs = {c["confidence_1_to_100"] for c in result["candidate_cells"]}
+    assert len(confs) > 1
+
+
+def test_collapsed_score_flag_true_on_flat_scores() -> None:
+    candidates = [
+        {"cell": (0, 0), "score": 0.0, "module_scores": {"logic_rule": 0.5}, "module_details": {}},
+        {"cell": (0, 1), "score": 0.0, "module_scores": {"logic_rule": 0.5}, "module_details": {}},
+    ]
+    diagnostics = aggregate_candidate_scores(
+        candidates,
+        {"logic_rule": 1.0},
+        {"type": "gate_then_weighted_sum", "gating_enabled": False, "score_spread_enabled": False},
+    )
+    assert diagnostics["collapsed_score_flag"] is True
+
+
+def test_best_confidence_rises_with_larger_margin() -> None:
+    low = map_best_confidence_1_100(
+        margin_to_top2=0.01,
+        top1_top5_mean_gap=0.01,
+        effective_candidate_count=5,
+        gated_candidate_count=5,
+        score_entropy_like=0.95,
+        collapsed_score_flag=True,
+    )
+    high = map_best_confidence_1_100(
+        margin_to_top2=0.2,
+        top1_top5_mean_gap=0.15,
+        effective_candidate_count=5,
+        gated_candidate_count=2,
+        score_entropy_like=0.4,
+        collapsed_score_flag=False,
+    )
+    assert high > low

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -209,3 +209,13 @@ def test_best_confidence_rises_with_larger_margin() -> None:
         collapsed_score_flag=False,
     )
     assert high > low
+
+
+def test_confidence_score_not_equal_ranking_score_contract() -> None:
+    result = run_inference([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    assert result["best_ranking_score"] == result["best_cell"]["score"]
+    assert result["best_confidence_score"] == result["confidence_score"]
+    assert result["metadata"]["score_type"] == "ranking_score"
+    assert result["metadata"]["score_can_be_negative"] is True
+    assert result["metadata"]["confidence_score_is_not_ranking_score"] is True
+    assert result["best_cell"]["confidence_1_to_100"] == result["metadata"]["best_cell_confidence_1_to_100"]

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from src.inference_service import _normalize_scores, build_cell_candidates, rank_candidates, score_candidates
+from src.inference_service import (
+    _normalize_scores,
+    aggregate_candidate_scores,
+    build_cell_candidates,
+    rank_candidates,
+    score_candidates,
+)
 
 
 def test_module_weights_take_effect() -> None:
@@ -68,6 +74,75 @@ def test_no_global_module_state_leakage_between_calls() -> None:
 
 
 def test_constant_module_scores_are_neutral_not_all_ones() -> None:
-    out = _normalize_scores({(0, 0): 2.0, (0, 1): 2.0})
+    out = _normalize_scores({(0, 0): 2.0, (0, 1): 2.0}, mode="minmax")
     assert out[(0, 0)] == 0.5
     assert out[(0, 1)] == 0.5
+
+
+def test_normalization_disabled_keeps_weak_signals_close() -> None:
+    raw = {(0, 0): 0.51, (0, 1): 0.5, (1, 1): 0.49}
+    out = _normalize_scores(raw, mode="disabled")
+    assert out == raw
+
+
+def test_hard_gate_can_eliminate_high_support_candidate() -> None:
+    candidates = [
+        {
+            "cell": (0, 0),
+            "score": 0.0,
+            "module_scores": {"logic_rule": 0.9},
+            "module_details": {
+                "directional_consistency": {"row_violation_count": 2.0, "col_violation_count": 1.0},
+                "line_consistency": {
+                    "diag_violation_count": 0.0,
+                    "monotonic_break_flag": 1.0,
+                    "percentile_outlier_flag": 1.0,
+                    "gap_outlier_flag": 0.0,
+                },
+            },
+        },
+        {
+            "cell": (0, 1),
+            "score": 0.0,
+            "module_scores": {"logic_rule": 0.6},
+            "module_details": {
+                "directional_consistency": {"row_violation_count": 0.0, "col_violation_count": 0.0},
+                "line_consistency": {
+                    "diag_violation_count": 0.0,
+                    "monotonic_break_flag": 0.0,
+                    "percentile_outlier_flag": 0.0,
+                    "gap_outlier_flag": 0.0,
+                },
+            },
+        },
+    ]
+    aggregate_candidate_scores(
+        candidates,
+        {"logic_rule": 1.0},
+        {"type": "gate_then_weighted_sum", "gating_enabled": True, "hard_violation_threshold": 2.0},
+    )
+    ranked = rank_candidates(candidates)
+    assert ranked[0]["cell"] == (0, 1)
+
+
+def test_contradiction_penalty_changes_ranking() -> None:
+    candidates = [
+        {
+            "cell": (0, 0),
+            "score": 0.0,
+            "module_scores": {"logic_rule": 0.7, "line_consistency": 0.7},
+            "module_details": {"logic_rule": {"local_contradiction_penalty": 0.8}, "line_consistency": {}},
+        },
+        {
+            "cell": (0, 1),
+            "score": 0.0,
+            "module_scores": {"logic_rule": 0.65, "line_consistency": 0.65},
+            "module_details": {"logic_rule": {"local_contradiction_penalty": 0.0}, "line_consistency": {}},
+        },
+    ]
+    aggregate_candidate_scores(
+        candidates,
+        {"logic_rule": 0.5, "line_consistency": 0.5},
+        {"type": "gate_then_weighted_sum", "gating_enabled": True},
+    )
+    assert rank_candidates(candidates)[0]["cell"] == (0, 1)

--- a/tests/test_mainline_upgrade.py
+++ b/tests/test_mainline_upgrade.py
@@ -140,6 +140,7 @@ def test_global_assignment_exact_path() -> None:
     cell_details = result.details[(0, 1)]
     assert cell_details["used_exact_assignment"] in (0.0, 1.0)
     assert cell_details["global_assignment_mode"] == 1.0
+    assert "forced_anchor_avg_assignment_cost" in cell_details
 
 
 def test_global_assignment_greedy_fallback_path() -> None:
@@ -148,6 +149,20 @@ def test_global_assignment_greedy_fallback_path() -> None:
         result = module.score([[1, -1], [-1, 4]], [(0, 1), (1, 0)], 2)
     details = result.details[(0, 1)]
     assert details["used_greedy_fallback"] == 1.0
+
+
+def test_global_assignment_cost_delta_penalizes_wrong_anchor() -> None:
+    board = [[1, -1, 3], [-1, 5, -1], [7, 8, 9]]
+    module = MODULES["global_assignment_prior"].__class__(assignment_mode="exact")
+    result = module.score(board, [(0, 1), (1, 0), (1, 2)], 4)
+    deltas = [result.details[cell]["anchor_cost_delta_vs_best"] for cell in result.details]
+    assert max(deltas) > 0.0
+
+
+def test_confidence_not_artificially_high_when_gap_small() -> None:
+    result = run_inference([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    assert result["metadata"]["margin_to_top2"] >= 0.0
+    assert result["best_cell"]["confidence_1_to_100"] <= 95.0
 
 
 def test_discover_full_boards_skips_bad_json_csv_txt_without_crashing(tmp_path: Path) -> None:

--- a/tests/test_multi_target_inference.py
+++ b/tests/test_multi_target_inference.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.inference_service import run_multi_target_inference, solve_joint_assignment
+
+
+def _fake_single_result(top1_row: int, top1_col: int, alt_row: int, alt_col: int) -> dict:
+    return {
+        "status": "ok",
+        "candidate_cells": [
+            {
+                "row": top1_row,
+                "col": top1_col,
+                "score": 0.9,
+                "contradiction_penalty": 0.0,
+                "gate_multiplier": 1.0,
+            },
+            {
+                "row": alt_row,
+                "col": alt_col,
+                "score": 0.85,
+                "contradiction_penalty": 0.0,
+                "gate_multiplier": 1.0,
+            },
+        ],
+    }
+
+
+def test_joint_assignment_dedups_duplicate_individual_top1() -> None:
+    board = [[1, -1], [-1, 4]]
+    with patch(
+        "src.inference_service.run_inference",
+        side_effect=[
+            _fake_single_result(1, 2, 2, 1),
+            _fake_single_result(1, 2, 2, 1),
+        ],
+    ):
+        result = run_multi_target_inference(board, [2, 3], source="t")
+    assigned_cells = {(a["row"], a["col"]) for a in result["assignments"]}
+    assert len(assigned_cells) == 2
+    assert result["metadata"]["duplicate_top1_count_before_assignment"] == 1
+    assert result["metadata"]["duplicate_top1_count_after_assignment"] == 0
+
+
+def test_joint_assignment_keeps_strong_individual_top1() -> None:
+    board = [[1, -1], [-1, 4]]
+    with patch(
+        "src.inference_service.run_inference",
+        side_effect=[
+            {
+                "status": "ok",
+                "candidate_cells": [
+                    {"row": 1, "col": 2, "score": 0.99, "contradiction_penalty": 0.0, "gate_multiplier": 1.0},
+                    {"row": 2, "col": 1, "score": 0.2, "contradiction_penalty": 0.0, "gate_multiplier": 1.0},
+                ],
+            },
+            {
+                "status": "ok",
+                "candidate_cells": [
+                    {"row": 1, "col": 2, "score": 0.8, "contradiction_penalty": 0.0, "gate_multiplier": 1.0},
+                    {"row": 2, "col": 1, "score": 0.79, "contradiction_penalty": 0.0, "gate_multiplier": 1.0},
+                ],
+            },
+        ],
+    ):
+        result = run_multi_target_inference(board, [2, 3], source="t")
+    t2 = next(a for a in result["assignments"] if a["target_number"] == 2)
+    assert (t2["row"], t2["col"]) == (1, 2)
+    assert t2["was_reassigned_from_individual_top1"] is False
+
+
+def test_solve_joint_assignment_exact_path() -> None:
+    assigned, mode = solve_joint_assignment(
+        target_numbers=[2, 3],
+        unopened_cells=[(0, 1), (1, 0)],
+        cost_matrix=[[0.1, 0.9], [0.9, 0.1]],
+        assignment_mode="exact",
+    )
+    assert mode == "exact"
+    assert len(set(assigned.values())) == 2
+
+
+def test_solve_joint_assignment_greedy_fallback_path() -> None:
+    with patch("src.inference_service.linear_sum_assignment", None):
+        assigned, mode = solve_joint_assignment(
+            target_numbers=[2, 3],
+            unopened_cells=[(0, 1), (1, 0)],
+            cost_matrix=[[0.1, 0.9], [0.9, 0.1]],
+            assignment_mode="exact",
+        )
+    assert mode == "greedy"
+    assert len(set(assigned.values())) == 2
+
+
+def test_multi_target_assignment_count_matches_targets() -> None:
+    result = run_multi_target_inference([[1, -1], [-1, 4]], [2, 3], source="t")
+    assert len(result["assignments"]) == 2
+    assert len({(a["row"], a["col"]) for a in result["assignments"]}) == 2


### PR DESCRIPTION
### Motivation

- Extend the service to support joint inference for multiple target numbers with a single API call and reduce duplicate assignments across targets.
- Improve candidate scoring by adding gating, contradiction penalties, and optional normalization to better suppress inconsistent candidates.
- Surface richer module diagnostics and aggregation metadata for debugging and downstream calibration.

### Description

- Added a new endpoint `POST /infer_multi_target_positions` in `src/api.py` and new facade `infer_multi_target_positions` in `src/inference_facade.py` that call `run_multi_target_inference`.
- Introduced joint-assignment configuration and logic by adding `joint_assignment` and enhanced `aggregator` options in `configs/inference.yaml` and corresponding loaders in `src/inference_config.py` (`load_aggregator_config`, `load_joint_assignment_config`).
- Implemented gated aggregation and normalization modes in `src/inference_service.py` with `aggregate_candidate_scores`, changed scoring pipeline to emit support/penalty/gate values, and replaced simple minmax mapping with a margin/density-based `map_score_to_confidence_1_100`.
- Added multi-target assignment solver (`build_target_cell_score_matrix`, `solve_joint_assignment`, `dedup_ranked_candidates`) and `run_multi_target_inference` which aggregates per-target run results and returns unique assignments and metadata.
- Extended `src/inference_models.py` to support multi-target request/response schemas and richer `CandidateCell`/`InferenceMetadata` fields and added `InferMultiTargetPositionResponse` and `MultiTargetAssignment` models.
- Enhanced scoring modules in `src/scoring_modules.py` to emit per-cell `details` (contradiction penalties, violation counts, assignment costs), refactored `global_assignment_prior` to report costs and feasibility, and added utility helpers used by aggregation and joint assignment.
- Updated tests and added new coverage: new `tests/test_multi_target_inference.py`, updated `tests/test_infer_target_position_api.py`, `tests/test_inference_service.py`, and `tests/test_mainline_upgrade.py` to validate gating, normalization, global-assignment diagnostics, and the multi-target API.

### Testing

- Ran the test suite with `pytest` including newly added `tests/test_multi_target_inference.py` and updated tests; all tests passed.
- Verified API-level behavior via `tests/test_infer_target_position_api.py` which includes `test_multi_target_api_returns_unique_assignments` and it succeeded.
- Exercised scoring/aggregation behaviors with unit tests in `tests/test_inference_service.py` that validate normalization modes, gating elimination, and contradiction penalties and they succeeded.
- Confirmed `global_assignment_prior` diagnostics via `tests/test_mainline_upgrade.py` updates and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8697bc7c4832482b869f7b846fa66)