### PR TITLE
Multi-size training pipeline, streaming masked dataset, and robustness/IO improvements

### DIFF
--- a/README_local_training.md
+++ b/README_local_training.md
@@ -1,69 +1,57 @@
-# Local Training Pipeline (Real-First + Synthetic + Holdout)
+# Local Multi-Size Training Pipeline（一條指令重訓）
 
-## 1) 從真盤建庫
+## Python 版本建議
+- 建議使用 **Python 3.11**（主線已驗證）。
+- `scripts/run_training_pipeline.py` 對 Python 3.14+ 預設會 fail-fast。
+- 若你要強制嘗試未驗證版本，可加：`--allow-unsupported-python`。
+
+## 一條指令
 ```bash
-python scripts/build_real_board_corpus.py \
-  --output data/full_boards/full_board_corpus.jsonl \
-  --audit reports/full_board_corpus_audit.json
+python scripts/run_training_pipeline.py \
+  --input-dir . \
+  --generate-synthetic \
+  --enable-inference
 ```
 
-## 2) 生成 synthetic profile + boards
+單尺寸訓練範例：
 ```bash
-python scripts/fit_real_board_generator.py \
-  --real-corpus data/full_boards/full_board_corpus.jsonl \
-  --output artifacts/synthetic_generator_profile.json
-
-python scripts/generate_synthetic_boards.py \
-  --real-corpus data/full_boards/full_board_corpus.jsonl \
-  --profile artifacts/synthetic_generator_profile.json \
-  --output data/full_boards/synthetic_board_corpus.jsonl \
-  --per-real 12
+python scripts/run_training_pipeline.py --input-dir . --size-class 10x10 --max-workers 6 --model-strategy global_only
 ```
 
-## 3) build masking ranking dataset
-```bash
-python scripts/build_masked_ranking_dataset.py \
-  --real-corpus data/full_boards/full_board_corpus.jsonl \
-  --synthetic-corpus data/full_boards/synthetic_board_corpus.jsonl \
-  --mask-ratios 0.1,0.2,0.3,0.5 \
-  --masks-per-ratio 2 \
-  --output data/ranking/ranking_dataset.parquet \
-  --feature-schema artifacts/feature_schema.json
-```
+此命令會依序完成：
+1. 掃描 `--input-dir` 下所有 `.xlsx`（支援多尺寸，優先從檔名抓 `10x12` 這類 hint，否則回退內容推斷）。
+2. 驗證每個候選子矩陣是否為 `1..N` 的完整 permutation（缺值/重複/越界會 rejected 並寫進 audit）。
+3. 產出多尺寸 corpus（每筆含 `rows/cols/size_class/board_size/source_file/sheet_name/board_id`）。
+4. 建 ranking dataset。
+5. split train/valid/holdout（保留 per-size 統計）。
+6. 訓練 global 模型。
+7. 依 `size_class` 訓練 per-size 模型（資料不足會跳過，runtime 用 global fallback）。
+8. 寫出 model registry + readiness 報告。
 
-> 若資料量過大可加 `--shard-rows 2000000` 產生 shard+manifest。
+## 主要輸出檔案
+- `data/full_boards/full_board_corpus.jsonl`
+- `reports/full_board_corpus_audit.json`
+- `reports/multisize_corpus_summary.json`
+- `data/ranking/ranking_dataset.parquet`
+- `data/ranking/splits/train.parquet`
+- `data/ranking/splits/valid.parquet`
+- `data/ranking/splits/holdout.parquet`
+- `data/ranking/splits/split_summary.json`
+- `artifacts/global/main_ranker.pkl`
+- `artifacts/sizes/<size_class>/main_ranker.pkl`
+- `artifacts/model_registry.json`
+- `reports/multisize_training_summary.json`
+- `reports/runtime_readiness_report.json`
 
-## 4) 本地訓練
-```bash
-python scripts/train_local_ranker.py \
-  --train-real-path data/ranking/train_real.parquet \
-  --train-synth-path data/ranking/train_synth.parquet \
-  --holdout-real-path data/ranking/holdout_real.parquet \
-  --device auto \
-  --max-workers auto
-```
+## Runtime 選模規則
+- `src/main_ranker.py` 會先用盤面大小（`rows x cols`）組成 `size_class`。
+- 若 registry 有對應 `per_size[size_class]` 且 artifact 存在，就用該模型。
+- 否則 fallback 到 `global` 模型。
+- 若 `strict_missing_artifact=true` 且 global/per-size 都不存在，會 fail-fast。
 
-輸出：
-- `artifacts/main_ranker.pkl`
-- `artifacts/main_ranker_meta.json`
-- `reports/train_local_ranker_report.json`
-
-## 5) 跑 real holdout backtest
-```bash
-python scripts/run_real_holdout_backtest.py \
-  --train-real data/ranking/train_real.parquet \
-  --train-synth data/ranking/train_synth.parquet \
-  --holdout-real data/ranking/holdout_real.parquet \
-  --output reports/real_holdout_backtest_summary.json
-```
-
-## 6) 推理啟用新模型
-`configs/inference.yaml`:
-```yaml
-trained_ranker:
-  enabled: true
-  strict_missing_artifact: true
-```
-
-- 啟用時會走：`feasibility gate -> trained ranker -> (可選) existing reranker`。
-- 若 `artifacts/main_ranker.pkl` 缺失且 `strict_missing_artifact=true`，推理會 fail-fast。
+## 常用參數
+- `--model-strategy auto|per_size|global_only`
+- `--min-real-boards-per-size 5`
+- `--mask-ratios 0.1,0.2,0.3,0.5`
+- `--holdout-ratio 0.2`
+- `--max-workers 1`

--- a/scripts/build_masked_ranking_dataset.py
+++ b/scripts/build_masked_ranking_dataset.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import argparse
+import faulthandler
 import json
+import os
+import shutil
+from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
 import pandas as pd
 
-from src.masking_dataset import MaskingConfig, build_masked_ranking_dataset, write_rank_dataset
+from src.masking_dataset import (
+    MaskingConfig,
+    iter_masked_ranking_dataset_chunks,
+)
+from src.safe_io import SafeWriteConfig, write_dataframe_chunks_safe
 from src.whole_board_features import (
     DEPRECATED_FEATURE_PREFIXES,
     FEATURE_MERGE_MAP,
@@ -17,6 +25,14 @@ from src.whole_board_features import (
     NEAR_CONSTANT_STD_EPS,
     is_primary_feature_column,
 )
+
+
+def _enable_fault_handler() -> None:
+    os.environ.setdefault("PYTHONFAULTHANDLER", "1")
+    try:
+        faulthandler.enable()
+    except Exception:
+        pass
 
 
 def read_jsonl(path: Path) -> List[Dict[str, Any]]:
@@ -48,52 +64,49 @@ def _feature_category(col: str) -> str:
     return "kept_features"
 
 
-def _dead_or_constant(df: pd.DataFrame, features: List[str]) -> List[str]:
-    dead: List[str] = []
-    for col in features:
-        s = df[col].fillna(0.0)
-        if s.empty:
-            dead.append(col)
-            continue
-        unique = s.nunique(dropna=False)
-        if unique <= 1:
-            dead.append(col)
-            continue
-        if float(s.std()) <= NEAR_CONSTANT_STD_EPS:
-            dead.append(col)
-            continue
-        dominant = float(s.value_counts(normalize=True, dropna=False).iloc[0])
-        if dominant >= NEAR_CONSTANT_DOMINANT_RATIO:
-            dead.append(col)
-    return sorted(set(dead))
+def _merge_value_counts(dst: Dict[float, int], src: pd.Series) -> None:
+    for value, cnt in src.items():
+        dst[float(value)] = int(dst.get(float(value), 0) + int(cnt))
 
 
-def _size_summary(df: pd.DataFrame, features: List[str]) -> Dict[str, Dict[str, int]]:
-    out: Dict[str, Dict[str, int]] = {}
-    for size, sub in df.groupby("size_class"):
-        valid = []
-        for col in features:
-            if col not in sub.columns:
-                continue
-            s = sub[col].fillna(0.0)
-            if s.nunique(dropna=False) > 1 and float(s.std()) > NEAR_CONSTANT_STD_EPS:
-                valid.append(col)
-        out[str(size)] = {
-            "rows": int(len(sub)),
-            "candidate_groups": int(sub["group_id"].nunique()) if "group_id" in sub.columns else 0,
-            "effective_feature_count": int(len(valid)),
-        }
-    return out
+def _update_size_agg(size_agg: Dict[str, Dict[str, Dict[str, float]]], size: str, col: str, s: pd.Series) -> None:
+    cell = size_agg[size].setdefault(col, {"n": 0.0, "sum": 0.0, "sum_sq": 0.0, "nunique": 0.0})
+    values = s.fillna(0.0).astype(float)
+    n = float(len(values))
+    cell["n"] += n
+    cell["sum"] += float(values.sum())
+    cell["sum_sq"] += float((values * values).sum())
+    cell["nunique"] += float(values.nunique(dropna=False) > 1)
+
+
+def _std_from_agg(n: float, s: float, s2: float) -> float:
+    if n <= 1:
+        return 0.0
+    mean = s / n
+    var = max(s2 / n - mean * mean, 0.0)
+    return float(var**0.5)
+
+
+def _peak_rss_mb() -> float | None:
+    try:
+        import resource  # type: ignore
+
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        return float(usage.ru_maxrss) / 1024.0
+    except Exception:
+        return None
 
 
 def main() -> None:
+    _enable_fault_handler()
     parser = argparse.ArgumentParser()
+    parser.add_argument("--size-class", choices=["4x5", "6x10", "8x10", "10x10", "10x12", "10x16"], default="")
     parser.add_argument("--real-corpus", default="data/full_boards/full_board_corpus.jsonl")
     parser.add_argument("--synthetic-corpus", default="data/full_boards/synthetic_board_corpus.jsonl")
     parser.add_argument("--output", default="data/ranking/ranking_dataset.parquet")
     parser.add_argument("--mask-ratios", default="0.1,0.2,0.3,0.5")
     parser.add_argument("--masks-per-ratio", type=int, default=2)
-    parser.add_argument("--shard-rows", type=int, default=0)
+    parser.add_argument("--shard-rows", type=int, default=150000)
     parser.add_argument("--feature-schema", default="artifacts/feature_schema_residue.json")
     parser.add_argument("--max-file-mb", type=int, default=100)
     parser.add_argument("--feature-audit-before", default="reports/feature_audit_before.json")
@@ -101,6 +114,7 @@ def main() -> None:
     parser.add_argument("--feature-merge-map", default="reports/feature_merge_map.json")
     parser.add_argument("--dead-feature-report", default="reports/dead_feature_report.json")
     parser.add_argument("--size-aware-summary", default="reports/size_aware_feature_summary.json")
+    parser.add_argument("--debug-crash-report", action="store_true")
     args = parser.parse_args()
 
     real_rows = read_jsonl(Path(args.real_corpus))
@@ -109,36 +123,116 @@ def main() -> None:
     if synth_path.exists():
         synth_rows = read_jsonl(synth_path)
 
+    if args.size_class:
+        real_rows = [r for r in real_rows if str(r.get("size_class", "")) == args.size_class]
+        synth_rows = [r for r in synth_rows if str(r.get("size_class", "")) == args.size_class]
     boards = real_rows + synth_rows
+    if not boards:
+        raise ValueError(f"no boards after size_class filter: {args.size_class or 'ALL'}")
     ratios = [float(x.strip()) for x in args.mask_ratios.split(",") if x.strip()]
-    df = build_masked_ranking_dataset(boards, MaskingConfig(ratios=ratios, masks_per_ratio=args.masks_per_ratio))
+    config = MaskingConfig(ratios=ratios, masks_per_ratio=args.masks_per_ratio)
 
-    all_feature_cols = [
-        c for c in df.columns if c.startswith("board_state_") or c.startswith("candidate_delta_")
-    ]
-    primary_before = [c for c in all_feature_cols if is_primary_feature_column(c)]
-    dead = _dead_or_constant(df, primary_before)
-    primary_after = [c for c in primary_before if c not in set(dead)]
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists() and output_path.is_file():
+        output_path.unlink()
+    if output_path.exists() and output_path.is_dir():
+        shutil.rmtree(output_path)
 
-    written = write_rank_dataset(
-        df,
-        Path(args.output),
-        shard_rows=args.shard_rows,
-        max_file_mb=args.max_file_mb,
-        producer_script="scripts/build_masked_ranking_dataset.py",
-    )
+    all_columns: List[str] = []
+    primary_cols: List[str] = []
+    row_count = 0
+    group_ids: set[str] = set()
+    size_rows: Dict[str, int] = defaultdict(int)
+    size_groups: Dict[str, set[str]] = defaultdict(set)
+    stats: Dict[str, Dict[str, Any]] = {}
+    size_agg: Dict[str, Dict[str, Dict[str, float]]] = defaultdict(dict)
 
-    deprecated = [c for c in all_feature_cols if c not in primary_after]
+    crash_ctx: Dict[str, Any] = {"stage": "stream_build", "board_count": len(boards), "rows": 0}
+
+    def on_progress(payload: Dict[str, Any]) -> None:
+        crash_ctx.update(
+            {
+                "stage": "stream_build",
+                "board_index": payload.get("board_index"),
+                "board_id": payload.get("board_id"),
+                "size_class": payload.get("size_class"),
+                "ratio": payload.get("ratio"),
+                "mask_idx": payload.get("mask_idx"),
+                "target": payload.get("target"),
+                "rows": payload.get("rows_emitted"),
+                "peak_rss_mb": _peak_rss_mb(),
+            }
+        )
+
+    chunks = iter_masked_ranking_dataset_chunks(boards, config, chunk_rows=max(1, args.shard_rows), progress_hook=on_progress)
+
+    def on_chunk(chunk: pd.DataFrame) -> None:
+        nonlocal row_count
+        for col in chunk.columns:
+            if col not in all_columns:
+                all_columns.append(col)
+        row_count += int(len(chunk))
+        if "group_id" in chunk.columns:
+            group_ids.update(str(v) for v in chunk["group_id"].dropna().tolist())
+        if "size_class" in chunk.columns:
+            for size, sub in chunk.groupby("size_class"):
+                size_rows[str(size)] += int(len(sub))
+                if "group_id" in sub.columns:
+                    size_groups[str(size)].update(str(v) for v in sub["group_id"].dropna().tolist())
+
+        chunk_features = [c for c in chunk.columns if c.startswith("board_state_") or c.startswith("candidate_delta_")]
+        for col in chunk_features:
+            if col not in stats:
+                stats[col] = {"n": 0.0, "sum": 0.0, "sum_sq": 0.0, "counts": {}}
+            if col not in primary_cols and is_primary_feature_column(col):
+                primary_cols.append(col)
+            s = chunk[col].fillna(0.0).astype(float)
+            stats[col]["n"] += float(len(s))
+            stats[col]["sum"] += float(s.sum())
+            stats[col]["sum_sq"] += float((s * s).sum())
+            _merge_value_counts(stats[col]["counts"], s.value_counts(dropna=False))
+            if "size_class" in chunk.columns:
+                for size, sub in chunk.groupby("size_class"):
+                    _update_size_agg(size_agg, str(size), col, sub[col])
+
+    try:
+        written = write_dataframe_chunks_safe(
+            chunks,
+            output_path,
+            fmt="parquet",
+            config=SafeWriteConfig(max_file_mb=args.max_file_mb, producer_script="scripts/build_masked_ranking_dataset.py"),
+            on_chunk=on_chunk,
+        )
+    except Exception:
+        if args.debug_crash_report:
+            print(json.dumps({"debug_crash_report": crash_ctx}, ensure_ascii=False, indent=2))
+        raise
+
+    dead: List[str] = []
+    for col in primary_cols:
+        item = stats.get(col, {})
+        n = float(item.get("n", 0.0))
+        std = _std_from_agg(n, float(item.get("sum", 0.0)), float(item.get("sum_sq", 0.0)))
+        counts = item.get("counts", {})
+        unique = len(counts)
+        dom = (max(counts.values()) / max(n, 1.0)) if counts else 1.0
+        if unique <= 1 or std <= NEAR_CONSTANT_STD_EPS or dom >= NEAR_CONSTANT_DOMINANT_RATIO:
+            dead.append(col)
+    dead = sorted(set(dead))
+    primary_after = [c for c in primary_cols if c not in set(dead)]
+
+    deprecated = [c for c in [c for c in all_columns if c.startswith("board_state_") or c.startswith("candidate_delta_")] if c not in primary_after]
     schema = {
         "version": FEATURE_SCHEMA_VERSION,
         "schema_strategy": "unified_schema_with_dynamic_optional_bins",
         "feature_columns": primary_after,
-        "primary_feature_count_before_pruning": len(primary_before),
+        "primary_feature_count_before_pruning": len(primary_cols),
         "primary_feature_count_after_pruning": len(primary_after),
         "near_constant_pruned_features": dead,
         "deprecated_features": deprecated,
         "deprecated_feature_prefixes": list(DEPRECATED_FEATURE_PREFIXES),
-        "row_columns": list(df.columns),
+        "row_columns": all_columns,
     }
     schema_path = Path(args.feature_schema)
     schema_path.parent.mkdir(parents=True, exist_ok=True)
@@ -155,12 +249,8 @@ def main() -> None:
         "dead_or_near_constant_features": sorted(dead),
         "kept_features": [],
     }
-    for col in primary_before:
-        cat = _feature_category(col)
-        feature_categories.setdefault(cat, []).append(col)
-        if col in dead and col not in feature_categories["dead_or_near_constant_features"]:
-            feature_categories["dead_or_near_constant_features"].append(col)
-
+    for col in primary_cols:
+        feature_categories.setdefault(_feature_category(col), []).append(col)
     for col in primary_after:
         feature_categories["kept_features"].append(col)
 
@@ -168,7 +258,10 @@ def main() -> None:
     Path(args.feature_audit_before).write_text(
         json.dumps(
             {
-                "feature_count": len(primary_before),
+                "selected_size_class": args.size_class or "ALL",
+                "real_board_count": len(real_rows),
+                "synthetic_board_count": len(synth_rows),
+                "feature_count": len(primary_cols),
                 "feature_categories": feature_categories,
                 "notes": "before pruning/de-dup",
             },
@@ -180,6 +273,9 @@ def main() -> None:
     Path(args.feature_audit_after).write_text(
         json.dumps(
             {
+                "selected_size_class": args.size_class or "ALL",
+                "real_board_count": len(real_rows),
+                "synthetic_board_count": len(synth_rows),
                 "feature_count": len(primary_after),
                 "removed_features": dead,
                 "kept_features": primary_after,
@@ -191,23 +287,19 @@ def main() -> None:
         encoding="utf-8",
     )
 
-    removed_map = {name: "near_constant_or_dead" for name in dead}
     merge_report = {
         "removed_features": sorted(dead),
         "merged_features": FEATURE_MERGE_MAP,
         "renamed_features": FEATURE_RENAME_MAP,
         "kept_features": primary_after,
-        "why_removed_or_merged": {
-            **removed_map,
-            **{k: v for k, v in FEATURE_MERGE_MAP.items()},
-            **{k: f"renamed_to:{v}" for k, v in FEATURE_RENAME_MAP.items()},
-        },
     }
     Path(args.feature_merge_map).write_text(json.dumps(merge_report, ensure_ascii=False, indent=2), encoding="utf-8")
-
     Path(args.dead_feature_report).write_text(
         json.dumps(
             {
+                "selected_size_class": args.size_class or "ALL",
+                "real_board_count": len(real_rows),
+                "synthetic_board_count": len(synth_rows),
                 "threshold_std_eps": NEAR_CONSTANT_STD_EPS,
                 "threshold_dominant_ratio": NEAR_CONSTANT_DOMINANT_RATIO,
                 "near_constant_features": dead,
@@ -218,10 +310,28 @@ def main() -> None:
         encoding="utf-8",
     )
 
-    size_summary = _size_summary(df, primary_after)
+    size_summary: Dict[str, Dict[str, int]] = {}
+    for size, rows in sorted(size_rows.items()):
+        eff = 0
+        for col in primary_after:
+            agg = size_agg.get(size, {}).get(col)
+            if not agg:
+                continue
+            std = _std_from_agg(float(agg["n"]), float(agg["sum"]), float(agg["sum_sq"]))
+            if float(agg["nunique"]) > 0 and std > NEAR_CONSTANT_STD_EPS:
+                eff += 1
+        size_summary[size] = {
+            "rows": int(rows),
+            "candidate_groups": int(len(size_groups.get(size, set()))),
+            "effective_feature_count": int(eff),
+        }
+
     Path(args.size_aware_summary).write_text(
         json.dumps(
             {
+                "selected_size_class": args.size_class or "ALL",
+                "real_board_count": len(real_rows),
+                "synthetic_board_count": len(synth_rows),
                 "schema_strategy": "unified_schema_with_dynamic_optional_bins",
                 "size_class_summary": size_summary,
                 "primary_feature_count": len(primary_after),
@@ -235,10 +345,14 @@ def main() -> None:
     print(
         json.dumps(
             {
-                "rows": len(df),
+                "selected_size_class": args.size_class or "ALL",
+                "real_board_count": len(real_rows),
+                "synthetic_board_count": len(synth_rows),
+                "rows": row_count,
+                "groups": len(group_ids),
                 "output": args.output,
                 "write": written,
-                "primary_before": len(primary_before),
+                "primary_before": len(primary_cols),
                 "primary_after": len(primary_after),
                 "dead": len(dead),
             },

--- a/scripts/build_root_xlsx_corpus_80.py
+++ b/scripts/build_root_xlsx_corpus_80.py
@@ -5,12 +5,13 @@ import json
 import re
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from openpyxl import load_workbook
 
-ALLOWED_SHAPES: Tuple[Tuple[int, int], ...] = ((8, 10), (10, 8))
 DIGIT_RE = re.compile(r"^\d+$")
+SIZE_HINT_RE = re.compile(r"(?<!\d)(\d{1,2})\s*[xX]\s*(\d{1,2})(?!\d)")
+COMMON_SHAPES: Tuple[Tuple[int, int], ...] = ((4, 5), (6, 10), (8, 10), (10, 10), (10, 12), (10, 16))
 
 
 def read_sheet_as_strings(ws) -> List[List[str]]:
@@ -23,17 +24,12 @@ def read_sheet_as_strings(ws) -> List[List[str]]:
     return [r + [""] * (width - len(r)) for r in table]
 
 
-
 def normalize_token(raw: str) -> str:
-    s = (raw or "")
-    s = s.strip().upper()
+    s = (raw or "").strip().upper()
     s = s.replace("O", "0").replace("I", "1")
-    if s.endswith(".0"):
-        head = s[:-2]
-        if DIGIT_RE.fullmatch(head):
-            s = head
+    if s.endswith(".0") and DIGIT_RE.fullmatch(s[:-2]):
+        s = s[:-2]
     return s
-
 
 
 def parse_int_token(raw: str) -> Optional[int]:
@@ -46,10 +42,23 @@ def parse_int_token(raw: str) -> Optional[int]:
         return None
 
 
+def board_signature(grid: Sequence[Sequence[int]]) -> str:
+    return ",".join(str(v) for row in grid for v in row)
 
-def is_full_permutation(flat: Sequence[int], n: int) -> bool:
-    return len(flat) == n and sorted(flat) == list(range(1, n + 1))
 
+def validate_full_permutation(flat: Sequence[int], n: int) -> Tuple[bool, str]:
+    if len(flat) != n:
+        return False, "length_mismatch"
+    missing = sorted(set(range(1, n + 1)) - set(flat))
+    duplicates = sorted(v for v, cnt in Counter(flat).items() if cnt > 1)
+    out_of_range = sorted(v for v in flat if v < 1 or v > n)
+    if out_of_range:
+        return False, f"out_of_range_values:{out_of_range[:8]}"
+    if duplicates:
+        return False, f"duplicate_values:{duplicates[:8]}"
+    if missing:
+        return False, f"missing_values:{missing[:8]}"
+    return True, "ok"
 
 
 def matrix_to_visual(table: Sequence[Sequence[str]]) -> str:
@@ -76,60 +85,123 @@ def matrix_to_visual(table: Sequence[Sequence[str]]) -> str:
     return "\n".join(lines)
 
 
-
 def extract_submatrix(table: Sequence[Sequence[str]], top: int, left: int, rows: int, cols: int) -> List[List[str]]:
-    return [list(r[left:left + cols]) for r in table[top:top + rows]]
+    return [list(r[left : left + cols]) for r in table[top : top + rows]]
 
 
-
-def try_parse_board(sub: Sequence[Sequence[str]], rows: int, cols: int) -> Optional[List[List[int]]]:
+def try_parse_board(sub: Sequence[Sequence[str]], rows: int, cols: int) -> Tuple[Optional[List[List[int]]], str]:
     if len(sub) != rows:
-        return None
+        return None, "rows_mismatch"
     out: List[List[int]] = []
-    for row in sub:
+    non_int_cells: List[str] = []
+    for ridx, row in enumerate(sub, start=1):
         if len(row) != cols:
-            return None
+            return None, "cols_mismatch"
         parsed_row: List[int] = []
-        for cell in row:
+        for cidx, cell in enumerate(row, start=1):
             value = parse_int_token(cell)
             if value is None:
-                return None
+                non_int_cells.append(f"R{ridx}C{cidx}")
+                parsed_row.append(-999999)
+                continue
             parsed_row.append(value)
         out.append(parsed_row)
+
+    if non_int_cells:
+        return None, f"non_integer_cells:{non_int_cells[:6]}"
+
     flat = [v for row in out for v in row]
-    if not is_full_permutation(flat, rows * cols):
-        return None
+    ok, reason = validate_full_permutation(flat, rows * cols)
+    if not ok:
+        return None, reason
+    return out, "ok"
+
+
+def _factor_shapes(n: int) -> List[Tuple[int, int]]:
+    out: List[Tuple[int, int]] = []
+    if n <= 0:
+        return out
+    for r in range(2, int(n**0.5) + 1):
+        if n % r == 0:
+            c = n // r
+            out.append((r, c))
+            out.append((c, r))
     return out
 
 
+def _shapes_from_filename(name: str) -> List[Tuple[int, int]]:
+    found: List[Tuple[int, int]] = []
+    for m in SIZE_HINT_RE.finditer(name):
+        shape = (int(m.group(1)), int(m.group(2)))
+        if shape not in found:
+            found.append(shape)
+    return found
 
-def scan_sheet_for_boards(table: Sequence[Sequence[str]], shapes: Sequence[Tuple[int, int]]) -> Iterable[Tuple[int, int, int, int, List[List[int]]]]:
+
+def _infer_shapes(table: Sequence[Sequence[str]], filename: str) -> List[Tuple[int, int]]:
+    sheet_rows = len(table)
+    sheet_cols = max((len(r) for r in table), default=0)
+
+    int_values: List[int] = []
+    for row in table:
+        for cell in row:
+            v = parse_int_token(cell)
+            if v is not None and v > 0:
+                int_values.append(v)
+
+    inferred: List[Tuple[int, int]] = []
+    for n in {max(int_values) if int_values else 0, len(int_values)}:
+        for shape in _factor_shapes(n):
+            if shape not in inferred:
+                inferred.append(shape)
+
+    merged: List[Tuple[int, int]] = []
+    for shape in _shapes_from_filename(filename) + list(COMMON_SHAPES) + inferred:
+        r, c = shape
+        if r < 2 or c < 2:
+            continue
+        if r > sheet_rows or c > sheet_cols:
+            continue
+        if shape not in merged:
+            merged.append(shape)
+    return merged
+
+
+def scan_sheet_for_boards(
+    table: Sequence[Sequence[str]],
+    shapes: Sequence[Tuple[int, int]],
+) -> Tuple[List[Tuple[int, int, int, int, List[List[int]]]], Counter[str]]:
     if not table:
-        return
+        return [], Counter({"empty_sheet": 1})
+
     total_rows = len(table)
     total_cols = max(len(r) for r in table)
     seen_grids = set()
+    found: List[Tuple[int, int, int, int, List[List[int]]]] = []
+    rejects: Counter[str] = Counter()
+
     for rows, cols in shapes:
         if total_rows < rows or total_cols < cols:
             continue
         for top in range(total_rows - rows + 1):
             for left in range(total_cols - cols + 1):
                 sub = extract_submatrix(table, top, left, rows, cols)
-                parsed = try_parse_board(sub, rows, cols)
+                parsed, reason = try_parse_board(sub, rows, cols)
                 if parsed is None:
+                    rejects[f"{rows}x{cols}:{reason}"] += 1
                     continue
-                key = tuple(tuple(r) for r in parsed)
+                key = (rows, cols, board_signature(parsed))
                 if key in seen_grids:
+                    rejects[f"{rows}x{cols}:duplicate_within_sheet"] += 1
                     continue
                 seen_grids.add(key)
-                yield top, left, rows, cols, parsed
-
+                found.append((top, left, rows, cols, parsed))
+    return found, rejects
 
 
 def preview_filename(xlsx_name: str, sheet_name: str, top: int, left: int, rows: int, cols: int) -> str:
     safe = re.sub(r"[^A-Za-z0-9._-]+", "_", f"{Path(xlsx_name).stem}__{sheet_name}__r{top+1}_c{left+1}__{rows}x{cols}")
     return safe + ".txt"
-
 
 
 def build_corpus(input_dir: Path, preview_dir: Optional[Path]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
@@ -143,6 +215,7 @@ def build_corpus(input_dir: Path, preview_dir: Optional[Path]) -> Tuple[List[Dic
         "rejected": [],
         "size_counts": {},
         "errors": [],
+        "files": [],
     }
     seen_board_keys = set()
 
@@ -157,6 +230,8 @@ def build_corpus(input_dir: Path, preview_dir: Optional[Path]) -> Tuple[List[Dic
             continue
 
         file_hits = 0
+        file_report: Dict[str, Any] = {"file": xlsx_path.name, "sheets": [], "accepted_total": 0, "rejected_total": 0}
+
         for sheet_index, sheet_name in enumerate(wb.sheetnames, start=1):
             ws = wb[sheet_name]
             try:
@@ -165,18 +240,25 @@ def build_corpus(input_dir: Path, preview_dir: Optional[Path]) -> Tuple[List[Dic
                 audit["errors"].append({"file": xlsx_path.name, "sheet": sheet_name, "error": f"read_failed: {exc}"})
                 continue
 
+            inferred_shapes = _infer_shapes(table, xlsx_path.name)
+            found_boards, reject_reasons = scan_sheet_for_boards(table, inferred_shapes)
             sheet_hits = 0
-            for top, left, rows, cols, grid in scan_sheet_for_boards(table, ALLOWED_SHAPES):
-                board_key = tuple(tuple(r) for r in grid)
+            sheet_rejects = int(sum(reject_reasons.values()))
+
+            for top, left, rows, cols, grid in found_boards:
+                board_key = (rows, cols, board_signature(grid))
                 if board_key in seen_board_keys:
+                    sheet_rejects += 1
                     continue
                 seen_board_keys.add(board_key)
+
                 board_id = f"xlsx:{xlsx_path.stem}:{sheet_name}:{top+1}:{left+1}:{rows}x{cols}"
                 record = {
                     "board_id": board_id,
                     "rows": rows,
                     "cols": cols,
                     "size_class": f"{rows}x{cols}",
+                    "board_size": rows * cols,
                     "grid": grid,
                     "source": "root_xlsx_import",
                     "source_file": xlsx_path.name,
@@ -219,24 +301,39 @@ def build_corpus(input_dir: Path, preview_dir: Optional[Path]) -> Tuple[List[Dic
                     {
                         "file": xlsx_path.name,
                         "sheet": sheet_name,
-                        "reason": "no_8x10_or_10x8_full_permutation_found",
+                        "reason": "no_valid_full_permutation_found_for_inferred_shapes",
+                        "inferred_shapes": [f"{r}x{c}" for r, c in inferred_shapes],
+                        "top_rejected_reasons": reject_reasons.most_common(10),
                     }
                 )
 
+            file_report["sheets"].append(
+                {
+                    "sheet_name": sheet_name,
+                    "inferred_shapes": [f"{r}x{c}" for r, c in inferred_shapes],
+                    "accepted_boards": sheet_hits,
+                    "rejected_windows": sheet_rejects,
+                    "top_rejected_reasons": reject_reasons.most_common(10),
+                }
+            )
+            file_report["accepted_total"] += sheet_hits
+            file_report["rejected_total"] += sheet_rejects
+
         if file_hits == 0:
-            audit["errors"].append({"file": xlsx_path.name, "error": "no_valid_80_board_found_in_file"})
+            audit["errors"].append({"file": xlsx_path.name, "error": "no_valid_permutation_board_found_in_file"})
+
+        audit["files"].append(file_report)
 
     audit["size_counts"] = dict(size_counts)
     audit["board_count"] = len(records)
     return records, audit
 
 
-
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Build 80-scratch-board corpus from root xlsx files.")
+    parser = argparse.ArgumentParser(description="Build multi-size board corpus from root xlsx files.")
     parser.add_argument("--input-dir", default=".")
     parser.add_argument("--output", default="data/full_boards/full_board_corpus_80.jsonl")
-    parser.add_argument("--audit", default="reports/full_board_corpus_80_audit.json")
+    parser.add_argument("--audit", default="reports/full_board_corpus_audit.json")
     parser.add_argument("--preview-dir", default="reports/root_xlsx_previews")
     args = parser.parse_args()
 

--- a/scripts/generate_synthetic_boards.py
+++ b/scripts/generate_synthetic_boards.py
@@ -21,6 +21,7 @@ def read_jsonl(path: Path) -> List[Dict[str, Any]]:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--size-class", choices=["4x5", "6x10", "8x10", "10x10", "10x12", "10x16"], default="")
     parser.add_argument("--real-corpus", default="data/full_boards/full_board_corpus.jsonl")
     parser.add_argument("--profile", default="artifacts/synthetic_generator_profile.json")
     parser.add_argument("--output", default="data/full_boards/synthetic_board_corpus.jsonl")
@@ -30,6 +31,11 @@ def main() -> None:
     args = parser.parse_args()
 
     real_boards = read_jsonl(Path(args.real_corpus))
+    before_count = len(real_boards)
+    if args.size_class:
+        real_boards = [r for r in real_boards if str(r.get("size_class", "")) == args.size_class]
+    if not real_boards:
+        raise ValueError(f"no real boards for size_class={args.size_class or 'ALL'}")
     profile_data = json.loads(Path(args.profile).read_text(encoding="utf-8"))
     profiles = {k: SizeClassProfile(**v) for k, v in profile_data.items()}
 
@@ -74,7 +80,18 @@ def main() -> None:
         out_path,
         config=SafeWriteConfig(max_file_mb=args.max_file_mb, producer_script="scripts/generate_synthetic_boards.py"),
     )
-    print(f"generated {len(out_rows)} synthetic boards -> {out_path}")
+    print(
+        json.dumps(
+            {
+                "selected_size_class": args.size_class or "ALL",
+                "real_board_count_before_filter": before_count,
+                "real_board_count_after_filter": len(real_boards),
+                "synthetic_board_count": len(out_rows),
+                "output": str(out_path),
+            },
+            ensure_ascii=False,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import faulthandler
 import json
 import os
 import subprocess
+import sys
 from collections import Counter
 from pathlib import Path
-from typing import Dict
-
-import sys
+from typing import Any, Dict, List
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
@@ -18,11 +18,60 @@ from src.main_ranker import write_model_registry  # noqa: E402
 from src.safe_io import read_dataset_auto  # noqa: E402
 
 
-def _run(cmd: list[str]) -> None:
+STACK_OVERFLOW_CODES = {3221225725, -1073741571}
+
+
+def _enable_fault_handler() -> None:
+    os.environ.setdefault("PYTHONFAULTHANDLER", "1")
+    try:
+        faulthandler.enable()
+    except Exception:
+        pass
+
+
+def _check_python_supported(allow_unsupported_python: bool) -> None:
+    current = sys.version_info
+    if (current.major, current.minor) >= (3, 14) and not allow_unsupported_python:
+        raise RuntimeError(
+            "training pipeline is not validated on Python 3.14+. "
+            "Please use Python 3.11 virtualenv, or pass --allow-unsupported-python to bypass."
+        )
+
+
+def _decode_exit_message(return_code: int) -> str:
+    if return_code in STACK_OVERFLOW_CODES:
+        return f"exit_code={return_code} (0xC00000FD stack overflow)"
+    return f"exit_code={return_code}"
+
+
+def _run(cmd: list[str], stage: str, debug_crash_report: bool, crash_state: Dict[str, Any]) -> None:
     print("$", " ".join(cmd))
     env = dict(os.environ)
     env["PYTHONPATH"] = str(ROOT)
-    subprocess.run(cmd, check=True, env=env)
+    env.setdefault("PYTHONFAULTHANDLER", "1")
+    res = subprocess.run(cmd, check=False, env=env, capture_output=True, text=True)
+    if res.stdout:
+        print(res.stdout, end="" if res.stdout.endswith("\n") else "\n")
+    if res.stderr:
+        print(res.stderr, end="" if res.stderr.endswith("\n") else "\n", file=sys.stderr)
+    if res.returncode != 0:
+        msg = f"[pipeline:{stage}] failed: {_decode_exit_message(res.returncode)}"
+        if debug_crash_report:
+            print(
+                json.dumps(
+                    {
+                        "stage": stage,
+                        "command": cmd,
+                        "crash_state": crash_state,
+                        "return_code": res.returncode,
+                        "decoded": _decode_exit_message(res.returncode),
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                file=sys.stderr,
+            )
+        raise RuntimeError(msg)
 
 
 def _train_one(
@@ -32,7 +81,10 @@ def _train_one(
     out_dir: Path,
     size_class: str,
     max_workers: int,
-) -> Dict[str, str]:
+    feature_schema: Path,
+    debug_crash_report: bool,
+    crash_state: Dict[str, Any],
+) -> Dict[str, Any]:
     _run(
         [
             "python",
@@ -49,7 +101,12 @@ def _train_one(
             str(out_dir),
             "--max-workers",
             str(max_workers),
-        ]
+            "--feature-schema",
+            str(feature_schema),
+        ],
+        stage=f"train:{size_class or 'global'}",
+        debug_crash_report=debug_crash_report,
+        crash_state=crash_state,
     )
     meta = json.loads((out_dir / "main_ranker_meta.json").read_text(encoding="utf-8"))
     return {
@@ -63,10 +120,56 @@ def _train_one(
     }
 
 
+def _build_multisize_summary(corpus_df, split_summary: Dict[str, Any], registry: Dict[str, Any]) -> Dict[str, Any]:
+    real_by_size = Counter(corpus_df["size_class"].tolist()) if len(corpus_df) else Counter()
+    split_per_size = split_summary.get("per_size", {})
+    train_ps = split_per_size.get("train", {})
+    valid_ps = split_per_size.get("valid", {})
+    holdout_ps = split_per_size.get("holdout", {})
+
+    per_size_training: Dict[str, Dict[str, Any]] = {}
+    for size in sorted(set(real_by_size) | set(train_ps) | set(valid_ps) | set(holdout_ps)):
+        model_item = registry.get("per_size", {}).get(size)
+        per_size_training[size] = {
+            "real_boards": int(real_by_size.get(size, 0)),
+            "train_rows": int(train_ps.get(size, {}).get("rows", 0)),
+            "valid_rows": int(valid_ps.get(size, {}).get("rows", 0)),
+            "holdout_rows": int(holdout_ps.get(size, {}).get("rows", 0)),
+            "model_trained": bool(model_item),
+            "artifact_path": model_item.get("artifact_path") if model_item else "",
+        }
+
+    return {
+        "real_board_count": int(len(corpus_df)),
+        "real_board_per_size": dict(real_by_size),
+        "split_summary": split_summary,
+        "global_model": registry.get("global", {}),
+        "per_size_training": per_size_training,
+    }
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    if not path.exists():
+        return out
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def _write_jsonl(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--input-dir", default=".")
-    parser.add_argument("--glob", default="*.xlsx")
     parser.add_argument("--output-root", default=".")
     parser.add_argument("--generate-synthetic", action="store_true")
     parser.add_argument("--per-real", type=int, default=12)
@@ -77,18 +180,28 @@ def main() -> None:
     parser.add_argument("--min-real-boards-per-size", type=int, default=5)
     parser.add_argument("--max-file-mb", type=int, default=100)
     parser.add_argument("--enable-inference", action="store_true")
-    parser.add_argument("--strict", action="store_true")
     parser.add_argument("--max-workers", type=int, default=1)
+    parser.add_argument("--allow-unsupported-python", action="store_true")
+    parser.add_argument("--debug-crash-report", action="store_true")
+    parser.add_argument("--size-class", choices=["4x5", "6x10", "8x10", "10x10", "10x12", "10x16"], default="")
     args = parser.parse_args()
+    _enable_fault_handler()
+    _check_python_supported(args.allow_unsupported_python)
+
     print("[主線訓練進度 5%] 參數解析完成，準備啟動資料建置。")
+    crash_state: Dict[str, Any] = {"stage": "bootstrap"}
 
     root = Path(args.output_root)
     full = root / "data/full_boards/full_board_corpus.jsonl"
+    full_filtered = root / "data/full_boards/full_board_corpus.filtered.jsonl"
     synth = root / "data/full_boards/synthetic_board_corpus.jsonl"
     rank = root / "data/ranking/ranking_dataset.parquet"
     split_root = root / "data/ranking/splits"
     artifacts = root / "artifacts"
+    reports = root / "reports"
+    feature_schema = artifacts / "feature_schema_residue.json"
 
+    crash_state["stage"] = "build_root_xlsx_corpus"
     _run(
         [
             "python",
@@ -98,47 +211,152 @@ def main() -> None:
             "--output",
             str(full),
             "--audit",
-            str(root / "reports/full_board_corpus_80_audit.json"),
+            str(reports / "full_board_corpus_audit.json"),
             "--preview-dir",
-            str(root / "reports/root_xlsx_previews_80"),
-        ]
+            str(reports / "root_xlsx_previews"),
+        ],
+        stage="build_root_xlsx_corpus",
+        debug_crash_report=args.debug_crash_report,
+        crash_state=crash_state,
     )
-    print("[主線訓練進度 20%] 真實盤面語料建置完成。")
+    print("[主線訓練進度 20%] 多尺寸真實盤面語料建置完成。")
+    corpus_for_pipeline = full
+    full_rows = _read_jsonl(full)
+    before_count = len(full_rows)
+    if args.size_class:
+        full_rows = [row for row in full_rows if str(row.get("size_class", "")) == args.size_class]
+        if not full_rows:
+            raise ValueError(f"no real boards after filter size_class={args.size_class}")
+        _write_jsonl(full_filtered, full_rows)
+        corpus_for_pipeline = full_filtered
+    print(
+        json.dumps(
+            {
+                "selected_size_class": args.size_class or "ALL",
+                "real_boards_before_filter": before_count,
+                "real_boards_after_filter": len(full_rows),
+                "corpus_used": str(corpus_for_pipeline),
+            },
+            ensure_ascii=False,
+        )
+    )
+
     if args.generate_synthetic:
+        profile = artifacts / "synthetic_generator_profile.json"
+        crash_state["stage"] = "fit_synthetic_profile"
+        _run(
+            [
+                "python",
+                "scripts/fit_real_board_generator.py",
+                "--real-corpus",
+                str(corpus_for_pipeline),
+                "--output",
+                str(profile),
+            ],
+            stage="fit_synthetic_profile",
+            debug_crash_report=args.debug_crash_report,
+            crash_state=crash_state,
+        )
+        crash_state["stage"] = "generate_synthetic"
         _run(
             [
                 "python",
                 "scripts/generate_synthetic_boards.py",
+                "--size-class",
+                args.size_class,
                 "--real-corpus",
-                str(full),
+                str(corpus_for_pipeline),
+                "--profile",
+                str(profile),
                 "--output",
                 str(synth),
                 "--per-real",
                 str(args.per_real),
                 "--max-file-mb",
                 str(args.max_file_mb),
-            ]
+            ],
+            stage="generate_synthetic",
+            debug_crash_report=args.debug_crash_report,
+            crash_state=crash_state,
         )
         print("[主線訓練進度 30%] 合成盤面語料建置完成。")
+    else:
+        if synth.exists():
+            if synth.is_file():
+                synth.unlink()
+            elif synth.is_dir():
+                import shutil
+
+                shutil.rmtree(synth)
+        print("[主線訓練進度 30%] 未啟用 synthetic，已忽略舊 synthetic corpus。")
+
+    crash_state["stage"] = "build_masked_ranking_dataset"
+    mask_cmd = [
+        "python",
+        "scripts/build_masked_ranking_dataset.py",
+        "--size-class",
+        args.size_class,
+        "--real-corpus",
+        str(corpus_for_pipeline),
+        "--output",
+        str(rank),
+        "--mask-ratios",
+        args.mask_ratios,
+        "--feature-schema",
+        str(feature_schema),
+        "--max-file-mb",
+        str(args.max_file_mb),
+    ]
+    if args.generate_synthetic:
+        mask_cmd.extend(["--synthetic-corpus", str(synth)])
+    if args.debug_crash_report:
+        mask_cmd.append("--debug-crash-report")
     _run(
-        [
-            "python",
-            "scripts/build_masked_ranking_dataset.py",
-            "--real-corpus",
-            str(full),
-            "--synthetic-corpus",
-            str(synth),
-            "--output",
-            str(rank),
-            "--mask-ratios",
-            args.mask_ratios,
-            "--max-file-mb",
-            str(args.max_file_mb),
-        ]
+        mask_cmd,
+        stage="build_masked_ranking_dataset",
+        debug_crash_report=args.debug_crash_report,
+        crash_state=crash_state,
     )
     print("[主線訓練進度 45%] ranking dataset 建置完成。")
+
+    split_cmd = [
+        "python",
+        "scripts/split_ranking_dataset.py",
+        "--dataset-path",
+        str(rank),
+        "--output-root",
+        str(split_root),
+        "--holdout-ratio",
+        str(args.holdout_ratio),
+        "--split-mode",
+        args.split_mode,
+        "--max-file-mb",
+        str(args.max_file_mb),
+        "--valid-real-only",
+        "--holdout-real-only",
+        "--exclude-synth-from-valid",
+    ]
+    crash_state["stage"] = "split_dataset"
     _run(
-        [
+        split_cmd,
+        stage="split_dataset",
+        debug_crash_report=args.debug_crash_report,
+        crash_state=crash_state,
+    )
+    print("[主線訓練進度 55%] train/valid/holdout 切分完成。")
+
+    train = split_root / "train.parquet"
+    valid = split_root / "valid.parquet"
+    holdout = split_root / "holdout.parquet"
+
+    full_df = read_dataset_auto(corpus_for_pipeline)
+    real_size_counts = Counter(full_df["size_class"].tolist()) if len(full_df) else Counter()
+    if args.size_class and not real_size_counts:
+        raise ValueError(f"no corpus rows for size_class={args.size_class}")
+    split_summary_path = split_root / "split_summary.json"
+    split_summary = json.loads(split_summary_path.read_text(encoding="utf-8"))
+    if split_summary.get("valid_real_rows", 0) == 0 or split_summary.get("holdout_real_rows", 0) == 0:
+        relaxed_cmd = [
             "python",
             "scripts/split_ranking_dataset.py",
             "--dataset-path",
@@ -151,80 +369,150 @@ def main() -> None:
             args.split_mode,
             "--max-file-mb",
             str(args.max_file_mb),
-            "--valid-real-only",
-            "--holdout-real-only",
-            "--exclude-synth-from-valid",
+            "--include-synth-in-holdout",
         ]
-    )
-    print("[主線訓練進度 55%] train/valid/holdout 切分完成。")
-
-    train = split_root / "train.parquet"
-    valid = split_root / "valid.parquet"
-    holdout = split_root / "holdout.parquet"
-
-    full_df = read_dataset_auto(full)
-    real_size_counts = Counter(full_df["size_class"].tolist())
+        _run(
+            relaxed_cmd,
+            stage="split_dataset_relaxed",
+            debug_crash_report=args.debug_crash_report,
+            crash_state=crash_state,
+        )
+        split_summary = json.loads(split_summary_path.read_text(encoding="utf-8"))
 
     registry = {
         "model_strategy": "size_specific_with_global_fallback",
         "global": {},
         "per_size": {},
-        "feature_schema_path": "artifacts/feature_schema.json",
+        "feature_schema_path": str(feature_schema),
         "backend": "mixed",
         "train_stats": {"real_size_counts": dict(real_size_counts)},
     }
+    duplicate_size_skip = False
+    effective_model_strategy = args.model_strategy
+    if args.size_class and args.model_strategy in {"auto", "per_size"}:
+        effective_model_strategy = "global_only"
+        duplicate_size_skip = True
+    print(
+        json.dumps(
+            {
+                "selected_size_class": args.size_class or "ALL",
+                "effective_model_strategy": effective_model_strategy,
+                "skip_duplicate_per_size_training": duplicate_size_skip,
+            },
+            ensure_ascii=False,
+        )
+    )
+    if effective_model_strategy == "global_only":
+        registry["model_strategy"] = "global_only"
 
-    global_info = _train_one(train, valid, holdout, artifacts / "global", "", args.max_workers)
+    crash_state.update({"stage": "train_global", "split_summary": split_summary})
+    global_info = _train_one(
+        train,
+        valid,
+        holdout,
+        artifacts / "global",
+        "",
+        args.max_workers,
+        feature_schema,
+        args.debug_crash_report,
+        crash_state,
+    )
     registry["global"] = global_info
     print("[主線訓練進度 75%] global 模型訓練完成。")
+    per_size_splits = split_summary.get("per_size", {})
+    train_ps = per_size_splits.get("train", {})
+    valid_ps = per_size_splits.get("valid", {})
+    holdout_ps = per_size_splits.get("holdout", {})
 
-    if args.model_strategy != "global_only":
-        for size_class, count in sorted(real_size_counts.items()):
-            if args.model_strategy == "per_size" or count >= args.min_real_boards_per_size:
-                out = artifacts / "sizes" / size_class
-                registry["per_size"][size_class] = _train_one(train, valid, holdout, out, size_class, args.max_workers)
-                print(f"[主線訓練進度 85%] size={size_class} 模型訓練完成。")
+    if args.size_class:
+        print(
+            json.dumps(
+                {
+                    "selected_size_class": args.size_class,
+                    "ranking_rows_after_filter": int(split_summary.get("train_real_rows", 0) + split_summary.get("valid_real_rows", 0) + split_summary.get("holdout_real_rows", 0)),
+                    "ranking_groups_after_filter": int(
+                        split_summary.get("train_real_groups", 0)
+                        + split_summary.get("valid_real_groups", 0)
+                        + split_summary.get("holdout_real_groups", 0)
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        )
+
+    for size_class, count in sorted(real_size_counts.items()):
+        if effective_model_strategy == "global_only":
+            continue
+        should_train = effective_model_strategy == "per_size" or count >= args.min_real_boards_per_size
+        if not should_train:
+            continue
+        if train_ps.get(size_class, {}).get("rows", 0) <= 0:
+            continue
+        if valid_ps.get(size_class, {}).get("rows", 0) <= 0:
+            continue
+        if holdout_ps.get(size_class, {}).get("rows", 0) <= 0:
+            continue
+
+        out = artifacts / "sizes" / size_class
+        registry["per_size"][size_class] = _train_one(
+            train,
+            valid,
+            holdout,
+            out,
+            size_class,
+            args.max_workers,
+            feature_schema,
+            args.debug_crash_report,
+            crash_state,
+        )
+        print(f"[主線訓練進度 85%] size={size_class} 模型訓練完成。")
 
     write_model_registry(registry, artifacts / "model_registry.json")
 
-    split_summary_path = split_root / "split_summary.json"
-    split_summary = json.loads(split_summary_path.read_text(encoding="utf-8")) if split_summary_path.exists() else {}
-    synth_count = 0
-    if synth.exists():
-        try:
-            synth_df = read_dataset_auto(synth)
-            synth_count = int(len(synth_df))
-        except Exception:
-            synth_count = 0
+    reports.mkdir(parents=True, exist_ok=True)
+
+    corpus_audit = json.loads((reports / "full_board_corpus_audit.json").read_text(encoding="utf-8"))
+    multisize_corpus_summary = {
+        "scanned_xlsx": corpus_audit.get("files_checked", []),
+        "files": corpus_audit.get("files", []),
+        "size_counts": corpus_audit.get("size_counts", {}),
+        "board_count": corpus_audit.get("board_count", 0),
+    }
+    (reports / "multisize_corpus_summary.json").write_text(
+        json.dumps(multisize_corpus_summary, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    training_summary = _build_multisize_summary(full_df, split_summary, registry)
+    (reports / "multisize_training_summary.json").write_text(
+        json.dumps(training_summary, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
 
     readiness = {
         "real_full_board_count": int(len(full_df)),
         "per_size_real_board_count": dict(real_size_counts),
-        "synthetic_board_count": synth_count,
         "split": split_summary,
         "model_strategy": registry.get("model_strategy"),
-        "global_model_present": bool(Path(registry["global"]["artifact_path"]).exists())
-        if registry.get("global")
-        else False,
-        "per_size_model_present": {
-            k: bool(Path(v["artifact_path"]).exists()) for k, v in registry.get("per_size", {}).items()
-        },
+        "global_model_present": bool(Path(registry["global"]["artifact_path"]).exists()) if registry.get("global") else False,
+        "per_size_model_present": {k: bool(Path(v["artifact_path"]).exists()) for k, v in registry.get("per_size", {}).items()},
         "inference_strict_missing_artifact": True,
         "ready_for_runtime": bool(registry.get("global"))
         and bool(split_summary.get("valid_real_rows", 0) > 0)
         and bool(split_summary.get("holdout_real_rows", 0) > 0),
+        "global_artifact_path": registry.get("global", {}).get("artifact_path", ""),
+        "per_size_artifact_paths": {k: v.get("artifact_path", "") for k, v in registry.get("per_size", {}).items()},
     }
-    rep_path = root / "reports/runtime_readiness_report.json"
-    rep_path.parent.mkdir(parents=True, exist_ok=True)
-    rep_path.write_text(json.dumps(readiness, ensure_ascii=False, indent=2), encoding="utf-8")
+    (reports / "runtime_readiness_report.json").write_text(json.dumps(readiness, ensure_ascii=False, indent=2), encoding="utf-8")
     print("[主線訓練進度 95%] registry 與 readiness report 輸出完成。")
 
     if args.enable_inference:
         cfg_path = Path("configs/inference.yaml")
-        text = cfg_path.read_text(encoding="utf-8")
-        if "strict_missing_artifact" not in text:
-            text += "\ntrained_ranker:\n  enabled: true\n  strict_missing_artifact: true\n"
-            cfg_path.write_text(text, encoding="utf-8")
+        if cfg_path.exists():
+            text = cfg_path.read_text(encoding="utf-8")
+            if "strict_missing_artifact" not in text:
+                text += "\ntrained_ranker:\n  enabled: true\n  strict_missing_artifact: true\n"
+                cfg_path.write_text(text, encoding="utf-8")
 
     print(json.dumps({"status": "ok", "registry": str(artifacts / 'model_registry.json')}, ensure_ascii=False))
     print("[主線訓練進度 100%] 主線訓練流程完成。")

--- a/scripts/split_ranking_dataset.py
+++ b/scripts/split_ranking_dataset.py
@@ -40,6 +40,10 @@ def split_df(
             assignments[key] = "train"
             continue
         assignments[key] = "holdout" if _bucket(key, seed) < holdout_ratio else "train"
+    if keys.shape[0] > 0 and all(v != "holdout" for v in assignments.values()):
+        real_keys = keys[keys["source_type"] == "real"][key_col].tolist()
+        fallback_key = str(real_keys[0]) if real_keys else str(keys.iloc[0][key_col])
+        assignments[fallback_key] = "holdout"
 
     out = df.copy()
     out["split"] = out[key_col].map(assignments)
@@ -75,6 +79,20 @@ def _stats(frame: pd.DataFrame) -> Dict[str, int]:
     }
 
 
+def _per_size_stats(frame: pd.DataFrame) -> Dict[str, Dict[str, int]]:
+    out: Dict[str, Dict[str, int]] = {}
+    if "size_class" not in frame.columns:
+        return out
+    for size, sub in frame.groupby("size_class"):
+        real = sub[sub["source_type"] == "real"] if "source_type" in sub.columns else sub.iloc[0:0]
+        out[str(size)] = {
+            "rows": int(len(sub)),
+            "real_rows": int(len(real)),
+            "groups": int(sub["group_id"].nunique()) if "group_id" in sub.columns else 0,
+        }
+    return out
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataset-path", required=True)
@@ -83,9 +101,9 @@ def main() -> None:
     parser.add_argument("--split-mode", choices=["by_board", "by_lineage"], default="by_lineage")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--include-synth-in-holdout", action="store_true")
-    parser.add_argument("--valid-real-only", action="store_true", default=True)
-    parser.add_argument("--holdout-real-only", action="store_true", default=True)
-    parser.add_argument("--exclude-synth-from-valid", action="store_true", default=True)
+    parser.add_argument("--valid-real-only", action="store_true")
+    parser.add_argument("--holdout-real-only", action="store_true")
+    parser.add_argument("--exclude-synth-from-valid", action="store_true")
     parser.add_argument("--max-file-mb", type=int, default=100)
     args = parser.parse_args()
 
@@ -105,13 +123,19 @@ def main() -> None:
     out_root.mkdir(parents=True, exist_ok=True)
     info = {}
     for name, frame in splits.items():
-        meta = write_dataframe_safe(
-            frame,
-            out_root / f"{name}.parquet",
-            fmt="parquet",
-            config=SafeWriteConfig(max_file_mb=args.max_file_mb, producer_script="scripts/split_ranking_dataset.py"),
-            shard_rows=0,
-        )
+        out_path = out_root / f"{name}.parquet"
+        if frame.empty:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            frame.to_parquet(out_path, index=False)
+            meta = {"type": "file", "path": str(out_path), "size_mb": 0.0, "row_count": 0, "columns": list(frame.columns)}
+        else:
+            meta = write_dataframe_safe(
+                frame,
+                out_path,
+                fmt="parquet",
+                config=SafeWriteConfig(max_file_mb=args.max_file_mb, producer_script="scripts/split_ranking_dataset.py"),
+                shard_rows=0,
+            )
         st = _stats(frame)
         info[name] = {"meta": meta, **st}
 
@@ -129,6 +153,7 @@ def main() -> None:
         "valid_real_only": args.valid_real_only,
         "holdout_real_only": args.holdout_real_only,
         "exclude_synth_from_valid": args.exclude_synth_from_valid,
+        "per_size": {name: _per_size_stats(frame) for name, frame in splits.items()},
     }
     (out_root / "split_summary.json").write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
     print(json.dumps(summary, ensure_ascii=False))

--- a/scripts/train_local_ranker.py
+++ b/scripts/train_local_ranker.py
@@ -240,6 +240,8 @@ def main() -> None:
         valid_df = valid_df[valid_df["size_class"] == args.size_class].copy()
         holdout_df = holdout_df[holdout_df["size_class"] == args.size_class].copy()
         print(f"[訓練進度 40%] 已套用 size_class={args.size_class} 篩選。")
+        if train_df.empty or valid_df.empty or holdout_df.empty:
+            raise ValueError(f"insufficient rows after size filter: size_class={args.size_class}")
 
     model, feature_columns, run = train_once(
         train_df,

--- a/src/masking_dataset.py
+++ b/src/masking_dataset.py
@@ -4,7 +4,7 @@ import hashlib
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
 
 import pandas as pd
 
@@ -85,6 +85,9 @@ def build_rows_for_group(
                 "rows": rows,
                 "cols": cols,
                 "size_class": str(board_row["size_class"]),
+                "board_size": int(rows * cols),
+                "source_file": str(board_row.get("source_file", "")),
+                "sheet_name": str(board_row.get("sheet_name", "")),
                 "mask_ratio": float(mask_ratio),
                 "target_number": int(target_number),
                 "cand_row": int(r + 1),
@@ -108,8 +111,17 @@ def build_masked_ranking_dataset(
     boards: Iterable[Dict[str, object]],
     config: MaskingConfig,
 ) -> pd.DataFrame:
-    rows_out: List[Dict[str, object]] = []
-    for board in boards:
+    return pd.DataFrame(iter_masked_ranking_rows(boards, config))
+
+
+def iter_masked_ranking_rows(
+    boards: Iterable[Dict[str, object]],
+    config: MaskingConfig,
+    progress_hook: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> Iterator[Dict[str, object]]:
+    board_index = -1
+    total_rows = 0
+    for board_index, board in enumerate(boards):
         grid = board.get("grid")
         if not grid:
             continue
@@ -120,8 +132,40 @@ def build_masked_ranking_dataset(
                 masked = create_masked_board(grid, float(ratio), rng)
                 for target in range(1, max_value + 1):
                     group_id = f"{board['board_id']}::r{int(ratio * 100)}::m{mask_idx:03d}::t{target:03d}"
-                    rows_out.extend(build_rows_for_group(board, masked, group_id, float(ratio), target))
-    return pd.DataFrame(rows_out)
+                    batch = build_rows_for_group(board, masked, group_id, float(ratio), target)
+                    for row in batch:
+                        total_rows += 1
+                        yield row
+                    if progress_hook is not None:
+                        progress_hook(
+                            {
+                                "board_index": board_index,
+                                "board_id": str(board.get("board_id")),
+                                "size_class": str(board.get("size_class", "")),
+                                "ratio": float(ratio),
+                                "mask_idx": int(mask_idx),
+                                "target": int(target),
+                                "rows_emitted": int(total_rows),
+                            }
+                        )
+
+
+def iter_masked_ranking_dataset_chunks(
+    boards: Iterable[Dict[str, object]],
+    config: MaskingConfig,
+    chunk_rows: int,
+    progress_hook: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> Iterator[pd.DataFrame]:
+    if chunk_rows <= 0:
+        raise ValueError("chunk_rows must be > 0")
+    rows_out: List[Dict[str, object]] = []
+    for row in iter_masked_ranking_rows(boards, config, progress_hook=progress_hook):
+        rows_out.append(row)
+        if len(rows_out) >= chunk_rows:
+            yield pd.DataFrame(rows_out)
+            rows_out = []
+    if rows_out:
+        yield pd.DataFrame(rows_out)
 
 
 def write_rank_dataset(

--- a/src/safe_io.py
+++ b/src/safe_io.py
@@ -161,6 +161,67 @@ def write_jsonl_records_safe(
     return write_dataframe_safe(df, output, "jsonl", config=config, shard_rows=shard_rows)
 
 
+def write_dataframe_chunks_safe(
+    chunks: Iterable[pd.DataFrame],
+    output: Path,
+    fmt: str,
+    config: SafeWriteConfig,
+    on_chunk: Any = None,
+) -> Dict[str, Any]:
+    if fmt not in {"parquet", "csv", "csv.gz", "jsonl"}:
+        raise SafeIOError(f"unsupported format: {fmt}")
+    output.mkdir(parents=True, exist_ok=True)
+    shards: List[Dict[str, Any]] = []
+    total_rows = 0
+    all_columns: List[str] = []
+
+    def _write(path: Path, frame: pd.DataFrame) -> None:
+        if fmt == "parquet":
+            frame.to_parquet(path, index=False)
+        elif fmt == "csv":
+            frame.to_csv(path, index=False)
+        elif fmt == "csv.gz":
+            frame.to_csv(path, index=False, compression="gzip")
+        else:
+            frame.to_json(path, orient="records", lines=True, force_ascii=False)
+
+    suffix = {"parquet": ".parquet", "csv": ".csv", "csv.gz": ".csv.gz", "jsonl": ".jsonl"}[fmt]
+    for idx, chunk in enumerate(chunks):
+        if chunk is None or chunk.empty:
+            continue
+        if on_chunk is not None:
+            on_chunk(chunk)
+        for c in chunk.columns:
+            if c not in all_columns:
+                all_columns.append(c)
+        shard_path = output / f"shard_{idx:05d}{suffix}"
+        _write(shard_path, chunk)
+        _assert_under_limit(shard_path, config.max_file_mb)
+        rows = int(len(chunk))
+        total_rows += rows
+        shards.append({"path": str(shard_path), "rows": rows})
+
+    if not shards:
+        raise SafeIOError("no chunk data to write")
+
+    payload = _manifest_payload(
+        fmt=fmt,
+        shards=shards,
+        row_count=total_rows,
+        columns=all_columns,
+        producer_script=config.producer_script,
+    )
+    manifest = _write_manifest(output, payload, config.max_file_mb)
+    return {
+        "type": "dataset_dir",
+        "path": str(output),
+        "manifest": str(manifest),
+        "row_count": int(total_rows),
+        "columns": all_columns,
+        "shard_count": len(shards),
+    }
+
+
 def read_dataset_auto(path: Path) -> pd.DataFrame:
     if path.is_file():
         if path.suffix == ".parquet":

--- a/tests/test_run_training_pipeline_guards.py
+++ b/tests/test_run_training_pipeline_guards.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import scripts.run_training_pipeline as p
+
+
+def test_decode_exit_code_stack_overflow() -> None:
+    msg = p._decode_exit_message(3221225725)
+    assert "0xC00000FD" in msg
+
+
+def test_python_guard_blocks_314(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(p.sys, "version_info", SimpleNamespace(major=3, minor=14))
+    with pytest.raises(RuntimeError):
+        p._check_python_supported(False)
+    p._check_python_supported(True)

--- a/tests/test_safe_io_streaming.py
+++ b/tests/test_safe_io_streaming.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from src.safe_io import SafeWriteConfig, read_dataset_auto, write_dataframe_chunks_safe
+
+
+def test_streaming_chunk_writer_roundtrip(tmp_path: Path) -> None:
+    chunks = [pd.DataFrame({"a": [1, 2], "b": [3, 4]}), pd.DataFrame({"a": [5], "b": [6]})]
+    out = tmp_path / "ds.parquet"
+    meta = write_dataframe_chunks_safe(chunks, out, fmt="parquet", config=SafeWriteConfig(producer_script="t"))
+    assert meta["type"] == "dataset_dir"
+    loaded = read_dataset_auto(out)
+    assert len(loaded) == 3

--- a/tests/test_size_class_filters.py
+++ b/tests/test_size_class_filters.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+from scripts.split_ranking_dataset import split_df
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def test_generate_synthetic_size_class_filter(tmp_path: Path) -> None:
+    real = tmp_path / "real.jsonl"
+    profile = tmp_path / "profile.json"
+    out = tmp_path / "synth.jsonl"
+    _write_jsonl(
+        real,
+        [
+            {
+                "board_id": "b1",
+                "rows": 4,
+                "cols": 5,
+                "size_class": "4x5",
+                "grid": [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20]],
+            },
+            {
+                "board_id": "b2",
+                "rows": 6,
+                "cols": 10,
+                "size_class": "6x10",
+                "grid": [list(range(i * 10 + 1, i * 10 + 11)) for i in range(6)],
+            },
+        ],
+    )
+    profile.write_text(
+        json.dumps(
+            {
+                "4x5": {
+                    "rows": 4,
+                    "cols": 5,
+                    "size_class": "4x5",
+                    "feature_means": {
+                        "tail_entropy": 0.0,
+                        "same_tail_adjacency_rate": 0.0,
+                        "same_decade_proximity_rate": 0.0,
+                        "consecutive_neighbor_rate": 0.0,
+                        "row_known_entropy": 0.0,
+                        "col_known_entropy": 0.0,
+                        "edge_center_balance": 0.0,
+                    },
+                    "feature_stds": {
+                        "tail_entropy": 1.0,
+                        "same_tail_adjacency_rate": 1.0,
+                        "same_decade_proximity_rate": 1.0,
+                        "consecutive_neighbor_rate": 1.0,
+                        "row_known_entropy": 1.0,
+                        "col_known_entropy": 1.0,
+                        "edge_center_balance": 1.0,
+                    },
+                },
+                "6x10": {
+                    "rows": 6,
+                    "cols": 10,
+                    "size_class": "6x10",
+                    "feature_means": {
+                        "tail_entropy": 0.0,
+                        "same_tail_adjacency_rate": 0.0,
+                        "same_decade_proximity_rate": 0.0,
+                        "consecutive_neighbor_rate": 0.0,
+                        "row_known_entropy": 0.0,
+                        "col_known_entropy": 0.0,
+                        "edge_center_balance": 0.0,
+                    },
+                    "feature_stds": {
+                        "tail_entropy": 1.0,
+                        "same_tail_adjacency_rate": 1.0,
+                        "same_decade_proximity_rate": 1.0,
+                        "consecutive_neighbor_rate": 1.0,
+                        "row_known_entropy": 1.0,
+                        "col_known_entropy": 1.0,
+                        "edge_center_balance": 1.0,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    res = subprocess.run(
+        [
+            "python",
+            "scripts/generate_synthetic_boards.py",
+            "--size-class",
+            "4x5",
+            "--real-corpus",
+            str(real),
+            "--profile",
+            str(profile),
+            "--output",
+            str(out),
+            "--per-real",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(Path.cwd())},
+    )
+    payload = json.loads(res.stdout.strip())
+    assert payload["selected_size_class"] == "4x5"
+    assert payload["real_board_count_after_filter"] == 1
+
+
+def test_build_masked_size_class_empty_failfast(tmp_path: Path) -> None:
+    real = tmp_path / "real.jsonl"
+    _write_jsonl(
+        real,
+        [
+            {
+                "board_id": "b1",
+                "rows": 4,
+                "cols": 5,
+                "size_class": "4x5",
+                "grid": [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20]],
+                "source_type": "real",
+            }
+        ],
+    )
+    synth = tmp_path / "synth.jsonl"
+    synth.write_text("", encoding="utf-8")
+    out = tmp_path / "rank.parquet"
+    res = subprocess.run(
+        [
+            "python",
+            "scripts/build_masked_ranking_dataset.py",
+            "--size-class",
+            "10x10",
+            "--real-corpus",
+            str(real),
+            "--synthetic-corpus",
+            str(synth),
+            "--output",
+            str(out),
+            "--mask-ratios",
+            "0.5",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(Path.cwd())},
+    )
+    assert res.returncode != 0
+    assert "no boards after size_class filter" in (res.stderr + res.stdout)
+
+
+def test_split_fallback_prefers_real_key() -> None:
+    df = pd.DataFrame(
+        [
+            {"board_id": "s1", "lineage_id": "s1", "source_type": "synthetic", "group_id": "g1"},
+            {"board_id": "r1", "lineage_id": "r1", "source_type": "real", "group_id": "g2"},
+        ]
+    )
+    out = split_df(
+        df,
+        holdout_ratio=0.0,
+        split_mode="by_board",
+        seed=42,
+        include_synth_in_holdout=True,
+        valid_real_only=False,
+        holdout_real_only=False,
+        exclude_synth_from_valid=False,
+    )
+    holdout_keys = set(out["holdout"]["board_id"].tolist())
+    assert "r1" in holdout_keys

--- a/tests/test_streaming_masked_dataset.py
+++ b/tests/test_streaming_masked_dataset.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from src.masking_dataset import (
+    MaskingConfig,
+    build_masked_ranking_dataset,
+    iter_masked_ranking_dataset_chunks,
+    iter_masked_ranking_rows,
+)
+
+
+def _boards() -> list[dict[str, object]]:
+    return [
+        {
+            "board_id": "b1",
+            "lineage_id": "b1",
+            "rows": 2,
+            "cols": 2,
+            "size_class": "2x2",
+            "source_type": "real",
+            "grid": [[1, 2], [3, 4]],
+            "source_file": "x.xlsx",
+            "sheet_name": "S1",
+        }
+    ]
+
+
+def test_streaming_chunks_keep_contract() -> None:
+    cfg = MaskingConfig(ratios=[0.5], masks_per_ratio=2)
+    chunks = list(iter_masked_ranking_dataset_chunks(_boards(), cfg, chunk_rows=5))
+    assert chunks
+    total = sum(len(c) for c in chunks)
+    assert total > 0
+    assert all(len(c) <= 5 for c in chunks[:-1])
+    merged = pd.concat(chunks, ignore_index=True)
+    assert "group_id" in merged.columns
+    assert "label" in merged.columns
+    assert "size_class" in merged.columns
+
+
+def test_streaming_is_deterministic() -> None:
+    cfg = MaskingConfig(ratios=[0.5], masks_per_ratio=1)
+    run1 = [r["group_id"] for r in iter_masked_ranking_rows(_boards(), cfg)]
+    run2 = [r["group_id"] for r in iter_masked_ranking_rows(_boards(), cfg)]
+    assert run1 == run2
+
+
+def test_streaming_matches_legacy_semantics() -> None:
+    cfg = MaskingConfig(ratios=[0.5], masks_per_ratio=2)
+    legacy = (
+        build_masked_ranking_dataset(_boards(), cfg)
+        .sort_values(["group_id", "cand_row", "cand_col"])
+        .reset_index(drop=True)
+    )
+    streamed = pd.concat(list(iter_masked_ranking_dataset_chunks(_boards(), cfg, chunk_rows=3)), ignore_index=True)
+    streamed = streamed.sort_values(["group_id", "cand_row", "cand_col"]).reset_index(drop=True)
+    assert len(legacy) == len(streamed)
+    assert legacy["group_id"].tolist() == streamed["group_id"].tolist()
+    assert legacy["label"].sum() == streamed["label"].sum()


### PR DESCRIPTION
### Motivation
- Enable multi-size board support end-to-end so the pipeline can detect, validate, split, train per-size models and fallback to a global model at runtime.
- Improve memory/IO robustness by streaming masked dataset generation, adding chunked safe writers, and better crash diagnostics for long runs.
- Make corpus extraction more permissive and informative by inferring shapes from filenames/content and surfacing reject reasons for auditing.
- Add defensive guards (Python version checks, faulthandler enablement, debug crash reports) to make local runs more predictable.

### Description
- Introduces a single orchestrator `scripts/run_training_pipeline.py` that scans `.xlsx`, optionally filters by `--size-class`, generates synthetic boards, builds masked ranking dataset via streaming, splits datasets, trains global and per-size models, and writes `artifacts/model_registry.json` and readiness reports; adds `--allow-unsupported-python` and `--debug-crash-report` flags and crash-state propagation to subprocess invocations.
- Reworks masked dataset generation into streaming APIs in `src/masking_dataset.py` (`iter_masked_ranking_rows`, `iter_masked_ranking_dataset_chunks`) and updates `scripts/build_masked_ranking_dataset.py` to write parquet shards via new `write_dataframe_chunks_safe` in `src/safe_io.py`, perform size-aware aggregation, and produce richer audit/feature reports; also enables `--size-class` filtering and a debug crash dump.
- Enhances `scripts/build_root_xlsx_corpus_80.py` to infer multiple shapes from filenames/content, validate/diagnose permutation issues, avoid duplicate boards, and emit richer per-file audit details and previews; adds `board_signature` and improved validation (`validate_full_permutation`).
- Updates `scripts/generate_synthetic_boards.py`, `scripts/split_ranking_dataset.py`, and `scripts/train_local_ranker.py` to support `--size-class` filtering, safer split fallback logic, and stricter training failure on insufficient data; improves outputs to JSON summaries for easier automation.

### Testing
- Added unit tests `tests/test_streaming_masked_dataset.py` that verify streaming builders and determinism, and they passed.
- Added `tests/test_safe_io_streaming.py` to validate chunked writer roundtrip and it passed.
- Added `tests/test_run_training_pipeline_guards.py` to verify Python-guard and exit-code decoding and it passed.
- Added `tests/test_size_class_filters.py` to exercise `--size-class` filtering and split fallbacks and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37ff42dd8832499c12af4bff42a85)