### PR TITLE
Add spatial cluster postprocess to aggregator with diagnostics and tests

### DIFF
--- a/configs/inference.yaml
+++ b/configs/inference.yaml
@@ -104,6 +104,18 @@ modules:
     weighting_mode: yaml_normalized
     allow_abstain: true
     preserve_diagnostics: true
+    spatial_postprocess:
+      enabled: false
+      distance_metric: hybrid
+      top_m: 5
+      penalty_d1: 0.10
+      penalty_d2: 0.04
+      score_gap_gate: 0.06
+      protect_target_sensitive_threshold: 0.65
+      protect_structure_threshold: 0.62
+      protect_adjustment_threshold: 0.03
+      protect_multiplier: 0.5
+      max_penalty_per_candidate: 0.08
     tie_break_order:
       - target_sensitive_score
       - support_score

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -444,6 +444,195 @@ def rank_candidates(candidates: List[Dict[str, object]]) -> List[Dict[str, objec
     return sorted(candidates, key=lambda item: item["score"], reverse=True)
 
 
+def _score_sorted(candidates: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    return sorted(candidates, key=lambda item: float(item.get("score", 0.0)), reverse=True)
+
+
+def _safe_top_m(value: object, default: int = 5) -> int:
+    try:
+        top_m = int(value)
+    except (TypeError, ValueError):
+        top_m = default
+    return max(3, min(10, top_m))
+
+
+def _distance_penalty_weight(anchor: Cell, candidate: Cell, metric: str, d1: float, d2: float) -> float:
+    manhattan = abs(anchor[0] - candidate[0]) + abs(anchor[1] - candidate[1])
+    chebyshev = max(abs(anchor[0] - candidate[0]), abs(anchor[1] - candidate[1]))
+    if metric == "manhattan":
+        if manhattan == 1:
+            return d1
+        if manhattan == 2:
+            return d2
+        return 0.0
+    if metric == "chebyshev":
+        if chebyshev == 1:
+            return d1
+        if chebyshev == 2:
+            return d2
+        return 0.0
+    # hybrid: use chebyshev for immediate neighborhood, then manhattan for distance-2 ring.
+    if chebyshev == 1:
+        return d1
+    if manhattan == 2:
+        return d2
+    return 0.0
+
+
+def _apply_spatial_cluster_penalty(
+    ranked: List[Dict[str, object]],
+    spatial_cfg: Dict[str, object],
+) -> Tuple[List[Dict[str, object]], Dict[str, object]]:
+    enabled = bool(spatial_cfg.get("enabled", False))
+    metric = str(spatial_cfg.get("distance_metric", "hybrid")).lower()
+    if metric not in {"manhattan", "chebyshev", "hybrid"}:
+        metric = "hybrid"
+    top_m = _safe_top_m(spatial_cfg.get("top_m", 5), default=5)
+    if not enabled or not ranked:
+        return ranked, {
+            "enabled": enabled,
+            "applied": False,
+            "distance_metric": metric,
+            "top_m": top_m,
+            "affected_count": 0,
+            "total_penalty": 0.0,
+        }
+
+    d1 = max(0.0, float(spatial_cfg.get("penalty_d1", 0.10)))
+    d2 = max(0.0, float(spatial_cfg.get("penalty_d2", 0.04)))
+    score_gap_gate = max(0.0, float(spatial_cfg.get("score_gap_gate", 0.06)))
+    protect_sensitive_threshold = float(spatial_cfg.get("protect_target_sensitive_threshold", 0.65))
+    protect_structure_threshold = float(spatial_cfg.get("protect_structure_threshold", 0.62))
+    protect_adjustment_threshold = float(spatial_cfg.get("protect_adjustment_threshold", 0.03))
+    protect_multiplier = _clip(float(spatial_cfg.get("protect_multiplier", 0.5)), lo=0.1, hi=1.0)
+    max_penalty_per_candidate = _clip(float(spatial_cfg.get("max_penalty_per_candidate", 0.08)), lo=0.0, hi=0.2)
+
+    top_limit = min(top_m, len(ranked))
+    updated = list(ranked)
+    affected = 0
+    total_penalty = 0.0
+    for idx in range(top_limit):
+        cand = updated[idx]
+        cand["spatial_cluster_penalty"] = 0.0
+        cand["spatial_cluster_penalty_sources"] = []
+
+    for idx in range(1, top_limit):
+        cand = updated[idx]
+        cand_score = float(cand.get("score", 0.0))
+        per_candidate_penalty = 0.0
+        sources: List[Dict[str, object]] = []
+        for aid in range(idx):
+            anchor = updated[aid]
+            anchor_score = float(anchor.get("score", 0.0))
+            score_gap = anchor_score - cand_score
+            if score_gap < 0.0 or score_gap > score_gap_gate:
+                continue
+            weight = _distance_penalty_weight(
+                anchor=anchor["cell"],
+                candidate=cand["cell"],
+                metric=metric,
+                d1=d1,
+                d2=d2,
+            )
+            if weight <= 0.0:
+                continue
+            near_gap_boost = 1.0 - _clip(score_gap / max(score_gap_gate, 1e-9))
+            penalty = weight * near_gap_boost
+            target_sensitive_score = float(cand.get("target_sensitive_score", cand_score))
+            module_scores = cand.get("module_scores", {}) if isinstance(cand.get("module_scores", {}), dict) else {}
+            structural_score = max(
+                float(module_scores.get("structural_consistency", 0.0)),
+                float(module_scores.get("directional_consistency", 0.0)),
+                float(module_scores.get("line_consistency", 0.0)),
+            )
+            positive_adjustment = max(0.0, float(cand.get("assignment_delta", 0.0))) + max(
+                0.0, float(cand.get("pairwise_delta", 0.0))
+            )
+            if (
+                target_sensitive_score >= protect_sensitive_threshold
+                or structural_score >= protect_structure_threshold
+                or positive_adjustment >= protect_adjustment_threshold
+            ):
+                penalty *= protect_multiplier
+            penalty = min(penalty, max_penalty_per_candidate - per_candidate_penalty)
+            if penalty <= 0.0:
+                continue
+            per_candidate_penalty += penalty
+            sources.append(
+                {
+                    "anchor_cell": anchor["cell"],
+                    "score_gap": round(score_gap, 6),
+                    "penalty": round(penalty, 6),
+                }
+            )
+            if per_candidate_penalty >= max_penalty_per_candidate:
+                break
+        if per_candidate_penalty <= 0.0:
+            continue
+        affected += 1
+        total_penalty += per_candidate_penalty
+        cand["spatial_cluster_penalty"] = round(per_candidate_penalty, 6)
+        cand["spatial_cluster_penalty_sources"] = sources
+        new_score = cand_score - per_candidate_penalty
+        cand["score"] = new_score
+        cand["final_score"] = new_score
+        cand["ranking_score"] = new_score
+
+    resorted = _score_sorted(updated)
+    for pos, cand in enumerate(resorted, start=1):
+        cand["final_rank_position"] = pos
+    return resorted, {
+        "enabled": True,
+        "applied": bool(affected > 0),
+        "distance_metric": metric,
+        "top_m": top_m,
+        "affected_count": affected,
+        "total_penalty": round(total_penalty, 6),
+    }
+
+
+def _refresh_distribution_diagnostics(
+    diagnostics: Dict[str, Any],
+    ranked: List[Dict[str, object]],
+) -> Dict[str, Any]:
+    if not ranked:
+        return diagnostics
+    final_scores = [float(c.get("score", 0.0)) for c in ranked]
+    raw_mean = sum(final_scores) / len(final_scores)
+    raw_var = sum((s - raw_mean) ** 2 for s in final_scores) / len(final_scores)
+    final_std = math.sqrt(raw_var)
+    top_sorted = sorted(final_scores, reverse=True)
+    top1_top2_margin = 0.0 if len(top_sorted) < 2 else top_sorted[0] - top_sorted[1]
+    topk = top_sorted[: min(5, len(top_sorted))]
+    top1_top5_mean_gap = 0.0 if not topk else top_sorted[0] - (sum(topk) / len(topk))
+    tau = max(0.05, final_std)
+    exp_values = [math.exp((s - top_sorted[0]) / tau) for s in top_sorted]
+    z = sum(exp_values) or 1.0
+    probs = [x / z for x in exp_values]
+    entropy = -sum(p * math.log(max(p, 1e-12)) for p in probs)
+    max_entropy = math.log(max(len(probs), 1))
+    diagnostics.update(
+        {
+            "raw_score_min": min(final_scores),
+            "raw_score_max": max(final_scores),
+            "raw_score_std": final_std,
+            "final_score_min": min(final_scores),
+            "final_score_max": max(final_scores),
+            "final_score_std": final_std,
+            "top1_top2_margin": top1_top2_margin,
+            "top1_top5_mean_gap": top1_top5_mean_gap,
+            "score_entropy_like": entropy / max(max_entropy, 1e-12),
+            "collapsed_score_flag": final_std < 0.02 or top1_top2_margin < 0.01,
+            "final_top1_cell": ranked[0]["cell"],
+            "top1_changed_by_tiebreak": bool(
+                diagnostics.get("stage_a_top1_cell") is not None
+                and diagnostics.get("stage_a_top1_cell") != ranked[0]["cell"]
+            ),
+        }
+    )
+    return diagnostics
+
+
 def map_score_to_confidence_1_100(
     margin_to_top2: float,
     effective_candidate_count: int,
@@ -1208,6 +1397,10 @@ def _run_inference_detailed(
     )
     diagnostics = aggregate_candidate_scores(scored, weights, aggregator_cfg)
     ranked = rank_candidates(scored)
+    spatial_cfg = dict(aggregator_cfg.get("spatial_postprocess", {}))
+    ranked, spatial_diag = _apply_spatial_cluster_penalty(ranked, spatial_cfg)
+    diagnostics = _refresh_distribution_diagnostics(diagnostics, ranked)
+    diagnostics["spatial_postprocess"] = dict(spatial_diag)
     best = ranked[0]
 
     margin_to_top2 = 0.0 if len(ranked) <= 1 else max(
@@ -1325,6 +1518,8 @@ def _run_inference_detailed(
                 "zone_type": cell_profile["zone_type"],
                 "edge_bias_adjustment": edge_bias_adjustment,
                 "board_coverage_adjustment": board_coverage_adjustment,
+                "spatial_cluster_penalty": round(float(cell.get("spatial_cluster_penalty", 0.0)), 6),
+                "spatial_cluster_penalty_sources": cell.get("spatial_cluster_penalty_sources", []),
         }
         if preserve_diagnostics:
             for key in (
@@ -1452,6 +1647,12 @@ def _run_inference_detailed(
             "runtime_mode": runtime_mode,
             "fallback_reason": diagnostics.get("fallback_reason"),
             "elimination_version": str(aggregator_cfg.get("elimination_version", "v1")),
+            "spatial_postprocess_enabled": bool(spatial_diag.get("enabled", False)),
+            "spatial_postprocess_applied": bool(spatial_diag.get("applied", False)),
+            "spatial_postprocess_top_m": int(spatial_diag.get("top_m", 5)),
+            "spatial_postprocess_distance_metric": str(spatial_diag.get("distance_metric", "hybrid")),
+            "spatial_postprocess_affected_count": int(spatial_diag.get("affected_count", 0)),
+            "spatial_postprocess_total_penalty": round(float(spatial_diag.get("total_penalty", 0.0)), 6),
             "ranking_stage": rerank_meta["ranking_stage"],
             "reranker_version": rerank_meta["reranker_version"],
             "reranker_feature_schema_version": rerank_meta["reranker_feature_schema_version"],

--- a/tests/test_spatial_postprocess.py
+++ b/tests/test_spatial_postprocess.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from src.inference_service import _apply_spatial_cluster_penalty, _run_inference_detailed
+
+
+def _board() -> list[list[int]]:
+    return [
+        [1, -1, -1, -1],
+        [-1, 6, -1, -1],
+        [-1, -1, 11, -1],
+        [-1, -1, -1, 16],
+    ]
+
+
+def _agg_cfg(top_m: int, enabled: bool = True) -> dict:
+    return {
+        "type": "committee_weighted_sum",
+        "weighting_mode": "yaml_normalized",
+        "preserve_diagnostics": True,
+        "spatial_postprocess": {
+            "enabled": enabled,
+            "distance_metric": "hybrid",
+            "top_m": top_m,
+            "penalty_d1": 0.10,
+            "penalty_d2": 0.04,
+            "score_gap_gate": 0.2,
+            "protect_target_sensitive_threshold": 0.95,
+            "protect_structure_threshold": 0.95,
+            "protect_adjustment_threshold": 0.2,
+            "protect_multiplier": 0.5,
+            "max_penalty_per_candidate": 0.08,
+        },
+    }
+
+
+def test_spatial_disabled_keeps_existing_result() -> None:
+    board = _board()
+    off = _run_inference_detailed(
+        board,
+        7,
+        source="spatial_off",
+        apply_reranker_stage=False,
+        aggregator_config=_agg_cfg(5, False),
+    )
+    base = _run_inference_detailed(board, 7, source="spatial_base", apply_reranker_stage=False)
+    assert [(c["row"], c["col"]) for c in off["candidate_cells"]] == [
+        (c["row"], c["col"]) for c in base["candidate_cells"]
+    ]
+    assert [c["score"] for c in off["candidate_cells"]] == [c["score"] for c in base["candidate_cells"]]
+    assert off["metadata"]["spatial_postprocess_enabled"] is False
+    assert off["metadata"]["spatial_postprocess_applied"] is False
+
+
+def test_spatial_top_m_accepts_3_5_8_10() -> None:
+    board = _board()
+    for top_m in (3, 5, 8, 10):
+        out = _run_inference_detailed(
+            board,
+            7,
+            source=f"spatial_top_m_{top_m}",
+            apply_reranker_stage=False,
+            aggregator_config=_agg_cfg(top_m, True),
+        )
+        assert out["metadata"]["spatial_postprocess_top_m"] == top_m
+
+
+def test_spatial_postprocess_keeps_output_contract_consistent() -> None:
+    out = _run_inference_detailed(
+        _board(),
+        7,
+        source="spatial_contract",
+        apply_reranker_stage=False,
+        aggregator_config=_agg_cfg(5, True),
+    )
+    first = out["candidate_cells"][0]
+    assert out["best_cell"]["row"] == first["row"]
+    assert out["best_cell"]["col"] == first["col"]
+    assert abs(out["best_ranking_score"] - float(first["score"])) < 1e-6
+    assert out["metadata"]["final_top1_cell"] == (first["row"] - 1, first["col"] - 1)
+
+
+def test_spatial_penalty_spreads_clustered_high_scores() -> None:
+    ranked = [
+        {
+            "cell": (0, 0),
+            "score": 0.90,
+            "target_sensitive_score": 0.55,
+            "module_scores": {},
+            "assignment_delta": 0.0,
+            "pairwise_delta": 0.0,
+        },
+        {
+            "cell": (0, 1),
+            "score": 0.89,
+            "target_sensitive_score": 0.55,
+            "module_scores": {},
+            "assignment_delta": 0.0,
+            "pairwise_delta": 0.0,
+        },
+        {
+            "cell": (1, 1),
+            "score": 0.88,
+            "target_sensitive_score": 0.55,
+            "module_scores": {},
+            "assignment_delta": 0.0,
+            "pairwise_delta": 0.0,
+        },
+        {
+            "cell": (3, 3),
+            "score": 0.87,
+            "target_sensitive_score": 0.55,
+            "module_scores": {},
+            "assignment_delta": 0.0,
+            "pairwise_delta": 0.0,
+        },
+    ]
+    cfg = deepcopy(_agg_cfg(4, True))["spatial_postprocess"]
+    cfg["score_gap_gate"] = 0.1
+    out, diag = _apply_spatial_cluster_penalty(deepcopy(ranked), cfg)
+    by_cell = {c["cell"]: c for c in out}
+    assert diag["applied"] is True
+    assert by_cell[(0, 1)]["spatial_cluster_penalty"] > 0.0
+    assert by_cell[(1, 1)]["spatial_cluster_penalty"] > 0.0
+    assert by_cell[(3, 3)].get("spatial_cluster_penalty", 0.0) == 0.0
+    assert by_cell[(0, 1)]["score"] < 0.89


### PR DESCRIPTION
### Motivation
- Reduce undesirable clustering of high-scoring candidate cells by applying a spatial penalty across the top-N candidates and surface diagnostics and metadata about the operation.
- Make the behavior configurable from `configs/inference.yaml` so different distance metrics, thresholds and caps can be tuned per deployment.

### Description
- Added a new `spatial_postprocess` section to `configs/inference.yaml` under `aggregator` to configure the postprocess behavior and parameters such as `distance_metric`, `top_m`, `penalty_d1`, `penalty_d2`, `score_gap_gate`, protection thresholds, and caps.
- Implemented spatial postprocessing in `src/inference_service.py` including helper functions `_score_sorted`, `_safe_top_m`, `_distance_penalty_weight`, `_apply_spatial_cluster_penalty`, and `_refresh_distribution_diagnostics` and integrated the postprocess into `_run_inference_detailed` to adjust candidate `score`/rank and diagnostics.
- Preserved diagnostics and added candidate-level fields `spatial_cluster_penalty` and `spatial_cluster_penalty_sources`, and run-level metadata fields `spatial_postprocess_*` (enabled/applied/top_m/distance_metric/affected_count/total_penalty).
- Ensured parameter safety/limits (clipping, fallbacks) and kept final ranking consistent by resorting and assigning `final_rank_position` after penalties.

### Testing
- Added `tests/test_spatial_postprocess.py` with tests: `test_spatial_disabled_keeps_existing_result`, `test_spatial_top_m_accepts_3_5_8_10`, `test_spatial_postprocess_keeps_output_contract_consistent`, and `test_spatial_penalty_spreads_clustered_high_scores`.
- Ran the new unit tests against the modified code and all new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb1ccc82883248ac7e96cc7c693b9)