### PR TITLE
Add number-bucket ranking inference endpoint with runtime aggregation

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from fastapi import FastAPI, HTTPException
 
-from src.inference_facade import infer_multi_target_positions, infer_target_position
+from src.inference_facade import infer_multi_target_positions, infer_number_bucket_position, infer_target_position
 from src.inference_models import (
+    InferNumberBucketPositionRequest,
     InferMultiTargetPositionRequest,
     InferMultiTargetPositionResponse,
     InferTargetPositionRequest,
@@ -41,5 +42,20 @@ def infer_multi_target_positions_api(payload: InferMultiTargetPositionRequest) -
             source=payload.source,
         )
         return InferMultiTargetPositionResponse(**result)
+    except InferenceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@app.post("/infer_number_bucket_position", response_model=InferTargetPositionResponse)
+def infer_number_bucket_position_api(payload: InferNumberBucketPositionRequest) -> InferTargetPositionResponse:
+    try:
+        result = infer_number_bucket_position(
+            board=payload.board,
+            target_number=payload.target_number,
+            bucket_size=payload.bucket_size,
+            exclude_opened=payload.exclude_opened,
+            source=payload.source,
+        )
+        return InferTargetPositionResponse(**result)
     except InferenceError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/src/inference_facade.py
+++ b/src/inference_facade.py
@@ -34,6 +34,24 @@ def infer_multi_target_positions(
     return compact_top10_response({"candidate_cells": pseudo_candidates})
 
 
+def infer_number_bucket_position(
+    board: List[List[int]],
+    target_number: int,
+    bucket_size: int = 10,
+    exclude_opened: bool = True,
+    source: str = "manual",
+) -> Dict[str, Any]:
+    from src.inference_service import run_number_bucket_inference
+
+    return run_number_bucket_inference(
+        board=board,
+        target_number=target_number,
+        bucket_size=bucket_size,
+        exclude_opened=exclude_opened,
+        source=source,
+    )
+
+
 def map_score_to_confidence_1_100(score: float, min_score: float, max_score: float) -> float:
     if max_score - min_score < 1e-12:
         return 50.0

--- a/src/inference_models.py
+++ b/src/inference_models.py
@@ -62,6 +62,26 @@ class InferMultiTargetPositionRequest(BaseModel):
         return value
 
 
+class InferNumberBucketPositionRequest(BaseModel):
+    board: List[List[int]]
+    target_number: int
+    bucket_size: int = 10
+    exclude_opened: bool = True
+    source: str = "manual"
+
+    @field_validator("board")
+    @classmethod
+    def validate_board_non_empty(cls, value: List[List[int]]) -> List[List[int]]:
+        return InferTargetPositionRequest.validate_board_non_empty(value)
+
+    @field_validator("bucket_size")
+    @classmethod
+    def validate_bucket_size(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("bucket_size must be positive")
+        return value
+
+
 class Top10Cell(BaseModel):
     row: int
     col: int

--- a/src/inference_service.py
+++ b/src/inference_service.py
@@ -1207,3 +1207,64 @@ def run_inference(
         include_module_details=False,
     )
     return compact_top10_response(detailed)
+
+
+def _build_number_bucket_target_set(
+    *,
+    target_number: int,
+    bucket_size: int,
+    n_total: int,
+    opened_numbers: Dict[int, Cell],
+    exclude_opened: bool,
+) -> List[int]:
+    if bucket_size <= 0:
+        raise InferenceError("bucket_size must be positive")
+    bucket_start = (target_number // bucket_size) * bucket_size
+    bucket_end = bucket_start + bucket_size - 1
+    target_set = [x for x in range(1, n_total + 1) if bucket_start <= x <= bucket_end]
+    if exclude_opened:
+        opened = set(opened_numbers.keys())
+        target_set = [x for x in target_set if x not in opened]
+    return target_set
+
+
+def run_number_bucket_inference(
+    board: List[List[int]],
+    target_number: int,
+    bucket_size: int = 10,
+    exclude_opened: bool = True,
+    source: str = "manual",
+) -> Dict[str, Any]:
+    parsed = parse_board_input(board)
+    n_total = parsed.rows * parsed.cols
+    if not (1 <= target_number <= n_total):
+        raise InferenceError("target_number out of range 1..N")
+
+    target_set = _build_number_bucket_target_set(
+        target_number=target_number,
+        bucket_size=bucket_size,
+        n_total=n_total,
+        opened_numbers=parsed.opened_numbers,
+        exclude_opened=exclude_opened,
+    )
+    if not target_set:
+        raise InferenceError("target_set is empty after applying board range/exclude_opened")
+
+    aggregated: Dict[Tuple[int, int], List[float]] = {}
+    for t in target_set:
+        out = _run_inference_detailed(board=board, target_number=t, source=source, apply_reranker_stage=True)
+        for cand in out.get("candidate_cells", []):
+            key = (int(cand["row"]), int(cand["col"]))
+            aggregated.setdefault(key, []).append(float(cand.get("score", 0.0)))
+
+    if not aggregated:
+        raise InferenceError("no candidate cells available for number bucket inference")
+
+    merged = []
+    for (row, col), scores in aggregated.items():
+        sorted_scores = sorted(scores, reverse=True)
+        top3 = sorted_scores[:3]
+        final_score = 0.7 * max(sorted_scores) + 0.3 * (sum(top3) / len(top3))
+        merged.append({"row": row, "col": col, "confidence_1_to_100": round(final_score * 100.0, 2)})
+    merged.sort(key=lambda x: float(x["confidence_1_to_100"]), reverse=True)
+    return compact_top10_response({"candidate_cells": merged})

--- a/tests/test_infer_target_position_api.py
+++ b/tests/test_infer_target_position_api.py
@@ -49,3 +49,36 @@ def test_already_opened_compact_response() -> None:
     assert set(payload.keys()) == {"top10", "best_confidence_1_to_100"}
     assert payload["top10"][0]["row"] == 2
     assert payload["top10"][0]["col"] == 1
+
+
+def test_infer_number_bucket_position_10x10_target_1() -> None:
+    board = [[-1 for _ in range(10)] for _ in range(10)]
+    response = client.post("/infer_number_bucket_position", json={"board": board, "target_number": 1})
+    assert response.status_code == 200
+
+
+def test_infer_number_bucket_position_10x10_target_90() -> None:
+    board = [[-1 for _ in range(10)] for _ in range(10)]
+    response = client.post("/infer_number_bucket_position", json={"board": board, "target_number": 90})
+    assert response.status_code == 200
+
+
+def test_infer_number_bucket_position_8x10_target_90_returns_422() -> None:
+    board = [[-1 for _ in range(10)] for _ in range(8)]
+    response = client.post("/infer_number_bucket_position", json={"board": board, "target_number": 90})
+    assert response.status_code == 422
+
+
+def test_infer_number_bucket_position_8x10_target_79_ok() -> None:
+    board = [[-1 for _ in range(10)] for _ in range(8)]
+    response = client.post("/infer_number_bucket_position", json={"board": board, "target_number": 79})
+    assert response.status_code == 200
+
+
+def test_infer_number_bucket_position_exclude_opened_can_empty_target_set() -> None:
+    board = [[i * 10 + j + 1 for j in range(10)] for i in range(10)]
+    response = client.post(
+        "/infer_number_bucket_position",
+        json={"board": board, "target_number": 90, "exclude_opened": True},
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
### Motivation

- Provide a runtime-first implementation for number-bucket ranking so callers can query the 10-number (configurable) bucket containing a `target_number` without breaking the existing exact `POST /infer_target_position` API. 
- Allow callers to exclude already-opened numbers from the bucket and return a `422` when the bucket yields no valid targets. 

### Description

- Added a new API endpoint `POST /infer_number_bucket_position` that accepts `board`, `target_number`, `bucket_size`, `exclude_opened`, and `source`, returning the same compact schema as existing inference endpoints (`top10` / `best_confidence_1_to_100`).
- Introduced `InferNumberBucketPositionRequest` schema with `bucket_size: int = 10` and `exclude_opened: bool = True`, and validation that `bucket_size` is positive. (`src/inference_models.py`)
- Implemented runtime bucket logic in the inference service: `_build_number_bucket_target_set(...)` computes the bucket via `bucket_start = (target_number // bucket_size) * bucket_size` and `bucket_end = bucket_start + bucket_size - 1`, restricts to `1..N`, and optionally removes opened numbers; `run_number_bucket_inference(...)` calls `_run_inference_detailed` for each target in the set and aggregates per-cell scores with `final_score = 0.7 * max_score + 0.3 * mean(top3_scores)`, then returns a compact top-10 response. (`src/inference_service.py`)
- Added facade wrapper `infer_number_bucket_position(...)` and wired the new endpoint into the FastAPI app. (`src/inference_facade.py`, `src/api.py`) 
- Added API tests covering bucket boundary and behavior: 10x10 target 1/90 success, 8x10 target 90 -> 422, 8x10 target 79 -> success, and `exclude_opened` causing empty target set -> 422. (`tests/test_infer_target_position_api.py`) 

### Testing

- Ran lint/format checks: `flake8 agent.py` succeeded but `flake8 src tests` surfaced an unrelated pre-existing `E501` issue in repository tests; one long-line in the modified test was fixed. 
- Verified Python syntax via `python -m py_compile $(git ls-files '*.py')` which succeeded. 
- Attempted to run `pytest -q tests/test_infer_target_position_api.py tests/test_inference_service.py`, but collection failed due to missing runtime dependencies (`fastapi` and `pandas`) in the current environment, so the new tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc65954160832482a2661ad1198bcc)