### PR TITLE
Add family-based neighborhood_association scoring module

### DIFF
--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -94,32 +94,22 @@ modules:
       ceil_score: 1.0
       relation_source: heuristic_family_profile_v1
   aggregator:
-    type: competitive_ensemble
-    fusion_mode: learned_meta_ranker
-    competitor_normalization: per_module_minmax
-    include_vote_features: true
-    include_rank_features: true
-    include_score_features: true
-    judge_model_type: logistic_ranker
-    judge_feature_schema_version: competitive_features_v1
-    judge_artifact_path: artifacts/competitive_judge_artifact.json
-    fallback_mode: weighted_rank_fusion
+    type: committee_weighted_sum
+    weighting_mode: equal_informative
+    allow_abstain: true
     preserve_diagnostics: true
-    rank_fusion_method: rrf
-    vote_top1_weight: 1.0
-    vote_top3_weight: 0.7
-    vote_top5_weight: 0.5
-    vote_rrf_weight: 0.8
-    vote_borda_weight: 0.6
-    vote_rrf_k: 10
-    gating_enabled: true
-    contradiction_penalty_weight: 1.0
-    hard_violation_threshold: 2.0
-    hard_gate_multiplier: 0.05
-    soft_gate_floor: 0.25
-    score_spread_enabled: true
-    score_spread_temperature: 0.2
-    elimination_version: v2
+    tie_break_order:
+      - target_sensitive_score
+      - support_score
+      - row_col_stable
+    diagnostics:
+      include_vote_features: true
+      include_rank_features: true
+      include_score_features: true
+    judge:
+      enabled: true
+      use_for_primary_ranking: false
+      artifact_path: artifacts/competitive_judge_artifact.json
 
 joint_assignment:
   enabled: true

--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -13,6 +13,7 @@ modules:
     skip_patterns: true
     mirror_sequences: true
     tail_analyzer: true
+    neighborhood_association: true
   weights:
     logic_rule: 0.2
     pattern_model: 0.04
@@ -27,6 +28,7 @@ modules:
     skip_patterns: 0.05
     mirror_sequences: 0.01
     tail_analyzer: 0.02
+    neighborhood_association: 0.04
   settings:
     global_assignment_prior:
       assignment_mode: greedy
@@ -68,6 +70,29 @@ modules:
       decay_gamma: 0.35
     tail_analyzer:
       window_size: 3
+    neighborhood_association:
+      radius: 1
+      use_diagonal: true
+      min_seed_count: 1
+      decay_by_distance: true
+      distance_decay_power: 1.0
+      enabled_seed_families:
+        - same_decade
+        - same_tail
+        - near_value
+      near_value_deltas: [1, 2, 10, 20]
+      enabled_neighbor_families:
+        - same_decade
+        - same_tail
+        - near_value
+      neighbor_value_deltas: [1, 2, 10, 20]
+      score_mode: weighted_pattern_overlap
+      seed_aggregation: mean
+      candidate_aggregation: mean
+      neutral_score_when_no_seed: 0.5
+      floor_score: 0.0
+      ceil_score: 1.0
+      relation_source: heuristic_family_profile_v1
   aggregator:
     type: competitive_ensemble
     fusion_mode: learned_meta_ranker

--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -2,7 +2,7 @@ modules:
   enabled:
     logic_rule: true
     pattern_model: true
-    prior_model: true
+    prior_model: false
     structural_consistency: true
     focus_score: true
     connectivity_heatmap: true
@@ -11,10 +11,11 @@ modules:
     mirror_sequences: true
     tail_analyzer: true
     neighborhood_association: true
+    local_arithmetic_relation: true
   weights:
     logic_rule: 0.2
     pattern_model: 0.04
-    prior_model: 0.03
+    prior_model: 0.0
     structural_consistency: 0.2
     focus_score: 0.02
     connectivity_heatmap: 0.02
@@ -23,6 +24,7 @@ modules:
     mirror_sequences: 0.01
     tail_analyzer: 0.02
     neighborhood_association: 0.04
+    local_arithmetic_relation: 0.06
   settings:
     global_assignment_prior:
       assignment_mode: greedy
@@ -53,6 +55,11 @@ modules:
       fast_enabled: true
     prior_model:
       fast_enabled: true
+    local_arithmetic_relation:
+      near_value_deltas: [1, 2, 3, 5, 8, 10, 20]
+      exact_near_deltas: [1, 2, 3]
+      medium_near_deltas: [5, 8, 10]
+      weak_score_floor: 0.52
     directional_consistency:
       fast_enabled: true
     line_consistency:

--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -3,10 +3,7 @@ modules:
     logic_rule: true
     pattern_model: true
     prior_model: true
-    directional_consistency: true
-    line_consistency: true
-    global_assignment_prior: true
-    pairwise_conditional_consistency: true
+    structural_consistency: true
     focus_score: true
     connectivity_heatmap: true
     difference_trend: true
@@ -18,10 +15,7 @@ modules:
     logic_rule: 0.2
     pattern_model: 0.04
     prior_model: 0.03
-    directional_consistency: 0.2
-    line_consistency: 0.2
-    global_assignment_prior: 0.03
-    pairwise_conditional_consistency: 0.12
+    structural_consistency: 0.2
     focus_score: 0.02
     connectivity_heatmap: 0.02
     difference_trend: 0.06
@@ -70,6 +64,13 @@ modules:
       decay_gamma: 0.35
     tail_analyzer:
       window_size: 3
+    stage2_adjustments:
+      global_assignment_enabled: true
+      pairwise_enabled: true
+      assignment_delta_scale: 0.08
+      assignment_penalty_scale: 0.08
+      pairwise_delta_scale: 0.06
+      pairwise_penalty_scale: 0.06
     neighborhood_association:
       radius: 1
       use_diagonal: true

--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -16,15 +16,15 @@ modules:
     logic_rule: 0.2
     pattern_model: 0.04
     prior_model: 0.0
-    structural_consistency: 0.2
-    focus_score: 0.02
-    connectivity_heatmap: 0.02
-    difference_trend: 0.06
-    skip_patterns: 0.05
-    mirror_sequences: 0.01
-    tail_analyzer: 0.02
+    structural_consistency: 0.26
+    focus_score: 0.04
+    connectivity_heatmap: 0.03
+    difference_trend: 0.08
+    skip_patterns: 0.07
+    mirror_sequences: 0.02
+    tail_analyzer: 0.03
     neighborhood_association: 0.04
-    local_arithmetic_relation: 0.06
+    local_arithmetic_relation: 0.07
   settings:
     global_assignment_prior:
       assignment_mode: greedy
@@ -86,12 +86,10 @@ modules:
       distance_decay_power: 1.0
       enabled_seed_families:
         - same_decade
-        - same_tail
         - near_value
       near_value_deltas: [1, 2, 10, 20]
       enabled_neighbor_families:
         - same_decade
-        - same_tail
         - near_value
       neighbor_value_deltas: [1, 2, 10, 20]
       score_mode: weighted_pattern_overlap
@@ -103,7 +101,7 @@ modules:
       relation_source: heuristic_family_profile_v1
   aggregator:
     type: committee_weighted_sum
-    weighting_mode: equal_informative
+    weighting_mode: yaml_normalized
     allow_abstain: true
     preserve_diagnostics: true
     tie_break_order:

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -103,6 +103,7 @@ def build_cell_candidates(
             "score": 0.0,
             "module_scores": {},
             "module_details": {},
+            "module_informative": {},
         }
         for cell in unopened_cells
     ]
@@ -128,6 +129,13 @@ def _normalize_scores(raw_scores: Dict[Cell, float], mode: str = "disabled") -> 
 
 def _clip(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
     return max(lo, min(hi, v))
+
+
+def _get_informative_value(result: ModuleScoreResult, cell: Cell) -> float:
+    informative = getattr(result, "informative_cells", None)
+    if not informative:
+        return 1.0
+    return _clip(float(informative.get(cell, 1.0)))
 
 
 def score_candidates_raw(
@@ -198,11 +206,13 @@ def score_candidates_raw(
         for c in candidates:
             c.setdefault("module_scores", {})
             c.setdefault("module_details", {})
+            c.setdefault("module_informative", {})
             cell = c["cell"]
             module_score = float(normalized.get(cell, 0.0))
             c["module_scores"][module_name] = module_score
             if result.details:
                 c["module_details"][module_name] = result.details.get(cell, {})
+            c["module_informative"][module_name] = _get_informative_value(result, cell)
             c["score"] += module_score * weight
 
     if pairwise_name in weights:
@@ -273,6 +283,8 @@ def score_candidates_raw(
             c["module_scores"][pairwise_name] = module_score
             if result.details:
                 c["module_details"][pairwise_name] = result.details.get(cell, {})
+            c.setdefault("module_informative", {})
+            c["module_informative"][pairwise_name] = _get_informative_value(result, cell)
             c["score"] += module_score * float(weights[pairwise_name])
 
     return candidates, weights, explanations
@@ -341,8 +353,10 @@ def collect_module_outputs(
     module_norm: Dict[str, Dict[Cell, float]] = {}
     module_rank: Dict[str, Dict[Cell, int]] = {}
     module_vote: Dict[str, Dict[Cell, Dict[str, float]]] = {}
+    module_informative: Dict[str, Dict[Cell, float]] = {}
     for name in module_names:
         raw = {c["cell"]: float(c.get("module_scores", {}).get(name, 0.0)) for c in candidates}
+        informative = {c["cell"]: float(c.get("module_informative", {}).get(name, 1.0)) for c in candidates}
         norm = normalize_scores_per_module(raw, mode=normalization)
         rank = compute_dense_ranks(norm)
         vote = compute_vote_signals(rank)
@@ -350,6 +364,7 @@ def collect_module_outputs(
         module_norm[name] = norm
         module_rank[name] = rank
         module_vote[name] = vote
+        module_informative[name] = informative
     stage_a_score_by_cell = {
         cell: sum(float(module_norm[m][cell]) for m in module_names) / max(len(module_names), 1)
         for cell in cells
@@ -363,6 +378,7 @@ def collect_module_outputs(
         "module_norm_score_by_cell": module_norm,
         "module_rank_by_cell": module_rank,
         "module_vote_by_cell": module_vote,
+        "module_informative_by_cell": module_informative,
         "stage_a_score_by_cell": stage_a_score_by_cell,
         "stage_a_rank_by_cell": stage_a_rank_by_cell,
         "stage_a_top1_cell": stage_a_top1_cell,
@@ -480,6 +496,7 @@ def apply_meta_judge(
     weights: Dict[str, float],
     stage_a: Dict[str, object],
     aggregator_cfg: Dict[str, object],
+    use_for_primary_ranking: bool = True,
 ) -> Optional[str]:
     artifact_path = str(aggregator_cfg.get("judge_artifact_path", "artifacts/competitive_judge_artifact.json"))
     expected_schema_version = str(aggregator_cfg.get("judge_feature_schema_version", "competitive_features_v1"))
@@ -493,6 +510,8 @@ def apply_meta_judge(
                 f"judge schema mismatch: artifact={artifact_schema}, expected={expected_schema_version}"
             )
     except (FileNotFoundError, ValueError) as exc:
+        if not use_for_primary_ranking:
+            return f"meta_judge_fallback:{exc}"
         if fallback_mode == "weighted_rank_fusion":
             apply_weighted_rank_fusion(candidates, weights, stage_a, aggregator_cfg)
         elif fallback_mode == "vote_based_fusion":
@@ -510,17 +529,107 @@ def apply_meta_judge(
         c["gate_multiplier"] = 1.0
         c["vote_bonus"] = float(c.get("top1_vote_count", 0.0))
         c["gated_score"] = score
-        c["score"] = score
+        c["judge_score"] = score
+        if use_for_primary_ranking:
+            c["score"] = score
         c["judge_artifact_version"] = str(artifact.get("created_at", artifact.get("schema_version", "unknown")))
         c["judge_feature_schema_version"] = str(artifact.get("schema_version", "unknown"))
     return None
+
+
+def _normalize_active_weights(
+    module_names: List[str],
+    module_informative: Dict[str, float],
+    yaml_weights: Dict[str, float],
+    weighting_mode: str,
+) -> Dict[str, float]:
+    active = [m for m in module_names if float(module_informative.get(m, 0.0)) > 0.0]
+    if not active:
+        return {}
+    if weighting_mode == "equal_informative":
+        each = 1.0 / len(active)
+        return {m: each for m in active}
+    if weighting_mode == "yaml_normalized":
+        base_sum = sum(float(yaml_weights.get(m, 0.0)) for m in active)
+        if base_sum <= 0:
+            each = 1.0 / len(active)
+            return {m: each for m in active}
+        return {m: float(yaml_weights.get(m, 0.0)) / base_sum for m in active}
+    raise InferenceError(f"Unsupported weighting_mode: {weighting_mode}")
+
+
+def apply_committee_weighted_sum(
+    candidates: List[Dict[str, object]],
+    weights: Dict[str, float],
+    aggregator_cfg: Dict[str, object],
+) -> Dict[str, object]:
+    if not candidates:
+        return {}
+    module_names = sorted(weights.keys())
+    weighting_mode = str(aggregator_cfg.get("weighting_mode", "equal_informative"))
+    per_module_active_counts = {m: 0 for m in module_names}
+    no_info_any = False
+    for cand in candidates:
+        informative_map = {
+            m: float(cand.get("module_informative", {}).get(m, 1.0))
+            for m in module_names
+        }
+        active_weights = _normalize_active_weights(
+            module_names=module_names,
+            module_informative=informative_map,
+            yaml_weights=weights,
+            weighting_mode=weighting_mode,
+        )
+        for m in active_weights:
+            per_module_active_counts[m] += 1
+        if not active_weights:
+            committee_score = 0.5
+            no_info = True
+            no_info_any = True
+        else:
+            committee_score = sum(
+                float(cand.get("module_scores", {}).get(m, 0.0)) * float(active_weights[m]) for m in active_weights
+            )
+            no_info = False
+        cand["committee_score"] = float(committee_score)
+        cand["final_score"] = float(committee_score)
+        cand["score"] = float(committee_score)
+        cand["ranking_score"] = float(committee_score)
+        cand["active_module_count"] = int(len(active_weights))
+        cand["active_weight_sum"] = float(sum(active_weights.values()))
+        cand["module_effective_weights"] = dict(active_weights)
+        cand["committee_weighting_mode"] = weighting_mode
+        cand["top_decision_source"] = "committee_weighted_sum"
+        cand["no_informative_modules"] = bool(no_info)
+    return {
+        "fusion_mode": "committee_weighted_sum",
+        "ranking_contract_version": "committee_weighted_sum_v1",
+        "committee_weighting_mode": weighting_mode,
+        "no_informative_modules": bool(no_info_any),
+        "active_module_names": [m for m, n in per_module_active_counts.items() if n > 0],
+        "inactive_module_names": [m for m, n in per_module_active_counts.items() if n == 0],
+        "per_module_participation_rate": {
+            m: (float(per_module_active_counts[m]) / max(len(candidates), 1)) for m in module_names
+        },
+        "final_top_determined_by": "committee_score_only",
+    }
 
 
 def finalize_candidate_ranking(
     candidates: List[Dict[str, object]],
     stage_a: Dict[str, object],
 ) -> List[Dict[str, object]]:
-    final_order = sorted(candidates, key=lambda x: float(x.get("score", 0.0)), reverse=True)
+    final_order = sorted(
+        candidates,
+        key=lambda x: (
+            float(x.get("final_score", x.get("score", 0.0))),
+            float(x.get("target_sensitive_score", stage_a["stage_a_score_by_cell"].get(x["cell"], 0.0))),
+            float(x.get("support_score", stage_a["stage_a_score_by_cell"].get(x["cell"], 0.0))),
+            -int(x["cell"][0]),
+            -int(x["cell"][1]),
+        ),
+        reverse=True,
+    )
     for idx, cand in enumerate(final_order, start=1):
         cand["stage_a_rank"] = int(stage_a["stage_a_rank_by_cell"].get(cand["cell"], idx))
         cand["final_rank_position"] = int(idx)
@@ -544,11 +653,73 @@ def aggregate_candidate_scores(
     weights: Dict[str, float],
     aggregator_cfg: Dict[str, object],
 ) -> Dict[str, float]:
-    if str(aggregator_cfg.get("type", "competitive_ensemble")) != "competitive_ensemble":
+    agg_type = str(aggregator_cfg.get("type", "competitive_ensemble"))
+    if agg_type == "committee_weighted_sum":
+        if not candidates:
+            return {}
+        stage_a = collect_module_outputs(candidates, weights, aggregator_cfg)
+        build_competitive_fusion_features(
+            candidates,
+            stage_a,
+            dict(
+                aggregator_cfg,
+                include_vote_features=bool(aggregator_cfg.get("diagnostics", {}).get("include_vote_features", True)),
+                include_rank_features=bool(aggregator_cfg.get("diagnostics", {}).get("include_rank_features", True)),
+                include_score_features=bool(aggregator_cfg.get("diagnostics", {}).get("include_score_features", True)),
+            ),
+        )
+        diag = apply_committee_weighted_sum(candidates, weights, aggregator_cfg)
+        judge_cfg = dict(aggregator_cfg.get("judge", {}))
+        fallback_reason = None
+        if bool(judge_cfg.get("enabled", False)):
+            fallback_reason = apply_meta_judge(
+                candidates,
+                weights,
+                stage_a,
+                {
+                    **aggregator_cfg,
+                    "judge_artifact_path": str(judge_cfg.get("artifact_path", "")),
+                    "fallback_mode": "weighted_rank_fusion",
+                },
+                use_for_primary_ranking=bool(judge_cfg.get("use_for_primary_ranking", False)),
+            )
+        final_order = finalize_candidate_ranking(candidates, stage_a)
+        final_scores = [float(c["score"]) for c in final_order]
+        raw_mean = sum(final_scores) / len(final_scores)
+        raw_var = sum((s - raw_mean) ** 2 for s in final_scores) / len(final_scores)
+        final_std = math.sqrt(raw_var)
+        top_sorted = sorted(final_scores, reverse=True)
+        top1_top2_margin = 0.0 if len(top_sorted) < 2 else top_sorted[0] - top_sorted[1]
+        topk = top_sorted[: min(5, len(top_sorted))]
+        top1_top5_mean_gap = 0.0 if not topk else top_sorted[0] - (sum(topk) / len(topk))
+        tau = max(0.05, final_std)
+        exp_values = [math.exp((s - top_sorted[0]) / tau) for s in top_sorted]
+        z = sum(exp_values) or 1.0
+        probs = [x / z for x in exp_values]
+        entropy = -sum(p * math.log(max(p, 1e-12)) for p in probs)
+        max_entropy = math.log(max(len(probs), 1))
+        return {
+            "raw_score_min": min(final_scores),
+            "raw_score_max": max(final_scores),
+            "raw_score_std": final_std,
+            "final_score_min": min(final_scores),
+            "final_score_max": max(final_scores),
+            "final_score_std": final_std,
+            "top1_top2_margin": top1_top2_margin,
+            "top1_top5_mean_gap": top1_top5_mean_gap,
+            "score_entropy_like": entropy / max(max_entropy, 1e-12),
+            "collapsed_score_flag": final_std < 0.02 or top1_top2_margin < 0.01,
+            "stage_a_top1_cell": stage_a["stage_a_top1_cell"],
+            "final_top1_cell": final_order[0]["cell"],
+            "top1_changed_by_tiebreak": bool(stage_a["stage_a_top1_cell"] != final_order[0]["cell"]),
+            "fallback_reason": fallback_reason,
+            **diag,
+        }
+    if agg_type != "competitive_ensemble":
         return _aggregate_candidate_scores_legacy(
             candidates=candidates,
             weights=weights,
-            agg_type=str(aggregator_cfg.get("type", "weighted_average")),
+            agg_type=agg_type,
             gating_enabled=bool(aggregator_cfg.get("gating_enabled", True)),
             contradiction_weight=float(aggregator_cfg.get("contradiction_penalty_weight", 1.0)),
             hard_violation_threshold=float(aggregator_cfg.get("hard_violation_threshold", 2.0)),
@@ -924,11 +1095,22 @@ def _run_inference_detailed(
                 "module_scores": {
                     k: round(float(v), 6) for k, v in sorted(cell["module_scores"].items())
                 },
+                "module_informative": {
+                    k: round(float(v), 6) for k, v in sorted(cell.get("module_informative", {}).items())
+                },
+                "module_effective_weights": {
+                    k: round(float(v), 6) for k, v in sorted(cell.get("module_effective_weights", {}).items())
+                },
                 "support_score": round(float(cell.get("support_score", score)), 6),
                 "contradiction_penalty": round(float(cell.get("contradiction_penalty", 0.0)), 6),
                 "gated_score": round(float(cell.get("gated_score", score)), 6),
                 "ranking_score": round(float(cell.get("ranking_score", score)), 6),
                 "final_score": score,
+                "committee_score": round(float(cell.get("committee_score", score)), 6),
+                "active_module_count": int(cell.get("active_module_count", len(weights))),
+                "active_weight_sum": round(float(cell.get("active_weight_sum", 1.0)), 6),
+                "committee_weighting_mode": str(cell.get("committee_weighting_mode", "")),
+                "top_decision_source": str(cell.get("top_decision_source", "")),
                 "gate_multiplier": round(float(cell.get("gate_multiplier", 1.0)), 6),
                 "vote_bonus": round(float(cell.get("vote_bonus", 0.0)), 6),
                 "target_sensitive_score": round(float(cell.get("target_sensitive_score", 0.0)), 6),
@@ -1049,8 +1231,16 @@ def _run_inference_detailed(
             "version": version,
             "aggregation_type": str(aggregator_cfg.get("type", "weighted_average")),
             "fusion_mode": str(aggregator_cfg.get("fusion_mode", "weighted_rank_fusion")),
+            "committee_weighting_mode": str(diagnostics.get("committee_weighting_mode", "")),
+            "no_informative_modules": bool(diagnostics.get("no_informative_modules", False)),
+            "active_module_names": diagnostics.get("active_module_names", []),
+            "inactive_module_names": diagnostics.get("inactive_module_names", []),
+            "per_module_participation_rate": diagnostics.get("per_module_participation_rate", {}),
+            "final_top_determined_by": str(diagnostics.get("final_top_determined_by", "")),
             "judge_model_type": str(aggregator_cfg.get("judge_model_type", "")),
-            "judge_artifact_path": str(aggregator_cfg.get("judge_artifact_path", "")),
+            "judge_artifact_path": str(
+                aggregator_cfg.get("judge_artifact_path", aggregator_cfg.get("judge", {}).get("artifact_path", ""))
+            ),
             "judge_artifact_version": str(diagnostics.get("judge_artifact_version", "unknown")),
             "judge_feature_schema_version": str(diagnostics.get("judge_feature_schema_version", "unknown")),
             "equal_start_enabled": bool(aggregator_cfg.get("type", "") == "competitive_ensemble"),

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -146,7 +146,7 @@ def _get_informative_value(result: ModuleScoreResult, cell: Cell) -> float:
 
 def _validate_committee_stage1_modules(weights: Dict[str, float]) -> None:
     stage1_modules = set(weights.keys())
-    banned = {"global_assignment_prior", "pairwise_conditional_consistency"}
+    banned = {"global_assignment_prior", "pairwise_conditional_consistency", "prior_model"}
     invalid = sorted(stage1_modules & banned)
     if invalid:
         raise InferenceError(f"committee stage-1 cannot include modules: {invalid}")
@@ -689,17 +689,21 @@ def apply_committee_weighted_sum(
             committee_score = 0.5
             no_info = True
             no_info_any = True
+            assignment_delta = 0.0
+            assignment_penalty = 0.0
+            pairwise_delta = 0.0
+            pairwise_penalty = 0.0
         else:
             committee_score = sum(
                 float(cand.get("module_scores", {}).get(m, 0.0)) * float(active_weights[m]) for m in active_weights
             )
             no_info = False
+            assignment_delta = float(cand.get("assignment_delta", 0.0))
+            assignment_penalty = float(cand.get("assignment_penalty", 0.0))
+            pairwise_delta = float(cand.get("pairwise_delta", 0.0))
+            pairwise_penalty = float(cand.get("pairwise_penalty", 0.0))
         stage1_base = float(committee_score)
-        assignment_delta = float(cand.get("assignment_delta", 0.0))
-        assignment_penalty = float(cand.get("assignment_penalty", 0.0))
         stage2_score = stage1_base + assignment_delta - assignment_penalty
-        pairwise_delta = float(cand.get("pairwise_delta", 0.0))
-        pairwise_penalty = float(cand.get("pairwise_penalty", 0.0))
         stage3_score = stage2_score + pairwise_delta - pairwise_penalty
         cand["stage1_base_score"] = stage1_base
         cand["stage2_assignment_adjusted_score"] = stage2_score

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -26,7 +26,13 @@ from src.competitive_fusion import (
 )
 from src.ranking_features import build_candidate_feature_rows
 from src.reranker import apply_reranker, load_reranker_artifact
-from src.scoring_modules import Cell, ModuleScoreResult, build_modules
+from src.scoring_modules import (
+    Cell,
+    GlobalAssignmentPriorModule,
+    ModuleScoreResult,
+    PairwiseConditionalConsistencyModule,
+    build_modules,
+)
 from src.scoring_modules import linear_sum_assignment
 
 
@@ -136,6 +142,20 @@ def _get_informative_value(result: ModuleScoreResult, cell: Cell) -> float:
     if not informative:
         return 1.0
     return _clip(float(informative.get(cell, 1.0)))
+
+
+def _validate_committee_stage1_modules(weights: Dict[str, float]) -> None:
+    stage1_modules = set(weights.keys())
+    banned = {"global_assignment_prior", "pairwise_conditional_consistency"}
+    invalid = sorted(stage1_modules & banned)
+    if invalid:
+        raise InferenceError(f"committee stage-1 cannot include modules: {invalid}")
+    if "structural_consistency" in stage1_modules and (
+        "directional_consistency" in stage1_modules or "line_consistency" in stage1_modules
+    ):
+        raise InferenceError("structural_consistency cannot be enabled with directional_consistency/line_consistency")
+    if "directional_consistency" in stage1_modules or "line_consistency" in stage1_modules:
+        raise InferenceError("committee stage-1 must use structural_consistency instead of directional/line modules")
 
 
 def score_candidates_raw(
@@ -288,6 +308,89 @@ def score_candidates_raw(
             c["score"] += module_score * float(weights[pairwise_name])
 
     return candidates, weights, explanations
+
+
+def _apply_stage2_adjustment_signals(
+    board: List[List[int]],
+    candidates: List[Dict[str, object]],
+    target_number: int,
+    module_settings: Optional[Dict[str, Dict[str, object]]] = None,
+    stage1_weights: Optional[Dict[str, float]] = None,
+) -> None:
+    if not candidates:
+        return
+    settings = module_settings or {}
+    stage2_cfg = dict(settings.get("stage2_adjustments", {}))
+    if not stage2_cfg:
+        stage2_cfg = {
+            "global_assignment_enabled": True,
+            "pairwise_enabled": True,
+            "assignment_delta_scale": 0.08,
+            "assignment_penalty_scale": 0.08,
+            "pairwise_delta_scale": 0.06,
+            "pairwise_penalty_scale": 0.06,
+        }
+    candidate_cells = [c["cell"] for c in candidates]
+    for cand in candidates:
+        cand["assignment_delta"] = 0.0
+        cand["assignment_penalty"] = 0.0
+        cand["pairwise_delta"] = 0.0
+        cand["pairwise_penalty"] = 0.0
+        cand["assignment_diagnostics"] = {}
+        cand["pairwise_diagnostics"] = {}
+
+    if bool(stage2_cfg.get("global_assignment_enabled", True)):
+        assign_cfg = dict(settings.get("global_assignment_prior", {}))
+        assign_module = GlobalAssignmentPriorModule(
+            assignment_mode=str(assign_cfg.get("assignment_mode", "greedy")),
+            top_m_candidates=int(assign_cfg.get("top_m_candidates", 4)),
+            exact_max_candidates=int(assign_cfg.get("exact_max_candidates", 20)),
+        )
+        assign_res = assign_module.score(board, candidate_cells, target_number)
+        delta_scale = float(stage2_cfg.get("assignment_delta_scale", 0.08))
+        penalty_scale = float(stage2_cfg.get("assignment_penalty_scale", 0.08))
+        for cand in candidates:
+            cell = cand["cell"]
+            s = float(assign_res.scores.get(cell, 0.5))
+            cand["assignment_delta"] = max(0.0, s - 0.5) * delta_scale
+            cand["assignment_penalty"] = max(0.0, 0.5 - s) * penalty_scale
+            cand["assignment_diagnostics"] = assign_res.details.get(cell, {}) if assign_res.details else {}
+
+    if bool(stage2_cfg.get("pairwise_enabled", True)):
+        pair_cfg = dict(settings.get("pairwise_conditional_consistency", {}))
+        pair_module = PairwiseConditionalConsistencyModule(
+            anchor_top_k_cells=int(pair_cfg.get("anchor_top_k_cells", 5)),
+            anchor_top_k_values=int(pair_cfg.get("anchor_top_k_values", 5)),
+            max_pair_trials_per_candidate=int(pair_cfg.get("max_pair_trials_per_candidate", 20)),
+            gating_enabled=bool(pair_cfg.get("gating_enabled", True)),
+            contradiction_penalty_weight=float(pair_cfg.get("contradiction_penalty_weight", 1.0)),
+            hard_violation_threshold=float(pair_cfg.get("hard_violation_threshold", 2.0)),
+            hard_gate_multiplier=float(pair_cfg.get("hard_gate_multiplier", 0.05)),
+            soft_gate_floor=float(pair_cfg.get("soft_gate_floor", 0.25)),
+            runtime_mode=str(pair_cfg.get("runtime_mode", "fast")),
+            candidate_top_n=int(pair_cfg.get("candidate_top_n", 8)),
+            global_assignment_mode=str(pair_cfg.get("global_assignment_mode", "greedy")),
+            global_assignment_top_m_candidates=int(pair_cfg.get("global_assignment_top_m_candidates", 4)),
+        )
+        if stage1_weights:
+            ranked = sorted(
+                candidates,
+                key=lambda c: sum(
+                    float(c.get("module_scores", {}).get(m, 0.0)) * float(stage1_weights.get(m, 0.0))
+                    for m in stage1_weights
+                ),
+                reverse=True,
+            )
+            pair_module.set_seed_ranked_candidates([c["cell"] for c in ranked])
+        pair_res = pair_module.score(board, candidate_cells, target_number)
+        delta_scale = float(stage2_cfg.get("pairwise_delta_scale", 0.06))
+        penalty_scale = float(stage2_cfg.get("pairwise_penalty_scale", 0.06))
+        for cand in candidates:
+            cell = cand["cell"]
+            s = float(pair_res.scores.get(cell, 0.5))
+            cand["pairwise_delta"] = max(0.0, s - 0.5) * delta_scale
+            cand["pairwise_penalty"] = max(0.0, 0.5 - s) * penalty_scale
+            cand["pairwise_diagnostics"] = pair_res.details.get(cell, {}) if pair_res.details else {}
 
 
 def score_candidates(
@@ -591,15 +694,35 @@ def apply_committee_weighted_sum(
                 float(cand.get("module_scores", {}).get(m, 0.0)) * float(active_weights[m]) for m in active_weights
             )
             no_info = False
-        cand["committee_score"] = float(committee_score)
-        cand["final_score"] = float(committee_score)
-        cand["score"] = float(committee_score)
-        cand["ranking_score"] = float(committee_score)
+        stage1_base = float(committee_score)
+        assignment_delta = float(cand.get("assignment_delta", 0.0))
+        assignment_penalty = float(cand.get("assignment_penalty", 0.0))
+        stage2_score = stage1_base + assignment_delta - assignment_penalty
+        pairwise_delta = float(cand.get("pairwise_delta", 0.0))
+        pairwise_penalty = float(cand.get("pairwise_penalty", 0.0))
+        stage3_score = stage2_score + pairwise_delta - pairwise_penalty
+        cand["stage1_base_score"] = stage1_base
+        cand["stage2_assignment_adjusted_score"] = stage2_score
+        cand["stage3_pairwise_adjusted_score"] = stage3_score
+        cand["committee_score"] = stage1_base
+        cand["final_score"] = stage3_score
+        cand["score"] = stage3_score
+        cand["ranking_score"] = stage3_score
         cand["active_module_count"] = int(len(active_weights))
         cand["active_weight_sum"] = float(sum(active_weights.values()))
         cand["module_effective_weights"] = dict(active_weights)
         cand["committee_weighting_mode"] = weighting_mode
-        cand["top_decision_source"] = "committee_weighted_sum"
+        cand["top_decision_source"] = "stage3_pairwise_adjusted_score"
+        cand["score_chain"] = {
+            "stage1_base_score": stage1_base,
+            "assignment_delta": assignment_delta,
+            "assignment_penalty": assignment_penalty,
+            "stage2_assignment_adjusted_score": stage2_score,
+            "pairwise_delta": pairwise_delta,
+            "pairwise_penalty": pairwise_penalty,
+            "stage3_pairwise_adjusted_score": stage3_score,
+            "final_score": stage3_score,
+        }
         cand["no_informative_modules"] = bool(no_info)
     return {
         "fusion_mode": "committee_weighted_sum",
@@ -611,7 +734,7 @@ def apply_committee_weighted_sum(
         "per_module_participation_rate": {
             m: (float(per_module_active_counts[m]) / max(len(candidates), 1)) for m in module_names
         },
-        "final_top_determined_by": "committee_score_only",
+        "final_top_determined_by": "score_chain_final_score",
     }
 
 
@@ -1045,6 +1168,15 @@ def _run_inference_detailed(
         module_settings=module_settings,
         normalization_mode=str(aggregator_cfg.get("normalization_mode", "disabled")),
     )
+    if str(aggregator_cfg.get("type", "")) == "committee_weighted_sum":
+        _validate_committee_stage1_modules(weights)
+    _apply_stage2_adjustment_signals(
+        board=board,
+        candidates=scored,
+        target_number=target_number,
+        module_settings=module_settings,
+        stage1_weights=weights,
+    )
     diagnostics = aggregate_candidate_scores(scored, weights, aggregator_cfg)
     ranked = rank_candidates(scored)
     best = ranked[0]
@@ -1095,6 +1227,9 @@ def _run_inference_detailed(
                 "module_scores": {
                     k: round(float(v), 6) for k, v in sorted(cell["module_scores"].items())
                 },
+                "primitive_module_scores": {
+                    k: round(float(v), 6) for k, v in sorted(cell["module_scores"].items())
+                },
                 "module_informative": {
                     k: round(float(v), 6) for k, v in sorted(cell.get("module_informative", {}).items())
                 },
@@ -1107,6 +1242,12 @@ def _run_inference_detailed(
                 "ranking_score": round(float(cell.get("ranking_score", score)), 6),
                 "final_score": score,
                 "committee_score": round(float(cell.get("committee_score", score)), 6),
+                "stage1_base_score": round(float(cell.get("stage1_base_score", score)), 6),
+                "assignment_delta": round(float(cell.get("assignment_delta", 0.0)), 6),
+                "assignment_penalty": round(float(cell.get("assignment_penalty", 0.0)), 6),
+                "pairwise_delta": round(float(cell.get("pairwise_delta", 0.0)), 6),
+                "pairwise_penalty": round(float(cell.get("pairwise_penalty", 0.0)), 6),
+                "score_chain": cell.get("score_chain", {}),
                 "active_module_count": int(cell.get("active_module_count", len(weights))),
                 "active_weight_sum": round(float(cell.get("active_weight_sum", 1.0)), 6),
                 "committee_weighting_mode": str(cell.get("committee_weighting_mode", "")),

--- a/src/mainline_eval.py
+++ b/src/mainline_eval.py
@@ -16,11 +16,16 @@ Cell = Tuple[int, int]
 
 CORE_MODULES = [
     "logic_rule",
+    "structural_consistency",
     "pattern_model",
     "prior_model",
-    "directional_consistency",
-    "line_consistency",
-    "global_assignment_prior",
+    "focus_score",
+    "connectivity_heatmap",
+    "difference_trend",
+    "skip_patterns",
+    "mirror_sequences",
+    "tail_analyzer",
+    "neighborhood_association",
 ]
 
 

--- a/src/mainline_eval.py
+++ b/src/mainline_eval.py
@@ -18,7 +18,6 @@ CORE_MODULES = [
     "logic_rule",
     "structural_consistency",
     "pattern_model",
-    "prior_model",
     "focus_score",
     "connectivity_heatmap",
     "difference_trend",
@@ -26,6 +25,7 @@ CORE_MODULES = [
     "mirror_sequences",
     "tail_analyzer",
     "neighborhood_association",
+    "local_arithmetic_relation",
 ]
 
 

--- a/src/neighborhood_association.py
+++ b/src/neighborhood_association.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+Board = List[List[int]]
+Cell = Tuple[int, int]
+
+
+@dataclass
+class ModuleScoreResult:
+    scores: Dict[Cell, float]
+    explanation: str
+    details: Dict[Cell, Dict[str, float]]
+
+
+@dataclass
+class SeedInfo:
+    row: int
+    col: int
+    value: int
+    matched_families: List[str]
+
+
+@dataclass
+class NeighborhoodProfile:
+    feature_values: Dict[str, float]
+    neighbor_count: int
+    total_weight: float
+
+
+def _clip(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, v))
+
+
+def same_decade_family(a: int, b: int) -> bool:
+    return (a - 1) // 10 == (b - 1) // 10
+
+
+def same_tail_family(a: int, b: int) -> bool:
+    return a % 10 == b % 10
+
+
+def near_value_family(a: int, b: int, deltas: Sequence[int]) -> bool:
+    return abs(a - b) in deltas
+
+
+def _distance(dr: int, dc: int, use_diagonal: bool) -> int:
+    if use_diagonal:
+        return max(abs(dr), abs(dc))
+    return abs(dr) + abs(dc)
+
+
+def _iter_neighbors(
+    board: Board,
+    row: int,
+    col: int,
+    radius: int,
+    use_diagonal: bool,
+) -> Iterable[Tuple[int, int, int]]:
+    rows, cols = len(board), len(board[0])
+    for rr in range(max(0, row - radius), min(rows, row + radius + 1)):
+        for cc in range(max(0, col - radius), min(cols, col + radius + 1)):
+            if rr == row and cc == col:
+                continue
+            dr = rr - row
+            dc = cc - col
+            dist = _distance(dr, dc, use_diagonal)
+            if dist <= 0 or dist > radius:
+                continue
+            value = board[rr][cc]
+            if value == -1:
+                continue
+            yield rr, cc, value
+
+
+def match_seed_family(
+    opened_value: int,
+    target_number: int,
+    enabled_seed_families: Sequence[str],
+    deltas: Sequence[int],
+) -> List[str]:
+    matched: List[str] = []
+    for family in enabled_seed_families:
+        if family == "same_decade" and same_decade_family(opened_value, target_number):
+            matched.append(family)
+        elif family == "same_tail" and same_tail_family(opened_value, target_number):
+            matched.append(family)
+        elif family == "near_value" and near_value_family(opened_value, target_number, deltas):
+            matched.append(family)
+        elif family == "exact_value" and opened_value == target_number:
+            matched.append(family)
+        elif family == "custom_relation":
+            continue
+    return matched
+
+
+def neighbor_relation_features(
+    neighbor_value: int,
+    target_number: int,
+    enabled_neighbor_families: Sequence[str],
+    deltas: Sequence[int],
+) -> Dict[str, float]:
+    features: Dict[str, float] = {
+        "same_decade_support": 0.0,
+        "same_tail_support": 0.0,
+        "near_value_support": 0.0,
+        "exact_value_support": 0.0,
+        "numeric_closeness": 1.0 / (1.0 + abs(neighbor_value - target_number)),
+    }
+    if "same_decade" in enabled_neighbor_families:
+        features["same_decade_support"] = 1.0 if same_decade_family(neighbor_value, target_number) else 0.0
+    if "same_tail" in enabled_neighbor_families:
+        features["same_tail_support"] = 1.0 if same_tail_family(neighbor_value, target_number) else 0.0
+    if "near_value" in enabled_neighbor_families:
+        is_near = near_value_family(neighbor_value, target_number, deltas)
+        features["near_value_support"] = 1.0 if is_near else 0.0
+        for d in deltas:
+            features[f"near_value_delta_{int(d)}"] = 1.0 if abs(neighbor_value - target_number) == int(d) else 0.0
+    if "exact_value" in enabled_neighbor_families:
+        features["exact_value_support"] = 1.0 if neighbor_value == target_number else 0.0
+    return features
+
+
+def _build_profile(
+    board: Board,
+    row: int,
+    col: int,
+    target_number: int,
+    radius: int,
+    use_diagonal: bool,
+    decay_by_distance: bool,
+    distance_decay_power: float,
+    enabled_neighbor_families: Sequence[str],
+    neighbor_value_deltas: Sequence[int],
+) -> NeighborhoodProfile:
+    weighted_sums: Dict[str, float] = {}
+    total_weight = 0.0
+    neighbor_count = 0
+
+    for rr, cc, value in _iter_neighbors(board, row, col, radius, use_diagonal):
+        dist = _distance(rr - row, cc - col, use_diagonal)
+        weight = 1.0
+        if decay_by_distance:
+            weight = 1.0 / max(float(dist) ** max(distance_decay_power, 1e-6), 1e-6)
+        feats = neighbor_relation_features(value, target_number, enabled_neighbor_families, neighbor_value_deltas)
+        for key, val in feats.items():
+            weighted_sums[key] = weighted_sums.get(key, 0.0) + weight * float(val)
+        total_weight += weight
+        neighbor_count += 1
+
+    if total_weight <= 0:
+        return NeighborhoodProfile(feature_values={}, neighbor_count=0, total_weight=0.0)
+
+    return NeighborhoodProfile(
+        feature_values={k: v / total_weight for k, v in weighted_sums.items()},
+        neighbor_count=neighbor_count,
+        total_weight=total_weight,
+    )
+
+
+def _profile_similarity(seed_profile: NeighborhoodProfile, candidate_profile: NeighborhoodProfile) -> float:
+    if seed_profile.total_weight <= 0 and candidate_profile.total_weight <= 0:
+        return 0.45
+    if seed_profile.total_weight <= 0 or candidate_profile.total_weight <= 0:
+        return 0.35
+
+    keys = sorted(set(seed_profile.feature_values.keys()) | set(candidate_profile.feature_values.keys()))
+    if not keys:
+        return 0.45
+    mean_abs_diff = sum(
+        abs(seed_profile.feature_values.get(k, 0.0) - candidate_profile.feature_values.get(k, 0.0)) for k in keys
+    ) / len(keys)
+    return _clip(1.0 - mean_abs_diff)
+
+
+class NeighborhoodAssociationModule:
+    name = "neighborhood_association"
+
+    def __init__(
+        self,
+        radius: int = 1,
+        use_diagonal: bool = True,
+        min_seed_count: int = 1,
+        decay_by_distance: bool = True,
+        distance_decay_power: float = 1.0,
+        enabled_seed_families: Sequence[str] = ("same_decade", "same_tail", "near_value"),
+        near_value_deltas: Sequence[int] = (1, 2, 10, 20),
+        enabled_neighbor_families: Sequence[str] = ("same_decade", "same_tail", "near_value"),
+        neighbor_value_deltas: Sequence[int] = (1, 2, 10, 20),
+        score_mode: str = "weighted_pattern_overlap",
+        seed_aggregation: str = "mean",
+        candidate_aggregation: str = "mean",
+        neutral_score_when_no_seed: float = 0.5,
+        floor_score: float = 0.0,
+        ceil_score: float = 1.0,
+        relation_source: str = "heuristic_family_profile_v1",
+    ) -> None:
+        if score_mode != "weighted_pattern_overlap":
+            raise ValueError(f"Unsupported score_mode: {score_mode}")
+        if seed_aggregation not in {"mean", "max"}:
+            raise ValueError(f"Unsupported seed_aggregation: {seed_aggregation}")
+        if candidate_aggregation not in {"mean"}:
+            raise ValueError(f"Unsupported candidate_aggregation: {candidate_aggregation}")
+
+        self.radius = max(1, int(radius))
+        self.use_diagonal = bool(use_diagonal)
+        self.min_seed_count = max(1, int(min_seed_count))
+        self.decay_by_distance = bool(decay_by_distance)
+        self.distance_decay_power = float(distance_decay_power)
+        self.enabled_seed_families = [str(x) for x in enabled_seed_families]
+        self.near_value_deltas = sorted({abs(int(x)) for x in near_value_deltas if int(x) > 0})
+        self.enabled_neighbor_families = [str(x) for x in enabled_neighbor_families]
+        self.neighbor_value_deltas = sorted({abs(int(x)) for x in neighbor_value_deltas if int(x) > 0})
+        self.seed_aggregation = seed_aggregation
+        self.neutral_score_when_no_seed = float(neutral_score_when_no_seed)
+        self.floor_score = float(floor_score)
+        self.ceil_score = float(ceil_score)
+        self.relation_source = relation_source
+
+    def _find_seeds(self, board: Board, target_number: int) -> List[SeedInfo]:
+        seeds: List[SeedInfo] = []
+        for r, row in enumerate(board):
+            for c, value in enumerate(row):
+                if value == -1:
+                    continue
+                matched = match_seed_family(value, target_number, self.enabled_seed_families, self.near_value_deltas)
+                if matched:
+                    seeds.append(SeedInfo(row=r, col=c, value=value, matched_families=matched))
+        return seeds
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        if not unopened_cells:
+            return ModuleScoreResult({}, "neighborhood_association: no unopened cells", details={})
+
+        seeds = self._find_seeds(board, target_number)
+        details: Dict[Cell, Dict[str, float]] = {}
+        scores: Dict[Cell, float] = {}
+
+        if len(seeds) < self.min_seed_count:
+            for cell in unopened_cells:
+                scores[cell] = _clip(self.neutral_score_when_no_seed, self.floor_score, self.ceil_score)
+                details[cell] = {
+                    "seed_count": float(len(seeds)),
+                    "effective_seed_count": 0.0,
+                    "candidate_neighbor_count": 0.0,
+                    "matched_seed_similarity_mean": 0.0,
+                    "matched_seed_similarity_max": 0.0,
+                    "same_decade_support": 0.0,
+                    "same_tail_support": 0.0,
+                    "near_value_support": 0.0,
+                    "used_radius": float(self.radius),
+                    "used_diagonal": float(self.use_diagonal),
+                    "no_seed_fallback_used": 1.0,
+                }
+            return ModuleScoreResult(
+                scores,
+                "neighborhood_association: 無足夠 seed，回退中性分數",
+                details=details,
+            )
+
+        seed_profiles: List[Tuple[SeedInfo, NeighborhoodProfile]] = []
+        for seed in seeds:
+            profile = _build_profile(
+                board,
+                seed.row,
+                seed.col,
+                target_number,
+                self.radius,
+                self.use_diagonal,
+                self.decay_by_distance,
+                self.distance_decay_power,
+                self.enabled_neighbor_families,
+                self.neighbor_value_deltas,
+            )
+            seed_profiles.append((seed, profile))
+
+        effective_seed_count = sum(1 for _, p in seed_profiles if p.neighbor_count > 0)
+
+        for cell in unopened_cells:
+            candidate_profile = _build_profile(
+                board,
+                cell[0],
+                cell[1],
+                target_number,
+                self.radius,
+                self.use_diagonal,
+                self.decay_by_distance,
+                self.distance_decay_power,
+                self.enabled_neighbor_families,
+                self.neighbor_value_deltas,
+            )
+            similarities: List[Tuple[float, SeedInfo]] = [
+                (_profile_similarity(seed_profile, candidate_profile), seed)
+                for seed, seed_profile in seed_profiles
+            ]
+            only_scores = [x[0] for x in similarities]
+            sim_mean = sum(only_scores) / max(len(only_scores), 1)
+            sim_max = max(only_scores) if only_scores else 0.0
+            final_score = sim_max if self.seed_aggregation == "max" else sim_mean
+            final_score = _clip(final_score, self.floor_score, self.ceil_score)
+            scores[cell] = final_score
+
+            top_sim, top_seed = max(similarities, key=lambda x: x[0]) if similarities else (0.0, None)
+            details[cell] = {
+                "seed_count": float(len(seeds)),
+                "effective_seed_count": float(effective_seed_count),
+                "candidate_neighbor_count": float(candidate_profile.neighbor_count),
+                "matched_seed_similarity_mean": float(sim_mean),
+                "matched_seed_similarity_max": float(sim_max),
+                "same_decade_support": float(candidate_profile.feature_values.get("same_decade_support", 0.0)),
+                "same_tail_support": float(candidate_profile.feature_values.get("same_tail_support", 0.0)),
+                "near_value_support": float(candidate_profile.feature_values.get("near_value_support", 0.0)),
+                "used_radius": float(self.radius),
+                "used_diagonal": float(self.use_diagonal),
+                "no_seed_fallback_used": 0.0,
+                "top_seed_row": float(top_seed.row + 1) if top_seed else -1.0,
+                "top_seed_col": float(top_seed.col + 1) if top_seed else -1.0,
+                "top_seed_value": float(top_seed.value) if top_seed else -1.0,
+                "top_seed_similarity": float(top_sim),
+            }
+        return ModuleScoreResult(
+            scores,
+            "neighborhood_association: 以 target 關聯 family 的局部鄰域共現支持度評分",
+            details=details,
+        )

--- a/src/neighborhood_association.py
+++ b/src/neighborhood_association.py
@@ -12,6 +12,7 @@ class ModuleScoreResult:
     scores: Dict[Cell, float]
     explanation: str
     details: Dict[Cell, Dict[str, float]]
+    informative_cells: Dict[Cell, float]
 
 
 @dataclass
@@ -231,11 +232,17 @@ class NeighborhoodAssociationModule:
 
     def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
         if not unopened_cells:
-            return ModuleScoreResult({}, "neighborhood_association: no unopened cells", details={})
+            return ModuleScoreResult(
+                {},
+                "neighborhood_association: no unopened cells",
+                details={},
+                informative_cells={},
+            )
 
         seeds = self._find_seeds(board, target_number)
         details: Dict[Cell, Dict[str, float]] = {}
         scores: Dict[Cell, float] = {}
+        informative_cells: Dict[Cell, float] = {}
 
         if len(seeds) < self.min_seed_count:
             for cell in unopened_cells:
@@ -252,11 +259,17 @@ class NeighborhoodAssociationModule:
                     "used_radius": float(self.radius),
                     "used_diagonal": float(self.use_diagonal),
                     "no_seed_fallback_used": 1.0,
+                    "abstain_flag": 1.0,
+                    "top_seed_row": -1.0,
+                    "top_seed_col": -1.0,
+                    "top_seed_value": -1.0,
                 }
+                informative_cells[cell] = 0.0
             return ModuleScoreResult(
                 scores,
                 "neighborhood_association: 無足夠 seed，回退中性分數",
                 details=details,
+                informative_cells=informative_cells,
             )
 
         seed_profiles: List[Tuple[SeedInfo, NeighborhoodProfile]] = []
@@ -314,13 +327,16 @@ class NeighborhoodAssociationModule:
                 "used_radius": float(self.radius),
                 "used_diagonal": float(self.use_diagonal),
                 "no_seed_fallback_used": 0.0,
+                "abstain_flag": 0.0,
                 "top_seed_row": float(top_seed.row + 1) if top_seed else -1.0,
                 "top_seed_col": float(top_seed.col + 1) if top_seed else -1.0,
                 "top_seed_value": float(top_seed.value) if top_seed else -1.0,
                 "top_seed_similarity": float(top_sim),
             }
+            informative_cells[cell] = 1.0
         return ModuleScoreResult(
             scores,
             "neighborhood_association: 以 target 關聯 family 的局部鄰域共現支持度評分",
             details=details,
+            informative_cells=informative_cells,
         )

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -544,6 +544,47 @@ class LineConsistencyModule:
         )
 
 
+class StructuralConsistencyModule:
+    name = "structural_consistency"
+
+    def __init__(self, fast_enabled: bool = True) -> None:
+        self.directional_module = DirectionalConsistencyModule(fast_enabled=fast_enabled)
+        self.line_module = LineConsistencyModule(fast_enabled=fast_enabled)
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        directional = self.directional_module.score(board, unopened_cells, target_number)
+        line = self.line_module.score(board, unopened_cells, target_number)
+        scores: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for cell in unopened_cells:
+            d_score = float(directional.scores.get(cell, NEUTRAL_SCORE))
+            l_score = float(line.scores.get(cell, NEUTRAL_SCORE))
+            combined = _clip(0.5 * d_score + 0.5 * l_score)
+            scores[cell] = combined
+            d_details = directional.details.get(cell, {}) if directional.details else {}
+            l_details = line.details.get(cell, {}) if line.details else {}
+            cell_details: Dict[str, float] = {
+                "structural_consistency": combined,
+                "directional_component_score": d_score,
+                "line_component_score": l_score,
+            }
+            cell_details.update({f"directional_{k}": float(v) for k, v in d_details.items()})
+            cell_details.update({f"line_{k}": float(v) for k, v in l_details.items()})
+            details[cell] = cell_details
+        return ModuleScoreResult(
+            scores,
+            "structural_consistency: 整合 directional 與 line 一次性結構一致性評分",
+            details=details,
+            informative_cells={
+                cell: min(
+                    float(directional.informative_cells.get(cell, 1.0)),
+                    float(line.informative_cells.get(cell, 1.0)),
+                )
+                for cell in unopened_cells
+            },
+        )
+
+
 class GlobalAssignmentPriorModule:
     name = "global_assignment_prior"
 
@@ -944,6 +985,9 @@ MODULE_FACTORIES = {
     "logic_rule": lambda cfg: LogicRuleModule(fast_enabled=bool(cfg.get("fast_enabled", True))),
     "pattern_model": lambda _cfg: PatternModelModule(),
     "prior_model": lambda cfg: PriorModelModule(fast_enabled=bool(cfg.get("fast_enabled", True))),
+    "structural_consistency": lambda cfg: StructuralConsistencyModule(
+        fast_enabled=bool(cfg.get("fast_enabled", True))
+    ),
     "directional_consistency": lambda cfg: DirectionalConsistencyModule(
         fast_enabled=bool(cfg.get("fast_enabled", True))
     ),

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -46,6 +46,7 @@ class ModuleScoreResult:
     scores: Dict[Cell, float]
     explanation: str
     details: Dict[Cell, Dict[str, float]] = field(default_factory=dict)
+    informative_cells: Dict[Cell, float] = field(default_factory=dict)
 
 
 class ScoringModule(Protocol):

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -456,12 +456,7 @@ def _line_components(board: Board, candidate: Cell, target_number: int) -> Dict[
 def _cell_number_compatibility(board: Board, cell: Cell, number: int) -> float:
     directional = _directional_components(board, cell, number)["directional_consistency"]
     line = _line_components(board, cell, number)["line_consistency"]
-    rows, cols = len(board), len(board[0])
-    center_r = (rows - 1) / 2.0
-    center_c = (cols - 1) / 2.0
-    max_dist = max(center_r + center_c, 1.0)
-    prior = 1.0 - ((abs(cell[0] - center_r) + abs(cell[1] - center_c)) / max_dist)
-    return _clip(0.4 * directional + 0.4 * line + 0.2 * prior)
+    return _clip(0.5 * directional + 0.5 * line)
 
 
 def _cell_number_compatibility_cached(
@@ -670,11 +665,10 @@ class GlobalAssignmentPriorModule:
         anchor_details: Dict[Cell, Dict[str, float]] = {}
         directional_scores = DirectionalConsistencyModule().score(board, unopened_cells, target_number).scores
         line_scores = LineConsistencyModule().score(board, unopened_cells, target_number).scores
-        prior_scores = PriorModelModule().score(board, unopened_cells, target_number).scores
         pre_ranked = sorted(
             unopened_cells,
             key=lambda cell: (
-                directional_scores.get(cell, 0.5) + line_scores.get(cell, 0.5) + prior_scores.get(cell, 0.5)
+                directional_scores.get(cell, 0.5) + line_scores.get(cell, 0.5)
             ),
             reverse=True,
         )
@@ -763,6 +757,253 @@ class GlobalAssignmentPriorModule:
             scores,
             "global_assignment_prior: 固定 target 後估計剩餘數字全局唯一分配一致性",
             details=details,
+        )
+
+
+def _pairs(values: List[int]) -> List[Tuple[int, int]]:
+    out: List[Tuple[int, int]] = []
+    for i in range(len(values)):
+        for j in range(i + 1, len(values)):
+            out.append((values[i], values[j]))
+    return out
+
+
+def _same_decade_family(a: int, b: int) -> bool:
+    return (a - 1) // 10 == (b - 1) // 10
+
+
+def _same_tail_family(a: int, b: int) -> bool:
+    return a % 10 == b % 10
+
+
+def _arithmetic_support_counts(values: List[int], target_number: int) -> Tuple[int, int, int]:
+    pair_list = _pairs(values)
+    midpoint = 0
+    continuation = 0
+    unique_steps: set[int] = set()
+    for a, b in pair_list:
+        if (2 * target_number) == (a + b):
+            midpoint += 1
+            unique_steps.add(abs(b - a))
+        d = b - a
+        if target_number == b + d or target_number == a - d:
+            continuation += 1
+            unique_steps.add(abs(d))
+    return midpoint, continuation, len([d for d in unique_steps if d > 0])
+
+
+def _gap_regularity(values: List[int]) -> float:
+    if len(values) < 3:
+        return NEUTRAL_SCORE
+    ordered = sorted(values)
+    gaps = [ordered[i + 1] - ordered[i] for i in range(len(ordered) - 1)]
+    if not gaps:
+        return NEUTRAL_SCORE
+    mean_gap = sum(abs(g) for g in gaps) / len(gaps)
+    if mean_gap <= 1e-9:
+        return NEUTRAL_SCORE
+    variance = sum((abs(g) - mean_gap) ** 2 for g in gaps) / len(gaps)
+    return _clip(1.0 / (1.0 + math.sqrt(variance)))
+
+
+class LocalArithmeticRelationModule:
+    name = "local_arithmetic_relation"
+
+    def __init__(
+        self,
+        near_value_deltas: Optional[List[int]] = None,
+        exact_near_deltas: Optional[List[int]] = None,
+        medium_near_deltas: Optional[List[int]] = None,
+        weak_score_floor: float = 0.52,
+    ) -> None:
+        self.near_value_deltas = sorted({abs(int(x)) for x in (near_value_deltas or [1, 2, 3, 5, 8, 10, 20])})
+        self.exact_near_deltas = sorted({abs(int(x)) for x in (exact_near_deltas or [1, 2, 3])})
+        self.medium_near_deltas = sorted({abs(int(x)) for x in (medium_near_deltas or [5, 8, 10])})
+        self.weak_score_floor = float(weak_score_floor)
+
+    def _seed_strength(self, value: int, target_number: int) -> float:
+        diff = abs(value - target_number)
+        near_strength = 0.0
+        if diff in self.exact_near_deltas:
+            near_strength = 1.0
+        elif diff in self.medium_near_deltas:
+            near_strength = 0.6
+        elif diff in self.near_value_deltas:
+            near_strength = 0.35
+        same_decade_bonus = 0.1 if _same_decade_family(value, target_number) else 0.0
+        same_tail_bonus = 0.08 if _same_tail_family(value, target_number) else 0.0
+        return _clip(near_strength + same_decade_bonus + same_tail_bonus)
+
+    def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
+        rows, cols = len(board), len(board[0])
+        opened: List[Tuple[int, int, int]] = [
+            (r, c, board[r][c]) for r in range(rows) for c in range(cols) if board[r][c] != -1
+        ]
+        details: Dict[Cell, Dict[str, float]] = {}
+        scores: Dict[Cell, float] = {}
+        informative_cells: Dict[Cell, float] = {}
+        if len(opened) < 2:
+            for cell in unopened_cells:
+                scores[cell] = NEUTRAL_SCORE
+                details[cell] = {
+                    "seed_count_total": 0.0,
+                    "seed_count_near": 0.0,
+                    "seed_count_same_decade": 0.0,
+                    "seed_count_same_tail": 0.0,
+                    "local_row_midpoint_support_count": 0.0,
+                    "local_row_continuation_support_count": 0.0,
+                    "local_col_midpoint_support_count": 0.0,
+                    "local_col_continuation_support_count": 0.0,
+                    "local_window_midpoint_support_count": 0.0,
+                    "local_window_continuation_support_count": 0.0,
+                    "row_gap_improvement": 0.0,
+                    "col_gap_improvement": 0.0,
+                    "window_signal_density": 0.0,
+                    "nearest_seed_distance": -1.0,
+                    "target_near_seed_strength": 0.0,
+                    "arithmetic_abstain": 1.0,
+                    "opened_number_count": float(len(opened)),
+                    "effective_local_known_count": 0.0,
+                }
+                informative_cells[cell] = 0.0
+            return ModuleScoreResult(
+                scores=scores,
+                explanation="local_arithmetic_relation: opened numbers < 2, abstain with neutral score",
+                details=details,
+                informative_cells=informative_cells,
+            )
+
+        seeds = [(r, c, v, self._seed_strength(v, target_number)) for r, c, v in opened]
+        active_seeds = [(r, c, v, s) for r, c, v, s in seeds if s > 0.0]
+        seed_count_same_decade = sum(1 for _, _, v, _ in seeds if _same_decade_family(v, target_number))
+        seed_count_same_tail = sum(1 for _, _, v, _ in seeds if _same_tail_family(v, target_number))
+
+        for r, c in unopened_cells:
+            row_vals = [board[r][cc] for cc in range(cols) if board[r][cc] != -1]
+            col_vals = [board[rr][c] for rr in range(rows) if board[rr][c] != -1]
+            win_vals = [
+                board[rr][cc]
+                for rr in range(max(0, r - 1), min(rows, r + 2))
+                for cc in range(max(0, c - 1), min(cols, c + 2))
+                if (rr != r or cc != c) and board[rr][cc] != -1
+            ]
+            cross_vals = []
+            for rr in range(rows):
+                if rr != r and board[rr][c] != -1:
+                    cross_vals.append(board[rr][c])
+            for cc in range(cols):
+                if cc != c and board[r][cc] != -1:
+                    cross_vals.append(board[r][cc])
+            diag_vals = []
+            if rows == cols:
+                for i in range(rows):
+                    if i != r and i != c and board[i][i] != -1:
+                        diag_vals.append(board[i][i])
+                for i in range(rows):
+                    j = cols - 1 - i
+                    if (i != r or j != c) and board[i][j] != -1 and (i, j) not in {(r, c)}:
+                        diag_vals.append(board[i][j])
+            local_vals = row_vals + col_vals + win_vals + cross_vals + diag_vals
+            effective_local_known_count = float(len(local_vals))
+
+            row_mid, row_cont, _ = _arithmetic_support_counts(row_vals, target_number)
+            col_mid, col_cont, _ = _arithmetic_support_counts(col_vals, target_number)
+            win_mid, win_cont, win_steps = _arithmetic_support_counts(win_vals + cross_vals, target_number)
+            local_pairs = max(len(_pairs(win_vals + cross_vals)), 1)
+            local_midpoint_strength = _clip((row_mid + col_mid + win_mid) / max(local_pairs, 1))
+            local_continuation_strength = _clip((row_cont + col_cont + win_cont) / max(local_pairs, 1))
+
+            row_gap_before = _gap_regularity(row_vals)
+            row_gap_after = _gap_regularity(row_vals + [target_number])
+            col_gap_before = _gap_regularity(col_vals)
+            col_gap_after = _gap_regularity(col_vals + [target_number])
+            row_gap_improve = row_gap_after - row_gap_before
+            col_gap_improve = col_gap_after - col_gap_before
+            row_col_gap_improvement_strength = _clip(0.5 + 0.5 * (row_gap_improve + col_gap_improve))
+
+            density_pairs = max(len(win_vals + cross_vals), 1)
+            seed_related = 0
+            for v in win_vals + cross_vals:
+                if abs(v - target_number) in self.near_value_deltas or _same_decade_family(v, target_number):
+                    seed_related += 1
+            window_signal_density = _clip(seed_related / density_pairs)
+
+            if active_seeds:
+                distances = [abs(sr - r) + abs(sc - c) for sr, sc, _, _ in active_seeds]
+                nearest_seed_distance = float(min(distances))
+                weighted_seed = [
+                    s / (1.0 + abs(sr - r) + abs(sc - c))
+                    for sr, sc, _, s in active_seeds
+                ]
+                target_near_seed_strength = _clip(sum(weighted_seed) / max(len(weighted_seed), 1))
+            else:
+                nearest_seed_distance = -1.0
+                target_near_seed_strength = 0.0
+            seed_region_proximity_strength = (
+                0.0 if nearest_seed_distance < 0 else _clip(1.0 / (1.0 + nearest_seed_distance))
+            )
+
+            weak_closeness = 0.0
+            if local_vals:
+                weak_closeness = _clip(
+                    sum(1.0 / (1.0 + abs(v - target_number)) for v in local_vals) / len(local_vals)
+                )
+
+            base_score = _clip(
+                0.28 * target_near_seed_strength
+                + 0.22 * local_midpoint_strength
+                + 0.18 * local_continuation_strength
+                + 0.16 * row_col_gap_improvement_strength
+                + 0.10 * window_signal_density
+                + 0.06 * seed_region_proximity_strength
+            )
+            signal_mass = (
+                target_near_seed_strength
+                + local_midpoint_strength
+                + local_continuation_strength
+                + abs(row_gap_improve)
+                + abs(col_gap_improve)
+                + window_signal_density
+            )
+            if signal_mass <= 1e-9 and weak_closeness <= 1e-9:
+                score = NEUTRAL_SCORE
+                informative = 0.0
+                abstain = 1.0
+            else:
+                informative = 1.0
+                abstain = 0.0
+                if base_score <= NEUTRAL_SCORE:
+                    score = _clip(self.weak_score_floor + 0.08 * weak_closeness)
+                else:
+                    score = base_score
+            scores[(r, c)] = score
+            informative_cells[(r, c)] = informative
+            details[(r, c)] = {
+                "seed_count_total": float(len(seeds)),
+                "seed_count_near": float(len(active_seeds)),
+                "seed_count_same_decade": float(seed_count_same_decade),
+                "seed_count_same_tail": float(seed_count_same_tail),
+                "local_row_midpoint_support_count": float(row_mid),
+                "local_row_continuation_support_count": float(row_cont),
+                "local_col_midpoint_support_count": float(col_mid),
+                "local_col_continuation_support_count": float(col_cont),
+                "local_window_midpoint_support_count": float(win_mid),
+                "local_window_continuation_support_count": float(win_cont),
+                "row_gap_improvement": float(row_gap_improve),
+                "col_gap_improvement": float(col_gap_improve),
+                "window_signal_density": float(window_signal_density),
+                "nearest_seed_distance": float(nearest_seed_distance),
+                "target_near_seed_strength": float(target_near_seed_strength),
+                "arithmetic_abstain": float(abstain),
+                "opened_number_count": float(len(opened)),
+                "effective_local_known_count": float(effective_local_known_count),
+                "arithmetic_unique_step_count": float(win_steps),
+            }
+        return ModuleScoreResult(
+            scores=scores,
+            explanation="local_arithmetic_relation: target-near local arithmetic support over row/col/window context",
+            details=details,
+            informative_cells=informative_cells,
         )
 
 
@@ -985,6 +1226,12 @@ MODULE_FACTORIES = {
     "logic_rule": lambda cfg: LogicRuleModule(fast_enabled=bool(cfg.get("fast_enabled", True))),
     "pattern_model": lambda _cfg: PatternModelModule(),
     "prior_model": lambda cfg: PriorModelModule(fast_enabled=bool(cfg.get("fast_enabled", True))),
+    "local_arithmetic_relation": lambda cfg: LocalArithmeticRelationModule(
+        near_value_deltas=list(cfg.get("near_value_deltas", [1, 2, 3, 5, 8, 10, 20])),
+        exact_near_deltas=list(cfg.get("exact_near_deltas", [1, 2, 3])),
+        medium_near_deltas=list(cfg.get("medium_near_deltas", [5, 8, 10])),
+        weak_score_floor=float(cfg.get("weak_score_floor", 0.52)),
+    ),
     "structural_consistency": lambda cfg: StructuralConsistencyModule(
         fast_enabled=bool(cfg.get("fast_enabled", True))
     ),

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -23,6 +23,7 @@ from src.fast_scoring import (
 )
 from src.neighborhood_association import NeighborhoodAssociationModule
 from src.vector_modules import (
+    compute_local_tail_evidence,
     connectivity_heatmap_vectorized,
     difference_trend_vectorized,
     focus_score_vectorized,
@@ -116,27 +117,28 @@ class PatternModelModule:
     name = "pattern_model"
 
     def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
-        rows, cols = len(board), len(board[0])
         result: Dict[Cell, float] = {}
-        target_tail = target_number % 10
+        details: Dict[Cell, Dict[str, float]] = {}
+        informative_cells: Dict[Cell, float] = {}
         for r, c in unopened_cells:
-            known_neighbors = 0
-            tail_matches = 0
-            for rr in range(max(0, r - 1), min(rows, r + 2)):
-                for cc in range(max(0, c - 1), min(cols, c + 2)):
-                    if rr == r and cc == c:
-                        continue
-                    val = board[rr][cc]
-                    if val == -1:
-                        continue
-                    known_neighbors += 1
-                    if (val % 10) == target_tail:
-                        tail_matches += 1
-            if known_neighbors == 0:
-                result[(r, c)] = 0.3
+            evidence = compute_local_tail_evidence(board, (r, c), target_number, window_size=3)
+            known_neighbors = int(evidence["known_neighbors"])
+            same_tail_neighbors = int(evidence["same_tail_neighbors"])
+            strong_tail_signal = bool(evidence["strong_tail_signal"] > 0.0)
+            if known_neighbors < 3 or not strong_tail_signal:
+                result[(r, c)] = 0.5
+                informative_cells[(r, c)] = 0.0
             else:
-                result[(r, c)] = (tail_matches + 1) / (known_neighbors + 1)
-        return ModuleScoreResult(result, "pattern_model: 使用局部尾數分佈與已開密度作啟發式評分")
+                raw = (same_tail_neighbors + 1.0) / (known_neighbors + 1.0)
+                result[(r, c)] = _clip(0.52 + 0.20 * _clip(raw))
+                informative_cells[(r, c)] = 1.0
+            details[(r, c)] = dict(evidence)
+        return ModuleScoreResult(
+            result,
+            "pattern_model: 使用局部尾數分佈與尾數證據 gate 評分",
+            details=details,
+            informative_cells=informative_cells,
+        )
 
 
 class PriorModelModule:
@@ -227,7 +229,18 @@ class TailAnalyzerModule:
 
     def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
         scores = tail_analyzer_vectorized(board, unopened_cells, target_number, window_size=self.window_size)
-        return ModuleScoreResult(scores, "tail_analyzer: 尾數分布局部相容性")
+        informative_cells: Dict[Cell, float] = {}
+        details: Dict[Cell, Dict[str, float]] = {}
+        for cell in unopened_cells:
+            evidence = compute_local_tail_evidence(board, cell, target_number, window_size=self.window_size)
+            informative_cells[cell] = 1.0 if evidence["strong_tail_signal"] > 0.0 else 0.0
+            details[cell] = dict(evidence)
+        return ModuleScoreResult(
+            scores,
+            "tail_analyzer: 尾數分布局部相容性（含局部尾數證據 gate）",
+            details=details,
+            informative_cells=informative_cells,
+        )
 
 
 def _clip(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
@@ -831,8 +844,7 @@ class LocalArithmeticRelationModule:
         elif diff in self.near_value_deltas:
             near_strength = 0.35
         same_decade_bonus = 0.1 if _same_decade_family(value, target_number) else 0.0
-        same_tail_bonus = 0.08 if _same_tail_family(value, target_number) else 0.0
-        return _clip(near_strength + same_decade_bonus + same_tail_bonus)
+        return _clip(near_strength + same_decade_bonus)
 
     def score(self, board: Board, unopened_cells: List[Cell], target_number: int) -> ModuleScoreResult:
         rows, cols = len(board), len(board[0])
@@ -948,6 +960,14 @@ class LocalArithmeticRelationModule:
                 weak_closeness = _clip(
                     sum(1.0 / (1.0 + abs(v - target_number)) for v in local_vals) / len(local_vals)
                 )
+            tail_evidence = compute_local_tail_evidence(board, (r, c), target_number, window_size=3)
+            conditional_same_tail_bonus = 0.0
+            if (
+                tail_evidence["strong_tail_signal"] > 0.0
+                and target_near_seed_strength > 0.0
+                and effective_local_known_count >= 4
+            ):
+                conditional_same_tail_bonus = 0.04 * _clip(tail_evidence["local_tail_ratio"])
 
             base_score = _clip(
                 0.28 * target_near_seed_strength
@@ -956,6 +976,7 @@ class LocalArithmeticRelationModule:
                 + 0.16 * row_col_gap_improvement_strength
                 + 0.10 * window_signal_density
                 + 0.06 * seed_region_proximity_strength
+                + conditional_same_tail_bonus
             )
             signal_mass = (
                 target_near_seed_strength
@@ -998,6 +1019,7 @@ class LocalArithmeticRelationModule:
                 "opened_number_count": float(len(opened)),
                 "effective_local_known_count": float(effective_local_known_count),
                 "arithmetic_unique_step_count": float(win_steps),
+                "conditional_same_tail_bonus": float(conditional_same_tail_bonus),
             }
         return ModuleScoreResult(
             scores=scores,

--- a/src/scoring_modules.py
+++ b/src/scoring_modules.py
@@ -21,6 +21,7 @@ from src.fast_scoring import (
     prepare_fast_inputs,
     prior_model_fast,
 )
+from src.neighborhood_association import NeighborhoodAssociationModule
 from src.vector_modules import (
     connectivity_heatmap_vectorized,
     difference_trend_vectorized,
@@ -988,6 +989,26 @@ MODULE_FACTORIES = {
     "skip_patterns": lambda _cfg: SkipPatternsModule(),
     "mirror_sequences": lambda _cfg: MirrorSequencesModule(),
     "tail_analyzer": lambda cfg: TailAnalyzerModule(window_size=int(cfg.get("window_size", 3))),
+    "neighborhood_association": lambda cfg: NeighborhoodAssociationModule(
+        radius=int(cfg.get("radius", 1)),
+        use_diagonal=bool(cfg.get("use_diagonal", True)),
+        min_seed_count=int(cfg.get("min_seed_count", 1)),
+        decay_by_distance=bool(cfg.get("decay_by_distance", True)),
+        distance_decay_power=float(cfg.get("distance_decay_power", 1.0)),
+        enabled_seed_families=list(cfg.get("enabled_seed_families", ["same_decade", "same_tail", "near_value"])),
+        near_value_deltas=list(cfg.get("near_value_deltas", [1, 2, 10, 20])),
+        enabled_neighbor_families=list(
+            cfg.get("enabled_neighbor_families", ["same_decade", "same_tail", "near_value"])
+        ),
+        neighbor_value_deltas=list(cfg.get("neighbor_value_deltas", [1, 2, 10, 20])),
+        score_mode=str(cfg.get("score_mode", "weighted_pattern_overlap")),
+        seed_aggregation=str(cfg.get("seed_aggregation", "mean")),
+        candidate_aggregation=str(cfg.get("candidate_aggregation", "mean")),
+        neutral_score_when_no_seed=float(cfg.get("neutral_score_when_no_seed", 0.5)),
+        floor_score=float(cfg.get("floor_score", 0.0)),
+        ceil_score=float(cfg.get("ceil_score", 1.0)),
+        relation_source=str(cfg.get("relation_source", "heuristic_family_profile_v1")),
+    ),
 }
 
 

--- a/src/vector_modules.py
+++ b/src/vector_modules.py
@@ -18,6 +18,73 @@ def _unopened_indices(unopened_cells: List[Cell]) -> tuple[np.ndarray, np.ndarra
     return rows, cols
 
 
+def compute_local_tail_evidence(
+    board: Board,
+    candidate: Cell,
+    target_number: int,
+    window_size: int = 3,
+) -> Dict[str, float]:
+    board_arr = np.asarray(board, dtype=np.int32)
+    rows, cols = board_arr.shape
+    r, c = candidate
+    target_tail = int(target_number) % 10
+    k = max(1, int(window_size))
+    if k % 2 == 0:
+        k += 1
+    rad = k // 2
+
+    known_neighbors = 0
+    same_tail_neighbors = 0
+    near_value_neighbors = 0
+    same_decade_neighbors = 0
+    row_same_tail_count = 0
+    col_same_tail_count = 0
+    row_near_count = 0
+    col_near_count = 0
+
+    for rr in range(max(0, r - rad), min(rows, r + rad + 1)):
+        for cc in range(max(0, c - rad), min(cols, c + rad + 1)):
+            if rr == r and cc == c:
+                continue
+            v = int(board_arr[rr, cc])
+            if v == -1:
+                continue
+            known_neighbors += 1
+            same_tail = int(v % 10 == target_tail)
+            near = int(abs(v - int(target_number)) in (1, 2))
+            same_decade = int((v - 1) // 10 == (int(target_number) - 1) // 10)
+            same_tail_neighbors += same_tail
+            near_value_neighbors += near
+            same_decade_neighbors += same_decade
+            if rr == r:
+                row_same_tail_count += same_tail
+                row_near_count += near
+            if cc == c:
+                col_same_tail_count += same_tail
+                col_near_count += near
+
+    local_tail_ratio = float(same_tail_neighbors / max(known_neighbors, 1))
+    has_structural_anchor = float(
+        (row_same_tail_count + col_same_tail_count + row_near_count + col_near_count) > 0
+    )
+    strong_tail_signal = (
+        (same_tail_neighbors >= 2 and known_neighbors >= 4 and (row_same_tail_count >= 1 or col_same_tail_count >= 1))
+        or (near_value_neighbors >= 1 and same_tail_neighbors >= 1 and known_neighbors >= 3)
+        or (local_tail_ratio >= 0.40 and (row_same_tail_count + col_same_tail_count) >= 2)
+    )
+    return {
+        "known_neighbors": float(known_neighbors),
+        "same_tail_neighbors": float(same_tail_neighbors),
+        "row_same_tail_count": float(row_same_tail_count),
+        "col_same_tail_count": float(col_same_tail_count),
+        "near_value_neighbors": float(near_value_neighbors),
+        "same_decade_neighbors": float(same_decade_neighbors),
+        "local_tail_ratio": float(local_tail_ratio),
+        "has_structural_anchor": has_structural_anchor,
+        "strong_tail_signal": float(strong_tail_signal),
+    }
+
+
 def focus_score_vectorized(board: Board, unopened_cells: List[Cell], window_size: int = 3) -> Dict[Cell, float]:
     if not unopened_cells:
         return {}
@@ -229,7 +296,15 @@ def tail_analyzer_vectorized(
 
     known_cnt = _box_sum(padded_known)
     match_cnt = _box_sum(padded_match)
-    ratio = (match_cnt + 1.0) / (known_cnt + 2.0)
     rr, cc = _unopened_indices(unopened_cells)
-    vals = _clip01(ratio[rr, cc])
+    vals = np.full(rr.shape[0], 0.5, dtype=np.float64)
+    ratio = np.where(known_cnt > 0, match_cnt / np.maximum(known_cnt, 1.0), 0.0)
+    for i, cell in enumerate(unopened_cells):
+        evidence = compute_local_tail_evidence(board, cell, target_number, window_size=window_size)
+        strong = bool(evidence.get("strong_tail_signal", 0.0) > 0.0)
+        if not strong:
+            vals[i] = 0.5
+            continue
+        local_ratio = float(ratio[rr[i], cc[i]])
+        vals[i] = float(np.clip(0.50 + 0.22 * np.clip(local_ratio, 0.0, 1.0), 0.0, 1.0))
     return {cell: float(vals[i]) for i, cell in enumerate(unopened_cells)}

--- a/tests/test_committee_fusion.py
+++ b/tests/test_committee_fusion.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from src.inference_service import (
+    _run_inference_detailed,
+    aggregate_candidate_scores,
+    build_cell_candidates,
+    score_candidates,
+)
+
+
+def _committee_cfg(weighting_mode: str = "equal_informative") -> dict:
+    return {
+        "type": "committee_weighted_sum",
+        "weighting_mode": weighting_mode,
+        "allow_abstain": True,
+        "preserve_diagnostics": True,
+        "tie_break_order": ["target_sensitive_score", "support_score", "row_col_stable"],
+        "diagnostics": {
+            "include_vote_features": True,
+            "include_rank_features": True,
+            "include_score_features": True,
+        },
+        "judge": {
+            "enabled": True,
+            "use_for_primary_ranking": False,
+            "artifact_path": "artifacts/does_not_exist.json",
+        },
+    }
+
+
+def test_equal_informative_weighting_gives_equal_share() -> None:
+    candidates = [
+        {
+            "cell": (0, 0),
+            "module_scores": {"a": 0.2, "b": 0.6, "c": 0.9},
+            "module_details": {},
+            "module_informative": {"a": 1.0, "b": 1.0, "c": 1.0},
+        }
+    ]
+    diag = aggregate_candidate_scores(candidates, {"a": 0.9, "b": 0.09, "c": 0.01}, _committee_cfg())
+    eff = candidates[0]["module_effective_weights"]
+    assert eff == {"a": 1 / 3, "b": 1 / 3, "c": 1 / 3}
+    assert diag["committee_weighting_mode"] == "equal_informative"
+
+
+def test_yaml_normalized_weighting_uses_only_active_modules() -> None:
+    candidates = [
+        {
+            "cell": (0, 0),
+            "module_scores": {"a": 0.2, "b": 0.6, "c": 0.9},
+            "module_details": {},
+            "module_informative": {"a": 1.0, "b": 0.0, "c": 1.0},
+        }
+    ]
+    aggregate_candidate_scores(
+        candidates,
+        {"a": 0.2, "b": 0.7, "c": 0.1},
+        _committee_cfg(weighting_mode="yaml_normalized"),
+    )
+    eff = candidates[0]["module_effective_weights"]
+    assert set(eff.keys()) == {"a", "c"}
+    assert abs(eff["a"] - (0.2 / 0.3)) < 1e-9
+    assert abs(eff["c"] - (0.1 / 0.3)) < 1e-9
+
+
+def test_committee_mode_uses_only_module_sum_for_primary_top() -> None:
+    candidates = [
+        {
+            "cell": (0, 0),
+            "module_scores": {"m1": 0.9, "m2": 0.4},
+            "module_details": {},
+            "module_informative": {"m1": 1.0, "m2": 1.0},
+        },
+        {
+            "cell": (0, 1),
+            "module_scores": {"m1": 0.8, "m2": 0.8},
+            "module_details": {},
+            "module_informative": {"m1": 1.0, "m2": 1.0},
+        },
+    ]
+    aggregate_candidate_scores(candidates, {"m1": 0.5, "m2": 0.5}, _committee_cfg())
+    ranked = sorted(candidates, key=lambda c: c["final_rank_position"])
+    assert ranked[0]["cell"] == (0, 1)
+    assert ranked[0]["top_decision_source"] == "committee_weighted_sum"
+
+
+def test_meta_judge_cannot_override_committee_primary_score() -> None:
+    candidates = [
+        {
+            "cell": (0, 0),
+            "module_scores": {"m1": 0.7},
+            "module_details": {},
+            "module_informative": {"m1": 1.0},
+        },
+        {
+            "cell": (0, 1),
+            "module_scores": {"m1": 0.6},
+            "module_details": {},
+            "module_informative": {"m1": 1.0},
+        },
+    ]
+    aggregate_candidate_scores(candidates, {"m1": 1.0}, _committee_cfg())
+    ranked = sorted(candidates, key=lambda c: c["final_rank_position"])
+    assert ranked[0]["cell"] == (0, 0)
+    assert all(abs(c["score"] - c["committee_score"]) < 1e-9 for c in candidates)
+
+
+def test_primary_tie_break_is_stable_and_deterministic() -> None:
+    candidates = [
+        {
+            "cell": (0, 0),
+            "module_scores": {"m1": 0.5},
+            "module_details": {},
+            "module_informative": {"m1": 1.0},
+            "target_sensitive_score": 0.8,
+            "support_score": 0.8,
+        },
+        {
+            "cell": (0, 1),
+            "module_scores": {"m1": 0.5},
+            "module_details": {},
+            "module_informative": {"m1": 1.0},
+            "target_sensitive_score": 0.8,
+            "support_score": 0.8,
+        },
+    ]
+    aggregate_candidate_scores(candidates, {"m1": 1.0}, _committee_cfg())
+    ranked = sorted(candidates, key=lambda c: c["final_rank_position"])
+    assert ranked[0]["cell"] == (0, 0)
+
+
+def test_candidate_payload_contains_participation_fields() -> None:
+    out = _run_inference_detailed([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    cell = out["candidate_cells"][0]
+    assert "module_informative" in cell
+    assert "module_effective_weights" in cell
+    assert "active_module_count" in cell
+
+
+def test_neighborhood_association_abstains_when_no_seed() -> None:
+    out = _run_inference_detailed(
+        [[1, -1, 3], [-1, 5, -1]],
+        4,
+        source="t",
+        apply_reranker_stage=False,
+        module_weights={"logic_rule": 0.5, "neighborhood_association": 0.5},
+        module_settings={
+            "neighborhood_association": {
+                "enabled_seed_families": ["same_tail"],
+                "min_seed_count": 2,
+            }
+        },
+        aggregator_config=_committee_cfg(),
+    )
+    cand = out["candidate_cells"][0]
+    assert cand["module_informative"]["neighborhood_association"] == 0.0
+
+
+def test_neighborhood_association_affects_score_when_seed_exists() -> None:
+    board = [[19, -1, 29], [39, -1, 49]]
+    with_module, _, _ = score_candidates(
+        board,
+        build_cell_candidates([(0, 1), (1, 1)]),
+        target_number=59,
+        module_weights={"logic_rule": 0.5, "neighborhood_association": 0.5},
+    )
+    without_module, _, _ = score_candidates(
+        board,
+        build_cell_candidates([(0, 1), (1, 1)]),
+        target_number=59,
+        module_weights={"logic_rule": 1.0},
+    )
+    s1 = {c["cell"]: c["module_scores"]["neighborhood_association"] for c in with_module}
+    s2 = {c["cell"]: c["module_scores"].get("neighborhood_association", -1.0) for c in without_module}
+    assert s1 != s2

--- a/tests/test_committee_fusion.py
+++ b/tests/test_committee_fusion.py
@@ -81,7 +81,7 @@ def test_committee_mode_uses_only_module_sum_for_primary_top() -> None:
     aggregate_candidate_scores(candidates, {"m1": 0.5, "m2": 0.5}, _committee_cfg())
     ranked = sorted(candidates, key=lambda c: c["final_rank_position"])
     assert ranked[0]["cell"] == (0, 1)
-    assert ranked[0]["top_decision_source"] == "committee_weighted_sum"
+    assert ranked[0]["top_decision_source"] == "stage3_pairwise_adjusted_score"
 
 
 def test_meta_judge_cannot_override_committee_primary_score() -> None:
@@ -173,3 +173,77 @@ def test_neighborhood_association_affects_score_when_seed_exists() -> None:
     s1 = {c["cell"]: c["module_scores"]["neighborhood_association"] for c in with_module}
     s2 = {c["cell"]: c["module_scores"].get("neighborhood_association", -1.0) for c in without_module}
     assert s1 != s2
+
+
+def test_no_duplicate_scoring_family_in_committee() -> None:
+    try:
+        _run_inference_detailed(
+            [[1, -1, 3], [-1, 5, -1]],
+            4,
+            source="t",
+            apply_reranker_stage=False,
+            module_weights={"structural_consistency": 0.5, "directional_consistency": 0.5},
+            aggregator_config=_committee_cfg(),
+        )
+    except Exception as exc:
+        assert "structural_consistency" in str(exc)
+        return
+    raise AssertionError("Expected fail-fast for duplicated structural family in committee stage-1")
+
+
+def test_structural_consistency_replaces_directional_and_line() -> None:
+    scored, _, _ = score_candidates(
+        [[1, -1, 3], [-1, 5, -1]],
+        build_cell_candidates([(0, 1), (1, 0), (1, 2)]),
+        target_number=4,
+        module_weights={"structural_consistency": 1.0},
+    )
+    assert "structural_consistency" in scored[0]["module_scores"]
+    assert "directional_consistency" not in scored[0]["module_scores"]
+    assert "line_consistency" not in scored[0]["module_scores"]
+
+
+def test_global_assignment_is_stage2_only() -> None:
+    out = _run_inference_detailed([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    cell = out["candidate_cells"][0]
+    assert "global_assignment_prior" not in cell["module_scores"]
+    assert "assignment_delta" in cell and "assignment_penalty" in cell
+
+
+def test_pairwise_is_stage2_only() -> None:
+    out = _run_inference_detailed([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    cell = out["candidate_cells"][0]
+    assert "pairwise_conditional_consistency" not in cell["module_scores"]
+    assert "pairwise_delta" in cell and "pairwise_penalty" in cell
+
+
+def test_score_chain_contract() -> None:
+    out = _run_inference_detailed([[1, -1, 3], [-1, 5, -1]], 4, source="t", apply_reranker_stage=False)
+    cell = out["candidate_cells"][0]
+    assert "score_chain" in cell
+    chain = cell["score_chain"]
+    assert "stage1_base_score" in chain
+    assert "stage2_assignment_adjusted_score" in chain
+    assert "stage3_pairwise_adjusted_score" in chain
+    assert "final_score" in chain
+
+
+def test_final_score_depends_on_single_stage1_base_path() -> None:
+    board = [[1, -1, 3], [-1, 5, -1]]
+    out = _run_inference_detailed(
+        board,
+        4,
+        source="t",
+        apply_reranker_stage=False,
+        module_weights={"logic_rule": 0.5, "structural_consistency": 0.5},
+        aggregator_config=_committee_cfg(),
+    )
+    cell = out["candidate_cells"][0]
+    expected = (
+        float(cell["stage1_base_score"])
+        + float(cell["assignment_delta"])
+        - float(cell["assignment_penalty"])
+        + float(cell["pairwise_delta"])
+        - float(cell["pairwise_penalty"])
+    )
+    assert abs(float(cell["final_score"]) - expected) < 1e-6

--- a/tests/test_local_arithmetic_relation.py
+++ b/tests/test_local_arithmetic_relation.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import pytest
+
+from src.inference_service import InferenceError, _run_inference_detailed
+from src.scoring_modules import (
+    GlobalAssignmentPriorModule,
+    PriorModelModule,
+    _cell_number_compatibility,
+    _directional_components,
+    _line_components,
+    build_modules,
+)
+
+
+def _committee_cfg() -> dict:
+    return {
+        "type": "committee_weighted_sum",
+        "weighting_mode": "equal_informative",
+        "allow_abstain": True,
+        "preserve_diagnostics": True,
+        "judge": {"enabled": False, "use_for_primary_ranking": False},
+        "diagnostics": {
+            "include_vote_features": True,
+            "include_rank_features": True,
+            "include_score_features": True,
+        },
+    }
+
+
+def test_prior_model_disabled_in_committee() -> None:
+    with pytest.raises(InferenceError):
+        _run_inference_detailed(
+            [[1, -1, 3], [-1, 5, -1]],
+            4,
+            source="t",
+            apply_reranker_stage=False,
+            module_weights={"prior_model": 1.0},
+            aggregator_config=_committee_cfg(),
+        )
+
+
+def test_global_assignment_no_prior_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("prior model should not be used by global assignment")
+
+    monkeypatch.setattr(PriorModelModule, "score", _boom)
+    module = GlobalAssignmentPriorModule(assignment_mode="greedy", top_m_candidates=2)
+    res = module.score([[1, -1, 3], [-1, 5, -1]], [(0, 1), (1, 0), (1, 1)], 4)
+    assert len(res.scores) == 3
+
+
+def test_cell_number_compatibility_without_prior() -> None:
+    board = [[1, -1, 3], [-1, 5, -1], [7, -1, 9]]
+    cell = (1, 0)
+    number = 4
+    directional = _directional_components(board, cell, number)["directional_consistency"]
+    line = _line_components(board, cell, number)["line_consistency"]
+    compat = _cell_number_compatibility(board, cell, number)
+    assert abs(compat - (0.5 * directional + 0.5 * line)) < 1e-9
+
+
+def test_local_arithmetic_relation_uses_target_near_seeds() -> None:
+    module = build_modules({"local_arithmetic_relation": {}})["local_arithmetic_relation"]
+    board = [[89, -1, 91], [30, -1, 40], [70, -1, 110]]
+    cells = [(0, 1), (1, 1), (2, 1)]
+    res = module.score(board, cells, 90)
+    top = max(cells, key=lambda c: res.scores[c])
+    assert top == (0, 1)
+    assert res.details[(0, 1)]["target_near_seed_strength"] >= res.details[(2, 1)]["target_near_seed_strength"]
+
+
+def test_local_arithmetic_relation_is_candidate_sensitive() -> None:
+    module = build_modules({"local_arithmetic_relation": {}})["local_arithmetic_relation"]
+    board = [[10, -1, 20], [35, -1, 50], [70, -1, 90]]
+    cells = [(0, 1), (1, 1), (2, 1)]
+    res = module.score(board, cells, 30)
+    scores = {res.scores[c] for c in cells}
+    assert len(scores) > 1
+
+
+def test_local_arithmetic_relation_row_col_gap_improvement_changes_by_cell() -> None:
+    module = build_modules({"local_arithmetic_relation": {}})["local_arithmetic_relation"]
+    board = [[12, -1, 18], [30, -1, 60], [33, -1, 36]]
+    cells = [(0, 1), (1, 1), (2, 1)]
+    res = module.score(board, cells, 24)
+    row_improvements = {res.details[c]["row_gap_improvement"] for c in cells}
+    col_improvements = {res.details[c]["col_gap_improvement"] for c in cells}
+    assert len(row_improvements) > 1 or len(col_improvements) > 1
+
+
+def test_local_arithmetic_relation_abstains_when_no_local_signal() -> None:
+    module = build_modules({"local_arithmetic_relation": {}})["local_arithmetic_relation"]
+    board = [[1, -1], [-1, -1]]
+    cells = [(0, 1), (1, 0), (1, 1)]
+    res = module.score(board, cells, 4)
+    assert all(res.informative_cells[c] == 0.0 for c in cells)
+    assert all(res.scores[c] == 0.5 for c in cells)
+
+
+def test_sparse_mode_uses_only_informative_modules() -> None:
+    board = [[1, -1], [-1, -1]]
+    out = _run_inference_detailed(
+        board,
+        4,
+        source="t",
+        apply_reranker_stage=False,
+        module_weights={"logic_rule": 0.5, "local_arithmetic_relation": 0.5},
+        aggregator_config=_committee_cfg(),
+    )
+    cell = out["candidate_cells"][0]
+    assert cell["module_informative"]["local_arithmetic_relation"] == 0.0
+    assert "local_arithmetic_relation" not in cell["module_effective_weights"]
+
+
+def test_no_position_bias_when_all_modules_abstain() -> None:
+    out = _run_inference_detailed(
+        [[1, -1], [-1, -1]],
+        4,
+        source="t",
+        apply_reranker_stage=False,
+        module_weights={"local_arithmetic_relation": 1.0},
+        aggregator_config=_committee_cfg(),
+    )
+    scores = {c["score"] for c in out["candidate_cells"]}
+    assert scores == {0.5}
+    assert out["metadata"]["no_informative_modules"] is True

--- a/tests/test_local_arithmetic_relation.py
+++ b/tests/test_local_arithmetic_relation.py
@@ -5,7 +5,10 @@ import pytest
 from src.inference_service import InferenceError, _run_inference_detailed
 from src.scoring_modules import (
     GlobalAssignmentPriorModule,
+    LocalArithmeticRelationModule,
+    PatternModelModule,
     PriorModelModule,
+    TailAnalyzerModule,
     _cell_number_compatibility,
     _directional_components,
     _line_components,
@@ -125,3 +128,66 @@ def test_no_position_bias_when_all_modules_abstain() -> None:
     scores = {c["score"] for c in out["candidate_cells"]}
     assert scores == {0.5}
     assert out["metadata"]["no_informative_modules"] is True
+
+
+def test_weak_same_tail_scatter_should_abstain() -> None:
+    board = [
+        [11, -1, 23, -1],
+        [-1, 45, -1, 67],
+        [89, -1, 14, -1],
+        [-1, 38, -1, 52],
+    ]
+    cells = [(0, 1), (0, 3), (1, 0), (1, 2), (2, 1), (2, 3), (3, 0), (3, 2)]
+    target = 31
+    pattern = PatternModelModule().score(board, cells, target)
+    tail = TailAnalyzerModule(window_size=3).score(board, cells, target)
+    assert all(pattern.informative_cells[c] == 0.0 for c in cells)
+    assert all(tail.informative_cells[c] == 0.0 for c in cells)
+    assert all(abs(pattern.scores[c] - 0.5) < 1e-9 for c in cells)
+    assert all(abs(tail.scores[c] - 0.5) < 1e-9 for c in cells)
+
+
+def test_strong_local_tail_signal_should_still_help() -> None:
+    board = [
+        [21, 31, -1],
+        [2, -1, 41],
+        [-1, 11, -1],
+    ]
+    cells = [(0, 2), (1, 1), (2, 0), (2, 2)]
+    target = 1
+    pattern = PatternModelModule().score(board, cells, target)
+    tail = TailAnalyzerModule(window_size=3).score(board, cells, target)
+    assert pattern.informative_cells[(1, 1)] == 1.0
+    assert tail.informative_cells[(1, 1)] == 1.0
+    assert 0.52 <= pattern.scores[(1, 1)] <= 0.72
+    assert 0.50 <= tail.scores[(1, 1)] <= 0.72
+
+
+def test_local_arithmetic_prefers_near_value_structure_over_same_tail_only() -> None:
+    module = LocalArithmeticRelationModule()
+    board = [
+        [11, -1, 31],
+        [45, -1, 55],
+        [57, -1, 59],
+    ]
+    cells = [(0, 1), (1, 1), (2, 1)]
+    res = module.score(board, cells, target_number=58)
+    assert res.scores[(2, 1)] > res.scores[(0, 1)]
+
+
+def test_committee_weighting_reduces_tail_only_dominance() -> None:
+    out = _run_inference_detailed(
+        [[7, 8, -1], [2, -1, 9], [-1, 1, -1]],
+        3,
+        source="t",
+        apply_reranker_stage=False,
+        module_weights={"structural_consistency": 0.8, "tail_analyzer": 0.2},
+        aggregator_config={
+            **_committee_cfg(),
+            "weighting_mode": "yaml_normalized",
+        },
+    )
+    cell = out["candidate_cells"][0]
+    weights = cell["module_effective_weights"]
+    if "tail_analyzer" in weights and "structural_consistency" in weights:
+        assert weights["tail_analyzer"] < weights["structural_consistency"]

--- a/tests/test_neighborhood_association.py
+++ b/tests/test_neighborhood_association.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from src.inference_service import build_cell_candidates, score_candidates
+from src.neighborhood_association import NeighborhoodAssociationModule
+from src.scoring_modules import build_modules
+
+
+def test_no_seed_returns_neutral_scores() -> None:
+    board = [
+        [1, -1, 3],
+        [4, -1, 6],
+        [8, -1, 9],
+    ]
+    unopened = [(0, 1), (1, 1), (2, 1)]
+    module = NeighborhoodAssociationModule(
+        enabled_seed_families=["same_tail"],
+        near_value_deltas=[1],
+        neutral_score_when_no_seed=0.5,
+    )
+    out = module.score(board, unopened, target_number=27)
+    assert all(abs(out.scores[cell] - 0.5) < 1e-9 for cell in unopened)
+    assert all(out.details[cell]["no_seed_fallback_used"] == 1.0 for cell in unopened)
+
+
+def test_same_tail_seed_affects_scores() -> None:
+    board = [
+        [19, 39, -1],
+        [9, 29, -1],
+        [11, 22, 35],
+    ]
+    unopened = [(0, 2), (1, 2)]
+    with_tail = NeighborhoodAssociationModule(
+        enabled_seed_families=["same_tail"],
+        enabled_neighbor_families=["same_tail"],
+        near_value_deltas=[1, 2, 10, 20],
+        neighbor_value_deltas=[1, 2, 10, 20],
+        radius=1,
+        use_diagonal=True,
+    ).score(board, unopened, target_number=29)
+    without_tail = NeighborhoodAssociationModule(
+        enabled_seed_families=["same_decade"],
+        enabled_neighbor_families=["same_decade"],
+        radius=1,
+        use_diagonal=True,
+    ).score(board, unopened, target_number=29)
+    assert with_tail.scores != without_tail.scores
+
+
+def test_same_decade_seed_affects_scores() -> None:
+    board = [
+        [72, 75, -1],
+        [81, 78, -1],
+        [64, 33, 55],
+    ]
+    unopened = [(0, 2), (1, 2)]
+    with_decade = NeighborhoodAssociationModule(
+        enabled_seed_families=["same_decade"],
+        enabled_neighbor_families=["same_decade"],
+        near_value_deltas=[1, 2],
+        neighbor_value_deltas=[1, 2],
+        radius=1,
+        use_diagonal=True,
+    ).score(board, unopened, target_number=79)
+    without_decade = NeighborhoodAssociationModule(
+        enabled_seed_families=["same_tail"],
+        enabled_neighbor_families=["same_tail"],
+        near_value_deltas=[1, 2],
+        neighbor_value_deltas=[1, 2],
+        radius=1,
+        use_diagonal=True,
+    ).score(board, unopened, target_number=79)
+    assert with_decade.scores != without_decade.scores
+
+
+def test_near_value_relation_affects_scores() -> None:
+    board = [
+        [88, 97, -1],
+        [78, 65, -1],
+        [12, 34, 56],
+    ]
+    unopened = [(0, 2), (1, 2)]
+    with_near = NeighborhoodAssociationModule(
+        enabled_seed_families=["near_value"],
+        enabled_neighbor_families=["near_value"],
+        near_value_deltas=[1, 2, 10, 20],
+        neighbor_value_deltas=[1, 2, 10, 20],
+        radius=1,
+        use_diagonal=True,
+    ).score(board, unopened, target_number=98)
+    without_near = NeighborhoodAssociationModule(
+        enabled_seed_families=["same_tail"],
+        enabled_neighbor_families=["same_tail"],
+        near_value_deltas=[1, 2, 10, 20],
+        neighbor_value_deltas=[1, 2, 10, 20],
+        radius=1,
+        use_diagonal=True,
+    ).score(board, unopened, target_number=98)
+    assert with_near.scores != without_near.scores
+
+
+def test_details_fields_present() -> None:
+    board = [
+        [19, 29, -1],
+        [39, 49, -1],
+        [12, 14, 16],
+    ]
+    unopened = [(0, 2), (1, 2)]
+    out = NeighborhoodAssociationModule().score(board, unopened, target_number=29)
+    required = {
+        "seed_count",
+        "effective_seed_count",
+        "candidate_neighbor_count",
+        "matched_seed_similarity_mean",
+        "matched_seed_similarity_max",
+        "same_decade_support",
+        "same_tail_support",
+        "near_value_support",
+        "used_radius",
+        "used_diagonal",
+        "no_seed_fallback_used",
+    }
+    assert required.issubset(out.details[(0, 2)].keys())
+
+
+def test_module_registered_in_factory() -> None:
+    modules = build_modules({"neighborhood_association": {"radius": 2}})
+    assert "neighborhood_association" in modules
+
+
+def test_yaml_settings_are_respected() -> None:
+    board = [
+        [19, 29, 39, -1],
+        [8, 18, 28, -1],
+        [7, 17, 27, 37],
+    ]
+    unopened = [(0, 3), (1, 3)]
+    module_r1 = NeighborhoodAssociationModule(radius=1, use_diagonal=False, neighbor_value_deltas=[1])
+    module_r2 = NeighborhoodAssociationModule(radius=2, use_diagonal=True, neighbor_value_deltas=[1, 10, 20])
+    out1 = module_r1.score(board, unopened, target_number=29)
+    out2 = module_r2.score(board, unopened, target_number=29)
+    assert out1.scores[(0, 3)] != out2.scores[(0, 3)]
+
+
+def test_module_works_through_mainline_score_candidates() -> None:
+    board = [
+        [19, 29, -1],
+        [9, 39, -1],
+    ]
+    candidates = build_cell_candidates([(0, 2), (1, 2)])
+    scored, _, _ = score_candidates(
+        board,
+        candidates,
+        target_number=29,
+        module_weights={"neighborhood_association": 1.0},
+        module_settings={
+            "neighborhood_association": {
+                "enabled_seed_families": ["same_tail", "same_decade", "near_value"],
+                "enabled_neighbor_families": ["same_tail", "same_decade", "near_value"],
+            }
+        },
+    )
+    assert "neighborhood_association" in scored[0]["module_scores"]

--- a/tests/test_neighborhood_association.py
+++ b/tests/test_neighborhood_association.py
@@ -20,6 +20,8 @@ def test_no_seed_returns_neutral_scores() -> None:
     out = module.score(board, unopened, target_number=27)
     assert all(abs(out.scores[cell] - 0.5) < 1e-9 for cell in unopened)
     assert all(out.details[cell]["no_seed_fallback_used"] == 1.0 for cell in unopened)
+    assert all(out.informative_cells[cell] == 0.0 for cell in unopened)
+    assert all(out.details[cell]["abstain_flag"] == 1.0 for cell in unopened)
 
 
 def test_same_tail_seed_affects_scores() -> None:
@@ -118,6 +120,10 @@ def test_details_fields_present() -> None:
         "used_radius",
         "used_diagonal",
         "no_seed_fallback_used",
+        "abstain_flag",
+        "top_seed_row",
+        "top_seed_col",
+        "top_seed_value",
     }
     assert required.issubset(out.details[(0, 2)].keys())
 

--- a/tests/test_vector_modules.py
+++ b/tests/test_vector_modules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from src.vector_modules import (
+    compute_local_tail_evidence,
     connectivity_heatmap_vectorized,
     difference_trend_vectorized,
     focus_score_vectorized,
@@ -30,3 +31,13 @@ def test_vector_modules_score_range_and_coverage() -> None:
     _assert_scores(skip_patterns_vectorized(board, unopened, target), unopened)
     _assert_scores(mirror_sequences_vectorized(board, unopened, target), unopened)
     _assert_scores(tail_analyzer_vectorized(board, unopened, target, window_size=3), unopened)
+
+
+def test_tail_evidence_gate_and_tail_analyzer_cap() -> None:
+    board = [[21, 31, -1], [2, -1, 41], [-1, 11, -1]]
+    unopened = [(0, 2), (1, 1), (2, 0), (2, 2)]
+    target = 1
+    scores = tail_analyzer_vectorized(board, unopened, target, window_size=3)
+    evidence_center = compute_local_tail_evidence(board, (1, 1), target, window_size=3)
+    assert evidence_center["strong_tail_signal"] == 1.0
+    assert 0.5 <= scores[(1, 1)] <= 0.72


### PR DESCRIPTION
### Motivation
- 引入一個可配置的局部鄰域共現（neighborhood association）啟發式模組，捕捉 target 與盤面已開數字之 family 關係並將局部 pattern 反投影到候選格打分。 
- 支援多種 family（`same_decade`、`same_tail`、`near_value`、`exact_value`）以及距離衰減、半徑、對角選項與聚合策略，避免寫死特定數字或只能做十位數版本。 
- 保持 deterministic heuristic（無訓練）、fail-fast 與主線相容，不改變 API contract，透過現有的 `score_candidates` 自動被呼叫。 

### Description
- 新增模組實作 `src/neighborhood_association.py`：包含 family 判定 helpers（`same_decade_family`、`same_tail_family`、`near_value_family`）、鄰域 feature 抽取、距離衰減、seed/profile 建構、相似度計算與候選聚合，並回傳豐富 diagnostics。 
- 在 `src/scoring_modules.py` 註冊 `neighborhood_association` 到 `MODULE_FACTORIES`，以支援由 `build_modules()` 建構與主線載入。 
- 在 `configs/inference.yaml` 啟用並加入預設權重與 settings（`radius`、`use_diagonal`、`enabled_seed_families`、`near_value_deltas`、aggregation 與 fallback/clipping 等）。 
- 新增測試 `tests/test_neighborhood_association.py`，覆蓋 neutral fallback、family 敏感性、設定影響、module factory 註冊與 mainline integration，以及 details 欄位檢查。 

### Testing
- 以專案驗證流程執行靜態與單元測試：`.venv/bin/flake8 src tests`（無 error）、`python -m py_compile $(git ls-files '*.py')`（語法檢查通過）。 
- 安裝必要環境套件以讓測試收集成功（`opencv-python-headless`, `pyyaml`），並執行單元測試：`.venv/bin/pytest -q`，結果為 `115 passed`，包含新增的 `tests/test_neighborhood_association.py`。
- 測試包含：`test_no_seed_returns_neutral_scores`, `test_same_tail_seed_affects_scores`, `test_same_decade_seed_affects_scores`, `test_near_value_relation_affects_scores`, `test_details_fields_present`, `test_module_registered_in_factory`, `test_yaml_settings_are_respected`, 以及 mainline `score_candidates` 整合測試，皆在本環境通過。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae7ae2458832488b012f2b96d78b8)